### PR TITLE
feat: match autosave shutdown wrapper

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/shutdown.c:
+	.text       start:0x00003FD8 end:0x00004004
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/shutdown.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/shutdown.c
+++ b/src/autosaveD/shutdown.c
@@ -1,0 +1,12 @@
+#include "types.h"
+
+extern u8 lbl_803E8150[];
+
+extern "C" void fn_2_3EC0(void);
+extern "C" void fn_801301C8(void* resource);
+
+extern "C" void fn_2_3FD8(void)
+{
+	fn_2_3EC0();
+	fn_801301C8(lbl_803E8150);
+}


### PR DESCRIPTION
Adds the autosave shutdown wrapper, releasing the module’s loaded window resources before destroying its shared runtime resource.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build, section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

Both operations remain direct calls in their original order. The function and its callees use C linkage while the translation unit retains the autosave module’s evidenced C++ language mode.