### PR TITLE
feat: match autosave window state getter

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/window_state.c:
+	.text       start:0x00003404 end:0x0000340C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/window_state.c",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/window_state.c
+++ b/src/autosaveD/window_state.c
@@ -1,0 +1,11 @@
+#include "types.h"
+
+typedef struct AutosaveWindow {
+	u8 unk_0x0[0x6C];
+	s32 state;
+} AutosaveWindow;
+
+s32 fn_2_3404(const AutosaveWindow* window)
+{
+	return window->state;
+}


### PR DESCRIPTION
Adds the autosave window state accessor, returning the current state stored at offset 0x6C.

The function’s 8-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The explicit window layout preserves the original field offset while keeping the implementation
entirely in C.