### PR TITLE
feat: match autosave render state initialization

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/render_state_init.c:
+	.text       start:0x00003FAC end:0x00003FD8
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/render_state_init.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/render_state_init.c
+++ b/src/autosaveD/render_state_init.c
@@ -1,0 +1,12 @@
+#include "types.h"
+
+extern "C" u8 lbl_803E8150[];
+
+extern "C" void fn_8012FF6C(void* context);
+extern "C" void fn_2_3E4C(void);
+
+extern "C" void fn_2_3FAC(void)
+{
+	fn_8012FF6C(lbl_803E8150);
+	fn_2_3E4C();
+}


### PR DESCRIPTION
Adds autosave render-state initialization, initializing the shared engine render context before resetting the autosave render slots and releasing any stale render resource.

The function’s 44-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The initialization order is preserved from the original: the shared context at lbl_803E8150 is
initialized first, followed by autosave-specific render-state cleanup.