### PR TITLE
feat: match autosave parameter snapshot

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/parameter_snapshot.c:
+	.text       start:0x000025A8 end:0x000026C0
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/parameter_snapshot.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/parameter_snapshot.c
+++ b/src/autosaveD/parameter_snapshot.c
@@ -1,0 +1,34 @@
+#include "types.h"
+
+struct AutosaveState {
+	u8 padding[0x810];
+	s32 parameters[10];
+};
+
+extern "C" void fn_80194234(s32 id, s32 value);
+extern "C" void fn_80194294(s32 id, s32* value);
+
+extern "C" void fn_2_25A8(AutosaveState* state)
+{
+	fn_80194294(6, &state->parameters[0]);
+	fn_80194294(8, &state->parameters[1]);
+	fn_80194294(12, &state->parameters[2]);
+	fn_80194294(10, &state->parameters[3]);
+	fn_80194294(11, &state->parameters[4]);
+	fn_80194294(9, &state->parameters[5]);
+	fn_80194294(20, &state->parameters[6]);
+	fn_80194294(3, &state->parameters[7]);
+	fn_80194294(4, &state->parameters[8]);
+	fn_80194294(14, &state->parameters[9]);
+
+	fn_80194234(6, 0);
+	fn_80194234(8, 0);
+	fn_80194234(12, 1);
+	fn_80194234(10, 5);
+	fn_80194234(11, 6);
+	fn_80194234(9, 1);
+	fn_80194234(20, 1);
+	fn_80194234(3, 3);
+	fn_80194234(4, 3);
+	fn_80194234(14, 0);
+}


### PR DESCRIPTION
Adds autosave parameter snapshotting, preserving ten engine parameters in the autosave state object before installing the temporary defaults required by the autosave screen.

The function’s 280-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The snapshot and replacement operations intentionally use the same non-sequential parameter ID order as the corresponding restoration routine, allowing the original settings to be restored when the autosave screen exits.