### PR TITLE
feat: match autosave render mode setter

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/render_mode_set.c:
+	.text       start:0x00004074 end:0x0000408C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/render_mode_set.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/render_mode_set.c
+++ b/src/autosaveD/render_mode_set.c
@@ -1,0 +1,17 @@
+#include "types.h"
+
+struct RenderState {
+	u8 unk0[0x84];
+	s32 mode;
+};
+
+extern "C" void fn_2_4074(RenderState* state, s32 mode)
+{
+	if (mode <= 0) {
+		return;
+	}
+	if (mode >= 3) {
+		return;
+	}
+	state->mode = mode;
+}


### PR DESCRIPTION
Adds the autosave render-mode setter, accepting only the two valid nonzero modes before updating the render state.

The function’s 24-byte .text section was verified byte-for-byte in objdiff at 100%. The object also
passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

Signed range checks are retained so the compiler emits the original early-return blelr and bgelr
sequence.