### PR TITLE
feat: match autosave controller status

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/controller_status.c:
+	.text       start:0x00002488 end:0x000024FC
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/controller_status.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/controller_status.c
+++ b/src/autosaveD/controller_status.c
@@ -1,0 +1,18 @@
+#include "types.h"
+
+extern "C" u8 lbl_80303EC8[];
+
+extern "C" s32 fn_800A9398(void* input, s32 controller);
+
+extern "C" s32 fn_2_2488(s32 state)
+{
+	switch (state) {
+		case 1:
+			return fn_800A9398(lbl_80303EC8, 0);
+		case 2:
+			return fn_800A9398(lbl_80303EC8, 1);
+		case 0:
+		default:
+			return fn_800A9398(lbl_80303EC8, -1);
+	}
+}


### PR DESCRIPTION
Adds the autosave controller-status adapter, mapping autosave states to the appropriate controller slot and returning the underlying input status unchanged.

The function’s 116-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

State 1 selects controller slot 0, state 2 selects slot 1, and all other states use the default
controller path. State 0 remains an explicit switch case because that source detail preserves the
original MetroWerks comparison tree.