### PR TITLE
feat: match autosave line counting

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/line_count.c:
+	.text       start:0x00000000 end:0x00000038
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/line_count.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/line_count.c
+++ b/src/autosaveD/line_count.c
@@ -1,0 +1,19 @@
+#include "types.h"
+
+extern "C" s32 fn_2_0(void* context, const u16* text)
+{
+	if (text == NULL) {
+		return 1;
+	}
+
+	s32 line_count = 1;
+	s32 character;
+	while ((character = *text) != 0) {
+		if (character == '\n') {
+			line_count++;
+		}
+		text++;
+	}
+
+	return line_count;
+}


### PR DESCRIPTION
Adds the autosave text line-count helper, scanning a null-terminated UTF-16 string and counting
newline characters.

The function’s 56-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

One matching-sensitive detail is that each UTF-16 code unit must be promoted into an explicit C s32 temporary. This reproduces the original unsigned halfword load followed by MetroWerks’ signed integer comparison.