### PR TITLE
feat: match autosave window configuration

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/window_configure.c:
+	.text       start:0x0000340C end:0x0000346C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/config/G9SE8P/config.yml
+++ b/config/G9SE8P/config.yml
@@ -51,6 +51,7 @@ modules:
   # so here. Without this the module comes out 0x10 short and every relative
   # branch past 0x476C shifts with it.
   force_active:
+    - fn_2_340C
     - fn_2_476C
 - object: files/movieD.rel
   hash: 6e2773a99ec5b05d5634d09521246e3e28bd6de9

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/window_configure.c",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/window_configure.c
+++ b/src/autosaveD/window_configure.c
@@ -1,0 +1,43 @@
+#include "types.h"
+
+typedef struct WindowConfig {
+	u32 unk_0x0;
+	u32 unk_0x4;
+	u32 tick_0;
+	u32 tick_1;
+} WindowConfig;
+
+typedef struct Color {
+	u8 red;
+	u8 green;
+	u8 blue;
+	u8 alpha;
+} Color;
+
+typedef struct MainState {
+	u8 unk_0x0[4];
+	u32 tick_0;
+	u32 tick_1;
+} MainState;
+
+extern MainState lbl_8029BB80;
+
+extern void fn_2_26C0(void* window, const WindowConfig* config, const Color* color);
+
+void fn_2_340C(void* window)
+{
+	WindowConfig config;
+	Color color;
+
+	config.unk_0x0 = 0;
+	config.unk_0x4 = 0;
+	config.tick_0  = lbl_8029BB80.tick_0;
+	config.tick_1  = lbl_8029BB80.tick_1;
+
+	color.red   = 0;
+	color.green = 0;
+	color.blue  = 0;
+	color.alpha = 0xA0;
+
+	fn_2_26C0(window, &config, &color);
+}


### PR DESCRIPTION
Adds autosave window configuration, constructing the local timing and color parameters before
forwarding them to the window setup routine.

The function’s 96-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

One matching-sensitive detail is that the function must be listed as force-active. Nothing in the
remaining module directly references its compiled symbol, so MetroWerks otherwise dead-strips it and shifts the resulting REL despite the function itself matching exactly.