### PR TITLE
feat: match autosave state initializer

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/state_init.c:
+	.text       start:0x00004004 end:0x00004070
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/state_init.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/state_init.c
+++ b/src/autosaveD/state_init.c
@@ -1,0 +1,50 @@
+#include "types.h"
+
+typedef struct GlobalState {
+	u32 unk_0x0;
+	u32 tick_high;
+	u32 tick_low;
+} GlobalState;
+
+typedef struct AutosaveState {
+	s32 unk_0x0;
+	s32 unk_0x4;
+	s32 unk_0x8;
+	s32 unk_0xC;
+	s32 unk_0x10;
+	f32 unk_0x14;
+	f32 unk_0x18;
+	f32 unk_0x1C;
+	f32 unk_0x20;
+	f32 unk_0x24;
+	s32 unk_0x28;
+	u32 unk_0x2C;
+	u32 tick_high;
+	u32 tick_low;
+	s32 unk_0x38;
+	s32 unk_0x3C;
+	s32 unk_0x40;
+} AutosaveState;
+
+extern GlobalState lbl_8029BB80;
+extern const f32 lbl_2_rodata_348;
+
+extern "C" void fn_2_4004(AutosaveState* state)
+{
+	state->unk_0x0   = 0;
+	state->unk_0x4   = 0;
+	state->unk_0x8   = 0;
+	state->unk_0xC   = 0;
+	state->unk_0x10  = 0;
+	state->unk_0x14  = lbl_2_rodata_348;
+	state->unk_0x18  = lbl_2_rodata_348;
+	state->unk_0x1C  = lbl_2_rodata_348;
+	state->unk_0x20  = lbl_2_rodata_348;
+	state->unk_0x24  = lbl_2_rodata_348;
+	state->unk_0x28  = 0;
+	state->unk_0x2C  = 0;
+	state->tick_high = lbl_8029BB80.tick_high;
+	state->tick_low  = lbl_8029BB80.tick_low;
+	state->unk_0x38  = 0;
+	state->unk_0x3C = state->unk_0x40 = 1;
+}


### PR DESCRIPTION
Adds initialization of the autosave window state, clearing its runtime fields, copying the saved tick pair, and establishing its enabled defaults.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build, section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

One matching-sensitive detail is that the five floating-point fields must use the autosave module’s existing constant-zero symbol. Writing literal 0.0f values produces the same instructions but assigns the relocation to a new translation-unit constant, while a non-const external causes MetroWerks to reload it for each field. The two final flags also remain a chained assignment to preserve the original reverse store order.