### PR TITLE
feat: match autosave render parameter initialization

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/render_params_init.c:
+	.text       start:0x00004004 end:0x00004070
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/render_params_init.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/render_params_init.c
+++ b/src/autosaveD/render_params_init.c
@@ -1,0 +1,51 @@
+#include "types.h"
+
+struct RenderParams {
+	u32 unk0;
+	u32 unk4;
+	u32 unk8;
+	u32 unkC;
+	u32 unk10;
+	f32 unk14;
+	f32 unk18;
+	f32 unk1C;
+	f32 unk20;
+	f32 unk24;
+	u32 unk28;
+	u32 unk2C;
+	u32 tick0;
+	u32 tick1;
+	u32 unk38;
+	u32 unk3C;
+	u32 unk40;
+};
+
+struct SharedState {
+	u32 unk0;
+	u32 tick0;
+	u32 tick1;
+};
+
+extern "C" const f32 lbl_2_rodata_348;
+extern "C" SharedState lbl_8029BB80;
+
+extern "C" void fn_2_4004(RenderParams* params)
+{
+	params->unk0  = 0;
+	params->unk4  = 0;
+	params->unk8  = 0;
+	params->unkC  = 0;
+	params->unk10 = 0;
+	params->unk14 = lbl_2_rodata_348;
+	params->unk18 = lbl_2_rodata_348;
+	params->unk1C = lbl_2_rodata_348;
+	params->unk20 = lbl_2_rodata_348;
+	params->unk24 = lbl_2_rodata_348;
+	params->unk28 = 0;
+	params->unk2C = 0;
+	params->tick0 = lbl_8029BB80.tick0;
+	params->tick1 = lbl_8029BB80.tick1;
+	params->unk38 = 0;
+	params->unk40 = 1;
+	params->unk3C = 1;
+}


### PR DESCRIPTION
Adds autosave render-parameter initialization, clearing the parameter block, initializing its
floating-point fields, copying the shared timing values, and enabling its two final state flags.

The function’s 108-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The shared timing values are copied directly from lbl_8029BB80, preserving the original load and store ordering.