### PR TITLE
feat: match autosave task system cleanup

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/task_system_cleanup.c:
+	.text       start:0x000022FC end:0x0000233C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/task_system_cleanup.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/task_system_cleanup.c
+++ b/src/autosaveD/task_system_cleanup.c
@@ -1,0 +1,15 @@
+#include "types.h"
+
+extern "C" s32 lbl_2_bss_40;
+extern "C" u8 lbl_2_data_398[];
+
+extern "C" void fn_2_3FAC(void);
+extern "C" void fn_8012CFA4(void* resource);
+
+extern "C" void fn_2_22FC(void)
+{
+	if (lbl_2_bss_40 != 0) {
+		fn_2_3FAC();
+		fn_8012CFA4(lbl_2_data_398);
+	}
+}


### PR DESCRIPTION
Adds autosave task-system cleanup, conditionally tearing down the active rendering state and clearing its associated resource descriptor.

The function’s 64-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

Cleanup is skipped when the task subsystem is inactive, matching the original callback’s guarded control flow.