### PR TITLE
feat: match autosave window destructor

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/window_destructor.c:
+	.text       start:0x00003A70 end:0x00003AE8
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/window_destructor.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/window_destructor.c
+++ b/src/autosaveD/window_destructor.c
@@ -1,0 +1,27 @@
+#include "types.h"
+
+typedef struct AutosaveWindow {
+	u8 base[0x18];
+	void* methods;
+	u8 unk_0x1C[0x58];
+	u8 selector[0x8C];
+} AutosaveWindow;
+
+extern void* lbl_2_data_43C[];
+
+extern "C" void fn_2_4798(void* selector, s32 flags);
+extern "C" void dtor_800186D0(void* window, s32 flags);
+extern "C" void fn_2_13F4(void* allocation);
+
+extern "C" AutosaveWindow* fn_2_3A70(AutosaveWindow* window, s32 flags)
+{
+	if (window != NULL) {
+		window->methods = lbl_2_data_43C;
+		fn_2_4798(window->selector, -1);
+		dtor_800186D0(window, 0);
+		if ((s16)flags > 0) {
+			fn_2_13F4(window);
+		}
+	}
+	return window;
+}


### PR DESCRIPTION
Adds destruction of the autosave window, restoring its method table, destroying the embedded selector and base window, and conditionally releasing the allocation according to the destructor flags.

The function’s 120-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

One matching-sensitive detail is that the deletion flag must be narrowed to a signed 16-bit value
before comparison. This reproduces the original extsh instruction used by MetroWerks destructor dispatch while retaining an ordinary C++ implementation.