### PR TITLE
feat: match autosave result getter

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/result_getter.c:
+	.text       start:0x00003404 end:0x0000340C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/result_getter.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/result_getter.c
+++ b/src/autosaveD/result_getter.c
@@ -1,0 +1,11 @@
+#include "types.h"
+
+struct AutosaveState {
+	u8 padding[0x6C];
+	s32 result;
+};
+
+extern "C" s32 fn_2_3404(AutosaveState* state)
+{
+	return state->result;
+}


### PR DESCRIPTION
Adds the autosave result getter, returning the completion/result field stored at offset 0x6C in the
autosave state object.

The function’s 8-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The field is updated by the autosave state logic and queried by several higher-level controllers to
determine the current completion outcome.