### PR TITLE
feat: carve the first game translation unit around main

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -13,6 +13,11 @@ Sections:
 	.sdata2     type:rodata align:32
 	.sbss2      type:bss align:8
 
+game/main.c:
+	extab       start:0x80005758 end:0x80005760
+	extabindex  start:0x8000BD04 end:0x8000BD10
+	.text       start:0x80012C9C end:0x80012E24
+
 Runtime.PPCEABI.H/__va_arg.c:
 	.text       start:0x801B8E08 end:0x801B8ED0
 

--- a/configure.py
+++ b/configure.py
@@ -379,6 +379,18 @@ config.libs = [
         ],
     },
     {
+        # Sonic Heroes' own code, as opposed to the SDK linked into it. Nothing
+        # here is named yet: the disc ships no map, so every translation unit
+        # boundary in this range has to be argued for from cross references.
+        "lib": "game",
+        "mw_version": "GC/1.3.2",
+        "cflags": cflags_base,
+        "progress_category": "game",
+        "objects": [
+            Object(NonMatching, "game/main.c", extra_cflags=["-opt noschedule"]),
+        ],
+    },
+    {
         "lib": "Runtime.PPCEABI.H",
         "mw_version": config.linker_version,
         "cflags": cflags_runtime,
@@ -415,9 +427,7 @@ def link_order_callback(module_id: int, objects: List[str]) -> List[str]:
 # Optional extra categories for progress tracking
 # Adjust as desired for your project
 config.progress_categories = [
-    # "game" is deliberately absent until game code is actually split. With no
-    # objects in a category the report divides 0 by 0 and prints 100 percent,
-    # which would publish a false number. Add it back with the first game TU.
+    ProgressCategory("game", "Game Code"),
     ProgressCategory("sdk", "SDK Code"),
 ]
 config.progress_each_module = args.verbose

--- a/src/game/main.c
+++ b/src/game/main.c
@@ -1,0 +1,119 @@
+#include "types.h"
+
+// The game's entry point, and the first of Sonic Heroes' own code to be
+// written. Everything under src/game is the game rather than the SDK linked
+// into it.
+//
+// The translation unit boundary here is provisional and covers main alone.
+// That is almost certainly too narrow: main is 0x188 bytes at 0x80012C9C with
+// unnamed functions immediately on both sides, and nothing yet establishes
+// where its file starts or ends. The disc ships no map, so the boundary has to
+// come from cross references, and none have been worked out for this range.
+// Widen the split once neighbours are shown to share data with this file.
+//
+// Almost everything main does goes through one dispatcher at 0x80011FA8, which
+// takes a small integer and a pointer. The codes it is called with here are
+// 0x10, 0x1C, 0x0D, 0x11, 0x01, 0x00, 0x12 and 0x0E, in that order. What they
+// select is not established, so they are left as the numbers the original
+// passes rather than guessed at with names.
+//
+// The unit is built with -opt noschedule, which is worth 30 points here on its
+// own: without it every instruction is right and the order is not. The same
+// setting is what matched EXIBios, so it is worth trying first on the next
+// game unit rather than last.
+//
+// main stands at 98.7%. Everything still different is one cause: the original
+// reserves a 0x50 frame where ours is 0x40, and the sixteen bytes it carries
+// beyond what it uses push each local up by eight. Its three blocks sit at
+// 0x08, 0x18 and 0x24; ours land at 0x08, 0x10 and 0x18 and are otherwise
+// identical. Registers, instruction order and instruction count already agree.
+//
+// Measured and rejected against that: GC/1.2.5n and GC/1.3 for the unit (1.3.2
+// and 1.3 tie at the top, 1.2.5n is twelve points worse), building it as C++
+// rather than C, and every ordering of the four locals. The gap is locals the
+// original declared and did not use, which leave no trace to recover them
+// from. The same wall stands in dbcomm, and it is the one thing worth solving
+// for both.
+
+// The dispatcher. Returns zero on failure for the two codes main checks.
+extern int fn_80011FA8(int code, void* arg);
+
+extern void PADInit(void);
+
+// Called as a pair on the way in. The first hands back a value the second
+// turns into the two words main copies into lbl_8029BB80 and passes on.
+extern u32 fn_8019D4D4(void);
+extern void fn_8019D448(u32* out, u32 arg);
+
+// Passed to the dispatcher under code 0x0D as the first word of a three word
+// block. In another unit's .data.
+extern u8 lbl_80298720[0x3C];
+
+// The block main runs its loop against. Only three words are touched here: two
+// written before the loop and one polled by it.
+typedef struct Unk8029BB80 {
+	u8 unk_0x0[0x4];
+	u32 unk_0x4;
+	u32 unk_0x8;
+	u8 unk_0xC[0x4];
+	u32 unk_0x10;
+	u8 unk_0x14[0x2C];
+} Unk8029BB80; // 0x40
+
+extern Unk8029BB80 lbl_8029BB80;
+
+// One byte of a pair in another unit's .sbss, set once on the way in.
+extern u8 lbl_8042C0C0;
+
+int main(int argc, char** argv)
+{
+	u32 args[4];
+	void* cfg[3];
+	u32 tick[2];
+	int i;
+
+	cfg[0] = lbl_80298720;
+	cfg[1] = 0;
+	cfg[2] = (void*)0x40000;
+
+	lbl_8042C0C0 = 1;
+
+	if (!fn_80011FA8(0x10, NULL)) {
+		return 0;
+	}
+
+	for (i = 1; i < argc; i++) {
+		fn_80011FA8(0x1C, argv[i]);
+	}
+
+	if (!fn_80011FA8(0x0D, cfg)) {
+		fn_80011FA8(0x11, NULL);
+		return 0;
+	}
+
+	PADInit();
+
+	for (i = 1; i < argc; i++) {
+		fn_80011FA8(0x1, argv[i]);
+	}
+
+	fn_8019D448(tick, fn_8019D4D4());
+
+	lbl_8029BB80.unk_0x4 = tick[0];
+	lbl_8029BB80.unk_0x8 = tick[1];
+
+	args[0] = 0;
+	args[1] = 0;
+	args[2] = tick[0];
+	args[3] = tick[1];
+	fn_80011FA8(0x0, args);
+
+	while (lbl_8029BB80.unk_0x10 == 0) {
+		fn_80011FA8(0x12, NULL);
+	}
+
+	fn_80011FA8(0x0E, NULL);
+	fn_80011FA8(0x11, NULL);
+
+	return 0;
+}


### PR DESCRIPTION
Opens `src/game` — the first of Sonic Heroes' own code, as opposed to the SDK linked into it. **`main` reaches 98.7%, not 100%, so the object stays `NonMatching`.** `main.dol` is untouched at `9214426b8a3fb1d6fe3dcff09bcc1a959e1e04a8`.

The SDK is effectively finished at 326/334 functions, so this is the next frontier: 4201 game functions in the DOL, of which 30 have names and 29 of those are auto-named destructors. `main` at `0x80012C9C` is the only real anchor, which is why it goes first.

## What it does

Nearly everything routes through one dispatcher at `0x80011FA8` taking a small integer and a pointer. It is called with 0x10, 0x1C, 0x0D, 0x11, 0x01, 0x00, 0x12 and 0x0E. What those select is not established, so they stay as the numbers the original passes rather than being guessed at with names. Two failure paths return early, two loops walk `argv`, and the last loop polls a word in `lbl_8029BB80` until it goes non-zero.

## Scaffolding this adds

- A `game` library in `configure.py` at GC/1.3.2.
- `ProgressCategory("game", "Game Code")`, which `configure.py` asked for in a comment: it was deliberately absent so an empty category could not divide 0 by 0 and publish a false 100%. The first game TU is the trigger, and this is it.
- `src/game/main.c` and its split.

## -opt noschedule again

Worth 30 points here on its own — 68.1% to 98.2%. Without it every instruction is right and the order is not. This is the same setting that matched EXIBios in #28, so it is worth trying **first** on the next game unit rather than last. GC/1.3.2 and GC/1.3 tie at the top; 1.2.5n is twelve points worse.

## What is left, and an honest caveat

Everything still different is one cause: the original reserves a 0x50 frame where ours is 0x40, and the sixteen bytes it carries beyond what it uses push each local up by eight. Its three blocks sit at 0x08, 0x18 and 0x24; ours land at 0x08, 0x10 and 0x18 and are otherwise identical. Registers, instruction order and instruction count already agree.

Rejected against that: 1.2.5n and 1.3 for the unit, building it as C++ rather than C (the game has destructors, so it was worth checking), and every ordering of the four locals. It is locals the original declared and did not use — the same wall as `dbcomm`, and the one thing worth solving for both.

**The boundary is provisional and covers `main` alone.** That is almost certainly too narrow: there are unnamed functions immediately on both sides and nothing yet establishes where its file starts or ends. It is marked as provisional in the file header. Widen the split once neighbours are shown to share data with it.

## AI assistance

Written with Claude Code. Verified in objdiff, DOL hash checked on each build.