### PR TITLE
feat: match autosave window factory

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/create_window.c:
+	.text       start:0x00003DF0 end:0x00003E4C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/create_window.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/create_window.c
+++ b/src/autosaveD/create_window.c
@@ -1,0 +1,17 @@
+#include "types.h"
+
+struct AutosaveWindow;
+
+extern "C" AutosaveWindow* fn_2_1424(u32 size);
+extern "C" AutosaveWindow* fn_2_3AE8(AutosaveWindow* window, void* parent, void* config);
+
+extern "C" AutosaveWindow* fn_2_3DF0(void* parent, void* config)
+{
+	AutosaveWindow* window;
+
+	window = fn_2_1424(0x838);
+	if (window != NULL) {
+		window = fn_2_3AE8(window, parent, config);
+	}
+	return window;
+}


### PR DESCRIPTION
Adds the autosave window factory, allocating the complete window object and invoking its constructor with the supplied parent and configuration when allocation succeeds.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build,
section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

The allocation result is returned unchanged when null and replaced with the constructor result
otherwise, reproducing the original C++ allocation pattern and register flow.