### PR TITLE
feat: match autosave widget rendering

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/widget_render.c:
+	.text       start:0x00003368 end:0x00003404
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/widget_render.c",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/widget_render.c
+++ b/src/autosaveD/widget_render.c
@@ -1,0 +1,22 @@
+#include "types.h"
+
+extern void* lbl_2_bss_54[2];
+
+extern void fn_2_25A8(void* context, const void* position, const void* size, s32 selected);
+extern void fn_80194234(s32 channel, void* resource);
+extern void fn_2_2868(void* context, const void* position, const void* size);
+extern void fn_2_24FC(void* context);
+
+void fn_2_3368(void* context, const void* position, const void* size, s32 selected)
+{
+	fn_2_25A8(context, position, size, selected);
+
+	if (selected != 0) {
+		fn_80194234(1, lbl_2_bss_54[0]);
+	} else {
+		fn_80194234(1, lbl_2_bss_54[1]);
+	}
+
+	fn_2_2868(context, position, size);
+	fn_2_24FC(context);
+}


### PR DESCRIPTION
Adds rendering of an autosave widget, including its initial setup, selected or unselected shared resource binding, geometry rendering, and finalization.

The function’s 156-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
 passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

One matching-sensitive detail is preserving all four incoming arguments across the initial setup
call. The straightforward staged implementation causes MetroWerks to retain them in r28 through r31, reproducing the original register allocation and call sequence.