### PR TITLE
feat: match autosave window input handling

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/window_input.c:
+	.text       start:0x000038F4 end:0x00003A70
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/window_input.c",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/window_input.c
+++ b/src/autosaveD/window_input.c
@@ -1,0 +1,77 @@
+#include "types.h"
+
+typedef struct AutosaveWindow {
+	u8 unk_0x0[0x38];
+	s32 mode;
+	u8 unk_0x3C[0x24];
+	s32 close_on_confirm;
+	s32 input_mode;
+	s32 play_confirm_sound;
+	s32 result;
+	s32 input_delay;
+	u8 selector[0x8C];
+	s32 selection;
+} AutosaveWindow;
+
+extern void* lbl_8042C388;
+
+extern s32 fn_2_2488(s32 input_mode);
+extern s32 fn_2_46B4(void* selector, s32 direction);
+extern void fn_800B52E8(void* sound_manager, u32 sound, s32 arg2, s32 arg3);
+extern void fn_80014154(void);
+
+void fn_2_38F4(AutosaveWindow* window)
+{
+	s32 action;
+	s32 selection;
+
+	if (window->input_delay == 0) {
+		switch (window->mode) {
+			case 0:
+			case 2:
+				action = fn_2_2488(window->input_mode);
+				switch (action) {
+					case 0:
+						switch (window->input_mode) {
+							case 1:
+								selection = fn_2_46B4(window->selector, 0);
+								break;
+							case 2:
+								selection = fn_2_46B4(window->selector, 1);
+								break;
+							case 0:
+							default:
+								selection = fn_2_46B4(window->selector, -1);
+								break;
+						}
+
+						if (selection == -1 || selection == window->selection) {
+							break;
+						}
+
+						window->selection = selection;
+						if (lbl_8042C388 != NULL) {
+							fn_800B52E8(lbl_8042C388, 0xE007, 0, 0);
+						}
+						break;
+					case 1:
+						break;
+					case 2:
+						window->result = window->selection;
+						if (window->play_confirm_sound != 0 && lbl_8042C388 != NULL) {
+							fn_800B52E8(lbl_8042C388, 0xE008, 0, 0);
+						}
+						if (window->close_on_confirm != 0) {
+							fn_80014154();
+						}
+						break;
+				}
+				break;
+			case 1:
+				window->result = 1;
+				break;
+		}
+	} else {
+		window->input_delay--;
+	}
+}


### PR DESCRIPTION
Adds autosave window input handling, including delayed input, selector movement, confirmation,
result-state updates, sound cues, and optional window closure.

The function’s 380-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

Two matching-sensitive details are the placement of the delay decrement in the else arm after the complete state machine and the explicit grouping of input mode zero with the default selector
direction. Together these reproduce MetroWerks’ original branch layout and range-based switch
generation.