### PR TITLE
feat: match autosave window no-op callback

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/window_noop.c:
+	.text       start:0x00004070 end:0x00004074
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/window_noop.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/window_noop.c
+++ b/src/autosaveD/window_noop.c
@@ -1,0 +1,1 @@
+extern "C" void fn_2_4070(void* window) { }


### PR DESCRIPTION
Adds the autosave window’s empty virtual callback used by its method table.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build, section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

The callback intentionally has an empty C body, producing the original four-byte blr. It is compiled in the autosave module’s evidenced C++ language mode with C linkage and is retained naturally through its method-table reference.