### PR TITLE
feat: match autosave state copy

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/state_copy.c:
+	.text       start:0x00003D64 end:0x00003DF0
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/state_copy.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/state_copy.c
+++ b/src/autosaveD/state_copy.c
@@ -1,0 +1,48 @@
+#include "types.h"
+
+typedef struct Pair {
+	u32 first;
+	u32 second;
+} Pair;
+
+typedef struct AutosaveState {
+	u32 unk_0x0;
+	u32 unk_0x4;
+	u32 unk_0x8;
+	u32 unk_0xC;
+	u32 unk_0x10;
+	Pair unk_0x14;
+	u32 unk_0x1C;
+	Pair unk_0x20;
+	Pair unk_0x28;
+	Pair unk_0x30;
+	u32 unk_0x38;
+	u32 unk_0x3C;
+	u32 unk_0x40;
+} AutosaveState;
+
+static inline void copy_pair(Pair* destination, const volatile Pair* source)
+{
+	u32 first  = source->first;
+	u32 second = source->second;
+
+	destination->first  = first;
+	destination->second = second;
+}
+
+extern "C" void fn_2_3D64(AutosaveState* destination, const AutosaveState* source)
+{
+	destination->unk_0x0  = source->unk_0x0;
+	destination->unk_0x4  = source->unk_0x4;
+	destination->unk_0x8  = source->unk_0x8;
+	destination->unk_0xC  = source->unk_0xC;
+	destination->unk_0x10 = source->unk_0x10;
+	copy_pair(&destination->unk_0x14, &source->unk_0x14);
+	destination->unk_0x1C = source->unk_0x1C;
+	copy_pair(&destination->unk_0x20, &source->unk_0x20);
+	copy_pair(&destination->unk_0x28, &source->unk_0x28);
+	copy_pair(&destination->unk_0x30, &source->unk_0x30);
+	destination->unk_0x38 = source->unk_0x38;
+	destination->unk_0x3C = source->unk_0x3C;
+	destination->unk_0x40 = source->unk_0x40;
+}


### PR DESCRIPTION
Adds the autosave state copy helper, copying the complete 68-byte state record including its four
paired subobjects.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build,
section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

One matching-sensitive detail is that each paired subobject is copied through an inline helper with an ordered volatile source. This preserves the original first-word then second-word loads and MetroWerks’ corresponding r5/r0 allocation; an ordinary structure assignment instead becomes a compact copy loop or reverses the temporary registers.