### PR TITLE
feat: match autosave select value

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/select_value.c:
+	.text       start:0x00004098 end:0x000040F0
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/config/G9SE8P/config.yml
+++ b/config/G9SE8P/config.yml
@@ -45,12 +45,12 @@ modules:
   hash: 120e89d6ca861f63ecf9c8f2d282bab5b500ab17
   symbols: config/G9SE8P/autosaveD/symbols.txt
   splits: config/G9SE8P/autosaveD/splits.txt
-  # Nothing inside the module references fn_2_476C, so mwld drops it once the
-  # translation unit that holds it is compiled rather than emitted by dtk: dtk
+  # Nothing inside the module references these entry points, so mwld drops them
+  # once their translation units are compiled rather than emitted by dtk: dtk
   # exports every symbol in the objects it writes, a hand written one has to say
-  # so here. Without this the module comes out 0x10 short and every relative
-  # branch past 0x476C shifts with it.
+  # so here. Without this the module is shortened and later code shifts with it.
   force_active:
+    - fn_2_4098
     - fn_2_476C
 - object: files/movieD.rel
   hash: 6e2773a99ec5b05d5634d09521246e3e28bd6de9

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/select_value.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/select_value.c
+++ b/src/autosaveD/select_value.c
@@ -1,0 +1,23 @@
+#include "types.h"
+
+typedef struct Selector {
+	s32 items[32];
+	s32 count;
+	s32 index;
+	s32 wrap;
+} Selector;
+
+extern "C" void fn_2_40F0(Selector* selector);
+
+extern "C" void fn_2_4098(Selector* selector, s32 value)
+{
+	s32 i;
+
+	for (i = 0; i != selector->count; i++) {
+		if (selector->items[i] == value) {
+			selector->index = i;
+			fn_2_40F0(selector);
+			break;
+		}
+	}
+}


### PR DESCRIPTION
Adds autosave selector lookup by entry value, updating the current index and applying the shared bounds helper when a matching entry is found.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build, section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

One matching-sensitive detail is that the scan must use an equality-terminated loop (i != count). The equivalent i < count form changes MetroWerks’ empty-list guard from the original beq to ble. The entry point is compiled in the autosave module’s evidenced C++ language mode with C linkage and remains force_active because it is externally invoked rather than referenced inside the REL.