### PR TITLE
feat: match autosave task callback cleanup

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/task_callback_cleanup.c:
+	.text       start:0x00001FB4 end:0x00001FE0
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/task_callback_cleanup.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/task_callback_cleanup.c
+++ b/src/autosaveD/task_callback_cleanup.c
@@ -1,0 +1,15 @@
+#include "types.h"
+
+typedef struct Task {
+	u8 padding[0x2C];
+	void* callback;
+} Task;
+
+extern "C" void fn_8012CC20(void* callback);
+
+extern "C" void fn_2_1FB4(Task* task)
+{
+	if (task->callback != NULL) {
+		fn_8012CC20(task->callback);
+	}
+}


### PR DESCRIPTION
Adds conditional cleanup of the autosave task callback object stored at offset 0x2C.

The function’s 44-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The callback field is intentionally left unchanged after the cleanup call, matching the original
lifecycle behavior and exact MetroWerks instruction sequence.