### PR TITLE
feat: match autosave task system initialization

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/task_system_init.c:
+	.text       start:0x0000233C end:0x00002488
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/task_system_init.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/task_system_init.c
+++ b/src/autosaveD/task_system_init.c
@@ -1,0 +1,59 @@
+#include "types.h"
+
+struct SaveState {
+	u8 padding[0x22];
+	u8 interval;
+};
+
+extern "C" s32 lbl_2_bss_40;
+extern "C" s32 lbl_2_bss_44;
+extern "C" u8 lbl_2_data_398[];
+extern "C" u8 lbl_80303EC8[];
+extern "C" u8 lbl_803E774C[];
+
+extern "C" SaveState* fn_80116D2C(void* state);
+extern "C" s32 fn_800A8BF8(void* settings);
+extern "C" void fn_800A8C00(void* settings, s32 interval);
+extern "C" void fn_8012D3A4(void* resource);
+extern "C" void fn_2_3FD8(void);
+
+extern "C" void fn_2_233C(void)
+{
+	lbl_2_bss_40 = 0;
+
+	s32 interval = fn_80116D2C(lbl_803E774C)->interval;
+	if (interval != fn_800A8BF8(lbl_80303EC8)) {
+		fn_800A8C00(lbl_80303EC8, interval);
+		lbl_2_bss_44 = 0;
+
+		switch (interval) {
+			case 20:
+				lbl_2_bss_44 = 1;
+				break;
+			case 40:
+				lbl_2_bss_44 = 2;
+				break;
+			case 60:
+				lbl_2_bss_44 = 3;
+				break;
+			case 80:
+				lbl_2_bss_44 = 4;
+				break;
+			case 100:
+				lbl_2_bss_44 = 5;
+				break;
+			case 120:
+				lbl_2_bss_44 = 6;
+				break;
+		}
+
+		if (lbl_2_bss_44 != 0) {
+			lbl_2_bss_40 = 1;
+		}
+	}
+
+	if (lbl_2_bss_40 != 0) {
+		fn_8012D3A4(lbl_2_data_398);
+		fn_2_3FD8();
+	}
+}


### PR DESCRIPTION
Adds autosave task-system initialization, synchronizing the configured interval, translating
supported intervals into cadence indices, and activating the associated rendering resource when
appropriate.

The function’s 332-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The supported interval values—20, 40, 60, 80, 100, and 120—map to cadence indices 1 through 6. Unsupported or unchanged values leave the subsystem inactive, matching the original control flow.