### PR TITLE
feat: match autosave dual selector

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/dual_selector.c:
+	.text       start:0x000045B8 end:0x000046B4
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/config/G9SE8P/config.yml
+++ b/config/G9SE8P/config.yml
@@ -45,12 +45,12 @@ modules:
   hash: 120e89d6ca861f63ecf9c8f2d282bab5b500ab17
   symbols: config/G9SE8P/autosaveD/symbols.txt
   splits: config/G9SE8P/autosaveD/splits.txt
-  # Nothing inside the module references fn_2_476C, so mwld drops it once the
-  # translation unit that holds it is compiled rather than emitted by dtk: dtk
+  # Nothing inside the module references these entry points, so mwld drops them
+  # once their translation units are compiled rather than emitted by dtk: dtk
   # exports every symbol in the objects it writes, a hand written one has to say
-  # so here. Without this the module comes out 0x10 short and every relative
-  # branch past 0x476C shifts with it.
+  # so here. Without this the module is shortened and later code shifts with it.
   force_active:
+    - fn_2_45B8
     - fn_2_476C
 - object: files/movieD.rel
   hash: 6e2773a99ec5b05d5634d09521246e3e28bd6de9

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/dual_selector.c",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/dual_selector.c
+++ b/src/autosaveD/dual_selector.c
@@ -1,0 +1,38 @@
+#include "types.h"
+
+// Selection state embedded in autosaveD's menu object. This routine processes
+// both controller ports before returning the entry at the resulting index.
+typedef struct Selector {
+	s32 items[33];
+	s32 index;
+} Selector;
+
+extern u8 lbl_80303EC8[];
+
+extern s32 fn_800A92E0(void* input, s32 button, s32 port);
+extern void fn_2_40F0(Selector* selector);
+
+s32 fn_2_45B8(Selector* selector)
+{
+	if (fn_800A92E0(lbl_80303EC8, 8, 0)) {
+		selector->index--;
+	} else if (fn_800A92E0(lbl_80303EC8, 4, 0)) {
+		selector->index++;
+	}
+
+	fn_2_40F0(selector);
+
+	if (fn_800A92E0(lbl_80303EC8, 8, 1)) {
+		selector->index--;
+	} else if (fn_800A92E0(lbl_80303EC8, 4, 1)) {
+		selector->index++;
+	}
+
+	fn_2_40F0(selector);
+
+	if (selector->index == -1) {
+		return -1;
+	}
+
+	return selector->items[selector->index];
+}


### PR DESCRIPTION
Adds the autosave menu’s two-controller selector handling, including left and right input processing, index bounds updates, and selected-entry retrieval.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build, section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

One matching-sensitive detail is that this entry point is not referenced internally by the REL. It therefore must be marked force_active; otherwise MetroWerks removes the compiled function and shortens the autosave module by 0xFC bytes. The translation unit also uses the adjacent autosave code’s noschedule,nopeephole optimization settings.