### PR TITLE
feat: match autosave task destructor

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/task_destructor.c:
+	.text       start:0x000020A8 end:0x0000211C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/task_destructor.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/task_destructor.c
+++ b/src/autosaveD/task_destructor.c
@@ -1,0 +1,27 @@
+#include "types.h"
+
+typedef struct Task {
+	u8 padding[0x18];
+	void* class_table;
+} Task;
+
+extern "C" u8 lbl_2_data_3C0[0x30];
+
+extern "C" void fn_80130464(s32 type);
+extern "C" Task* dtor_800186D0(Task* task, s32 flags);
+extern "C" void fn_2_13F4(void* memory);
+
+extern "C" Task* fn_2_20A8(Task* task, s16 flags)
+{
+	if (task != NULL) {
+		task->class_table = lbl_2_data_3C0;
+		fn_80130464(2);
+		dtor_800186D0(task, 0);
+
+		if (flags > 0) {
+			fn_2_13F4(task);
+		}
+	}
+
+	return task;
+}


### PR DESCRIPTION
Adds the autosave task deleting destructor. It restores the task class table, performs subsystem and base-object teardown, and conditionally releases the allocation through the module heap.

The function’s 116-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The deletion flags remain a signed 16-bit parameter, reproducing MetroWerks’ explicit sign extension before the conditional heap-free call. The destructor returns the original task pointer on every path.