### PR TITLE
feat: match autosave module shutdown

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/module_shutdown.c:
+	.text       start:0x0000139C end:0x000013CC
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/module_shutdown.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/module_shutdown.c
+++ b/src/autosaveD/module_shutdown.c
@@ -1,0 +1,14 @@
+#include "types.h"
+
+extern "C" u8 lbl_2_data_A8[0x18];
+
+extern "C" void fn_8012CB70(void* state);
+extern "C" void fn_801262DC(void);
+extern "C" void fn_2_3FD8(void);
+
+extern "C" void fn_2_139C(void)
+{
+	fn_8012CB70(lbl_2_data_A8);
+	fn_801262DC();
+	fn_2_3FD8();
+}


### PR DESCRIPTION
Adds autosave module shutdown, unregistering the module’s global state before shutting down its supporting subsystem and autosave resources.

The function’s 48-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The module state remains declared as the original 24-byte object at .data+0xA8, preserving the
module-relative address relocation and exact three-call teardown order.