### PR TITLE
feat: match autosave selector index setter

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/set_index.c:
+	.text       start:0x00004074 end:0x0000408C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/set_index.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/set_index.c
+++ b/src/autosaveD/set_index.c
@@ -1,0 +1,19 @@
+#include "types.h"
+
+typedef struct Selector {
+	s32 items[32];
+	s32 count;
+	s32 index;
+	s32 wrap;
+} Selector;
+
+extern "C" void fn_2_4074(Selector* selector, s32 index)
+{
+	if (index <= 0) {
+		return;
+	}
+	if (index >= 3) {
+		return;
+	}
+	selector->index = index;
+}


### PR DESCRIPTION
Adds the autosave selector index setter, accepting only the valid nonzero selector indices used by the autosave menu.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build, section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

One matching-sensitive detail is that the lower and upper bounds remain separate early-return checks. This reproduces the original blelr and bgelr instruction sequence exactly. The entry point is compiled in the autosave module’s evidenced C++ language mode with C linkage.