### PR TITLE
feat: match autosave startup wrapper

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/startup.c:
+	.text       start:0x00003FAC end:0x00003FD8
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/startup.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/startup.c
+++ b/src/autosaveD/startup.c
@@ -1,0 +1,12 @@
+#include "types.h"
+
+extern u8 lbl_803E8150[];
+
+extern "C" void fn_8012FF6C(void* resource);
+extern "C" void fn_2_3E4C(void);
+
+extern "C" void fn_2_3FAC(void)
+{
+	fn_8012FF6C(lbl_803E8150);
+	fn_2_3E4C();
+}


### PR DESCRIPTION
Adds the autosave startup wrapper, initializing the shared runtime resource before constructing the module’s window assets.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build, section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

Both initialization operations remain direct calls in their original order. The function and its callees use C linkage while the translation unit retains the autosave module’s evidenced C++ language mode.