### PR TITLE
feat: match autosave selector

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/selector.c:
+	.text       start:0x000046B4 end:0x0000476C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/selector.c",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/selector.c
+++ b/src/autosaveD/selector.c
@@ -1,0 +1,35 @@
+#include "types.h"
+
+// Selection state embedded in autosaveD's menu object. The adjustment helper
+// below only accesses the entry array and the current index; fn_2_40F0 applies
+// the list's bounds after left or right input changes that index.
+typedef struct Selector {
+	s32 items[33];
+	s32 index;
+} Selector;
+
+extern u8 lbl_80303EC8[];
+
+extern s32 fn_800A92E0(void* input, s32 button, s32 port);
+extern void fn_2_40F0(Selector* selector);
+
+s32 fn_2_46B4(Selector* selector, s32 port)
+{
+	if (port == -1) {
+		port = 0;
+	}
+
+	if (fn_800A92E0(lbl_80303EC8, 8, port)) {
+		selector->index--;
+	} else if (fn_800A92E0(lbl_80303EC8, 4, port)) {
+		selector->index++;
+	}
+
+	fn_2_40F0(selector);
+
+	if (selector->index == -1) {
+		return -1;
+	}
+
+	return selector->items[selector->index];
+}


### PR DESCRIPTION
Adds the autosave menu selector’s left/right input handling, index adjustment, bounds update, and selected-entry retrieval.

The function was verified byte-for-byte in objdiff, and the object passed the fresh-build, section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

One matching-sensitive detail is that this translation unit uses the same noschedule, nopeephole optimization settings as the adjacent autosave table unit. The selector’s entry array also occupies the first 0x84 bytes of its containing object, allowing the current index at offset 0x84 to produce the original indexed load exactly.