### PR TITLE
feat: match autosave task destruction flag

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/task_mark_destroy.c:
+	.text       start:0x000013E0 end:0x000013F4
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/task_mark_destroy.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/task_mark_destroy.c
+++ b/src/autosaveD/task_mark_destroy.c
@@ -1,0 +1,11 @@
+#include "types.h"
+
+typedef struct Task {
+	u8 padding[4];
+	u16 flags;
+} Task;
+
+extern "C" void fn_2_13E0(Task* task)
+{
+	task->flags |= 1;
+}


### PR DESCRIPTION
Adds the autosave task destruction marker, setting the low bit of the task’s 16-bit flags field.

The function’s 20-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

Keeping the flags field as u16 is matching-sensitive: the compound assignment reproduces MetroWerks’ original halfword load, bitwise OR, 16-bit truncation, and halfword store sequence.