### PR TITLE
feat: match autosave render callback no-op

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/render_callback_noop.c:
+	.text       start:0x00004070 end:0x00004074
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/render_callback_noop.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/render_callback_noop.c
+++ b/src/autosaveD/render_callback_noop.c
@@ -1,0 +1,3 @@
+#include "types.h"
+
+extern "C" void fn_2_4070(void) { }


### PR DESCRIPTION
 Adds the autosave render callback no-op referenced by the module’s callback table.

The function’s four-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.