### PR TITLE
feat: match autosave render state shutdown

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/render_state_shutdown.c:
+	.text       start:0x00003FD8 end:0x00004004
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/render_state_shutdown.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/render_state_shutdown.c
+++ b/src/autosaveD/render_state_shutdown.c
@@ -1,0 +1,12 @@
+#include "types.h"
+
+extern "C" u8 lbl_803E8150[];
+
+extern "C" void fn_2_3EC0(void);
+extern "C" void fn_801301C8(void* context);
+
+extern "C" void fn_2_3FD8(void)
+{
+	fn_2_3EC0();
+	fn_801301C8(lbl_803E8150);
+}


### PR DESCRIPTION
Adds autosave render-state shutdown, releasing the autosave render resources before shutting down the shared engine render context.

The function’s 44-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The teardown order is preserved from the original: autosave-specific resources are released first, followed by the shared context at lbl_803E8150.