### PR TITLE
feat: match autosave default rendering

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/default_render.c:
+	.text       start:0x0000340C end:0x0000346C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/config/G9SE8P/config.yml
+++ b/config/G9SE8P/config.yml
@@ -51,6 +51,7 @@ modules:
   # so here. Without this the module comes out 0x10 short and every relative
   # branch past 0x476C shifts with it.
   force_active:
+    - fn_2_340C
     - fn_2_476C
 - object: files/movieD.rel
   hash: 6e2773a99ec5b05d5634d09521246e3e28bd6de9

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/default_render.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/default_render.c
+++ b/src/autosaveD/default_render.c
@@ -1,0 +1,33 @@
+#include "types.h"
+
+struct Placement {
+	u32 values[4];
+};
+
+struct Color {
+	u8 red;
+	u8 green;
+	u8 blue;
+	u8 alpha;
+};
+
+extern "C" u32 lbl_8029BB80[];
+
+extern "C" void fn_2_26C0(void* state, Placement* placement, Color* color);
+
+extern "C" void fn_2_340C(void* state)
+{
+	Placement placement;
+	placement.values[0] = 0;
+	placement.values[1] = 0;
+	placement.values[2] = lbl_8029BB80[1];
+	placement.values[3] = lbl_8029BB80[2];
+
+	Color color;
+	color.red   = 0;
+	color.green = 0;
+	color.blue  = 0;
+	color.alpha = 0xA0;
+
+	fn_2_26C0(state, &placement, &color);
+}


### PR DESCRIPTION
Adds the autosave default-render wrapper, constructing a default placement block from the global display state and forwarding it with a black color at 0xA0 alpha to the lower-level renderer.

The function’s 96-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The packet fields use explicit assignments rather than aggregate initialization because aggregate initialization introduces hidden constant copies and changes MetroWerks code generation. The function is also marked force-active because it has no internal callers and would otherwise be dead-stripped after separation from the original monolithic object.