### PR TITLE
feat: match autosave variable grid selector

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/variable_grid_selector.c:
+	.text       start:0x00004160 end:0x00004344
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/config/G9SE8P/config.yml
+++ b/config/G9SE8P/config.yml
@@ -45,12 +45,12 @@ modules:
   hash: 120e89d6ca861f63ecf9c8f2d282bab5b500ab17
   symbols: config/G9SE8P/autosaveD/symbols.txt
   splits: config/G9SE8P/autosaveD/splits.txt
-  # Nothing inside the module references fn_2_476C, so mwld drops it once the
-  # translation unit that holds it is compiled rather than emitted by dtk: dtk
+  # Nothing inside the module references these entry points, so mwld drops them
+  # once their translation units are compiled rather than emitted by dtk: dtk
   # exports every symbol in the objects it writes, a hand written one has to say
-  # so here. Without this the module comes out 0x10 short and every relative
-  # branch past 0x476C shifts with it.
+  # so here. Without this the module is shortened and later code shifts with it.
   force_active:
+    - fn_2_4160
     - fn_2_476C
 - object: files/movieD.rel
   hash: 6e2773a99ec5b05d5634d09521246e3e28bd6de9

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/variable_grid_selector.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/variable_grid_selector.c
+++ b/src/autosaveD/variable_grid_selector.c
@@ -1,0 +1,74 @@
+#include "types.h"
+
+// Selection state embedded in autosaveD's menu object. This entry point moves
+// through a two-row grid whose rows may have different lengths.
+typedef struct Selector {
+	s32 items[33];
+	s32 index;
+} Selector;
+
+extern u8 lbl_80303EC8[];
+
+extern "C" {
+extern s32 fn_800A92E0(void* input, s32 button, s32 port);
+extern void fn_2_40F0(Selector* selector);
+}
+
+extern "C" s32 fn_2_4160(Selector* selector, s32 firstRowLength, s32 secondRowLength, s32 port)
+{
+	s32 currentIndex;
+
+	if (port == -1) {
+		port = 0;
+	}
+
+	{
+		Selector* state  = selector;
+		s32 canMoveUp    = 1;
+		s32 canMoveDown  = 1;
+		s32 canMoveLeft  = 1;
+		s32 canMoveRight = 1;
+		u32 isFirstRow;
+
+		currentIndex = state->index;
+		isFirstRow   = currentIndex < firstRowLength;
+
+		if (isFirstRow) {
+			canMoveUp = 0;
+		}
+		if (!isFirstRow) {
+			canMoveDown = 0;
+		}
+		if (*(volatile s32*)&state->index == 0 || currentIndex == firstRowLength) {
+			canMoveLeft = 0;
+		}
+		if (currentIndex == firstRowLength - 1
+		    || currentIndex == firstRowLength + secondRowLength - 1) {
+			canMoveRight = 0;
+		}
+
+		if (canMoveUp && fn_800A92E0(lbl_80303EC8, 8, port)) {
+			state->index -= firstRowLength;
+			while (state->index >= firstRowLength) {
+				state->index--;
+			}
+		} else if (canMoveDown && fn_800A92E0(lbl_80303EC8, 4, port)) {
+			state->index += firstRowLength;
+			while (state->index < firstRowLength) {
+				state->index++;
+			}
+		} else if (canMoveLeft && fn_800A92E0(lbl_80303EC8, 1, port)) {
+			state->index--;
+		} else if (canMoveRight && fn_800A92E0(lbl_80303EC8, 2, port)) {
+			state->index++;
+		}
+
+		fn_2_40F0(state);
+
+		if (state->index == -1) {
+			return -1;
+		}
+
+		return state->items[state->index];
+	}
+}


### PR DESCRIPTION
Adds the autosave selector helper that enables index wrapping.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build, section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

The entry point is compiled in the autosave module’s evidenced C++ language mode with C linkage. It remains force_active because it is externally invoked rather than referenced inside the REL.