### PR TITLE
feat: match autosave resource cleanup

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/resource_cleanup.c:
+	.text       start:0x00003E4C end:0x00003EC0
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/resource_cleanup.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/resource_cleanup.c
+++ b/src/autosaveD/resource_cleanup.c
@@ -1,0 +1,23 @@
+#include "types.h"
+
+struct Archive;
+
+extern Archive* lbl_2_bss_50;
+extern u32 lbl_2_bss_54[5];
+
+extern "C" void fn_801A46D0(Archive* archive);
+
+extern "C" void fn_2_3E4C(void)
+{
+	u32* asset = lbl_2_bss_54;
+	s32 i;
+
+	for (i = 0; i != 5; i++) {
+		*asset++ = 0;
+	}
+
+	if (lbl_2_bss_50 != NULL) {
+		fn_801A46D0(lbl_2_bss_50);
+		lbl_2_bss_50 = NULL;
+	}
+}


### PR DESCRIPTION
Adds cleanup of the autosave window resources, clearing the five cached asset pointers and releasing the mounted archive when present.

The function was verified byte-for-byte in objdiff, and the object passed the forced fresh-build,
section-size, Matching-link, and DOL and all 17 REL SHA-1 gates.

One matching-sensitive detail is that the cached assets must be cleared through a fixed five-
iteration pointer loop. MetroWerks fully unrolls that loop into the original alternating stw and addi
 > sequence; writing five equivalent assignments directly instead produces base-plus-offset stores.