### PR TITLE
feat: match autosave mode rendering

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/screen_render_mode.c:
+	.text       start:0x00003368 end:0x00003404
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/screen_render_mode.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/screen_render_mode.c
+++ b/src/autosaveD/screen_render_mode.c
@@ -1,0 +1,26 @@
+#include "types.h"
+
+struct RenderState {
+	s32 enabled[2];
+};
+
+extern "C" RenderState lbl_2_bss_54;
+
+extern "C" void fn_80194234(s32 id, s32 value);
+extern "C" void fn_2_25A8(void* state);
+extern "C" void fn_2_2868(void* state, void* position, void* scale);
+extern "C" void fn_2_24FC(void* state);
+
+extern "C" void fn_2_3368(void* state, void* position, void* scale, s32 mode)
+{
+	fn_2_25A8(state);
+
+	if (mode != 0) {
+		fn_80194234(1, lbl_2_bss_54.enabled[0]);
+	} else {
+		fn_80194234(1, lbl_2_bss_54.enabled[1]);
+	}
+
+	fn_2_2868(state, position, scale);
+	fn_2_24FC(state);
+}


### PR DESCRIPTION
Adds the mode-selecting autosave render wrapper, applying one of two saved render-enable values before drawing through the alternate autosave presentation path and restoring the previous engine parameters afterward.

The function’s 156-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

A nonzero mode selects the first saved render value, while zero selects the second. The surrounding
snapshot and restoration calls ensure the temporary render configuration remains scoped to this draw operation.