### PR TITLE
feat: match autosave parameter synchronization

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/parameter_sync.c:
+	.text       start:0x000024FC end:0x000025A8
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/parameter_sync.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/parameter_sync.c
+++ b/src/autosaveD/parameter_sync.c
@@ -1,0 +1,23 @@
+#include "types.h"
+
+struct AutosaveState {
+	u8 padding[0x810];
+	s32 parameters[10];
+};
+
+extern "C" void fn_80194234(s32 id, s32 value);
+
+extern "C" void fn_2_24FC(AutosaveState* state)
+{
+	fn_80194234(6, state->parameters[0]);
+	fn_80194234(8, state->parameters[1]);
+	fn_80194234(12, state->parameters[2]);
+	fn_80194234(10, state->parameters[3]);
+	fn_80194234(11, state->parameters[4]);
+	fn_80194234(9, state->parameters[5]);
+	fn_80194234(20, state->parameters[6]);
+	fn_80194234(3, state->parameters[7]);
+	fn_80194234(4, state->parameters[8]);
+	fn_80194234(14, state->parameters[9]);
+	fn_80194234(1, 0);
+}


### PR DESCRIPTION
Adds autosave parameter synchronization, copying ten fields from the autosave state object into their corresponding engine parameter slots and clearing the final control flag.

The function’s 172-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The parameter calls intentionally preserve the original non-sequential ID order while reading the
source values contiguously from offsets 0x810 through 0x834.