### PR TITLE
feat: match autosave widget overlay

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/widget_overlay.c:
+	.text       start:0x000032F8 end:0x00003368
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/widget_overlay.c",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/widget_overlay.c
+++ b/src/autosaveD/widget_overlay.c
@@ -1,0 +1,16 @@
+#include "types.h"
+
+extern void* lbl_2_bss_54[5];
+
+extern void fn_2_25A8(void* context, const void* position, const void* size);
+extern void fn_80194234(s32 channel, void* resource);
+extern void fn_2_2F94(void* context, const void* position, const void* size);
+extern void fn_2_24FC(void* context);
+
+void fn_2_32F8(void* context, const void* position, const void* size)
+{
+	fn_2_25A8(context, position, size);
+	fn_80194234(1, lbl_2_bss_54[4]);
+	fn_2_2F94(context, position, size);
+	fn_2_24FC(context);
+}


### PR DESCRIPTION
Adds rendering of the autosave widget overlay, including setup, binding of its shared overlay
resource, geometry submission, and finalization.

The function’s 112-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

One matching-sensitive detail is keeping the context, position, and size arguments live across the setup and resource-binding calls. This reproduces MetroWerks’ original r29 through r31 allocation and exact call sequence.