### PR TITLE
feat: match autosave task creation

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/task_create.c:
+	.text       start:0x00002294 end:0x000022FC
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/task_create.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/task_create.c
+++ b/src/autosaveD/task_create.c
@@ -1,0 +1,23 @@
+#include "types.h"
+
+typedef struct Task Task;
+
+extern "C" s32 lbl_2_bss_40;
+
+extern "C" void* fn_2_1424(u32 size);
+extern "C" Task* fn_2_211C(Task* task, void* context);
+extern "C" void fn_80130464(s32 type);
+
+extern "C" void fn_2_2294(void* context)
+{
+	if (context != NULL) {
+		if (lbl_2_bss_40 != 0) {
+			Task* task = (Task*)fn_2_1424(0x38);
+			if (task != NULL) {
+				fn_2_211C(task, context);
+			}
+		} else {
+			fn_80130464(2);
+		}
+	}
+}


### PR DESCRIPTION
Adds autosave task creation, validating the input context and subsystem state before allocating a 56- byte task object and running its constructor.

The function’s 104-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The function remains a void creation callback: it deliberately ignores the constructor’s returned
pointer, matching the original control flow and register behavior. Allocation is skipped for a null
context, while an inactive subsystem reports type 2.