### PR TITLE
feat: match autosave selector bounds

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/selector_bounds.c:
+	.text       start:0x000040F0 end:0x00004160
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/selector_bounds.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/selector_bounds.c
+++ b/src/autosaveD/selector_bounds.c
@@ -1,0 +1,29 @@
+#include "types.h"
+
+typedef struct Selector {
+	s32 items[32];
+	s32 count;
+	s32 index;
+	s32 wrap;
+} Selector;
+
+extern "C" void fn_2_40F0(Selector* selector)
+{
+	if (selector->wrap) {
+		if (selector->index < 0) {
+			selector->index = selector->count - 1;
+		}
+		if (selector->count > selector->index) {
+			return;
+		}
+		selector->index = 0;
+	} else {
+		if (selector->index < 0) {
+			selector->index = 0;
+		}
+		if (selector->count > selector->index) {
+			return;
+		}
+		selector->index = selector->count - 1;
+	}
+}


### PR DESCRIPTION
Adds the autosave selector’s shared bounds handling, including optional index wrapping and non- wrapping endpoint clamping.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build, section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

One matching-sensitive detail is that the upper-bound checks must be expressed as count  > index followed by an early return. The equivalent index >= count condition reverses MetroWerks’ compare operands and produces bltlr instead of the original bgtlr. The helper is compiled in the autosave module’s evidenced C++ language mode while retaining its original C linkage.