### PR TITLE
feat: match autosave module initialization

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/module_init.c:
+	.text       start:0x0000136C end:0x0000139C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/module_init.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/module_init.c
+++ b/src/autosaveD/module_init.c
@@ -1,0 +1,14 @@
+#include "types.h"
+
+extern "C" u8 lbl_2_data_A8[0x18];
+
+extern "C" void fn_2_3FAC(void);
+extern "C" void fn_80126254(void);
+extern "C" void fn_8012CA94(void* state);
+
+extern "C" void fn_2_136C(void)
+{
+	fn_2_3FAC();
+	fn_80126254();
+	fn_8012CA94(lbl_2_data_A8);
+}


### PR DESCRIPTION
Adds autosave module initialization, running the autosave startup routine, initializing its
supporting subsystem, and registering the module’s global state.

The function’s 48-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The module state remains declared as the original 24-byte object at .data+0xA8, preserving the
module-relative address relocation and exact three-call initialization order.