### PR TITLE
feat: match autosave task callbacks

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/task_noops.c:
+	.text       start:0x000013CC end:0x000013E0
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/task_noops.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/task_noops.c
+++ b/src/autosaveD/task_noops.c
@@ -1,0 +1,11 @@
+#include "types.h"
+
+extern "C" void fn_2_13CC(void) { }
+
+extern "C" void fn_2_13D0(void) { }
+
+extern "C" void fn_2_13D4(void) { }
+
+extern "C" void fn_2_13D8(void) { }
+
+extern "C" void fn_2_13DC(void) { }


### PR DESCRIPTION
Adds five empty autosave task callback entry points used by the task lifecycle interface.

The TU’s complete 20-byte .text section—five four-byte functions—was verified byte-for-byte in
objdiff at 100%. The object also passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The callbacks remain separate exported functions despite sharing empty implementations, preserving their original symbol boundaries and ordering.