### PR TITLE
feat: match autosave task callback setters

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/task_callback_setters.c:
+	.text       start:0x00001ED4 end:0x00001EF0
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/task_callback_setters.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/task_callback_setters.c
+++ b/src/autosaveD/task_callback_setters.c
@@ -1,0 +1,26 @@
+#include "types.h"
+
+typedef struct Task {
+	u8 padding_00[0x1C];
+	void* callback_1C;
+	u8 padding_20[0x0C];
+	void* callback_2C;
+	void* callback_30;
+} Task;
+
+extern "C" void fn_2_1ED4(Task* task, void* callback)
+{
+	task->callback_1C = callback;
+}
+
+extern "C" void fn_2_1EDC(Task* task, void* callback)
+{
+	task->callback_2C = callback;
+}
+
+extern "C" void fn_2_1EE4(Task* task, void* callback)
+{
+	task->callback_30 = callback;
+}
+
+extern "C" void fn_2_1EEC(void) { }


### PR DESCRIPTION
Adds three autosave task callback setters and the adjacent empty callback entry point. The setters populate callback fields at offsets 0x1C, 0x2C, and 0x30.

The TU’s complete 28-byte .text section was verified byte-for-byte in objdiff at 100%. The object
also passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The task layout retains explicit padding between the first and second callback fields, preserving the original direct stores and exact function ordering.