### PR TITLE
feat: match autosave selector core

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/selector_core.c:
+	.text       start:0x00004074 end:0x00004160
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/config/G9SE8P/config.yml
+++ b/config/G9SE8P/config.yml
@@ -51,6 +51,8 @@ modules:
   # so here. Without this the module comes out 0x10 short and every relative
   # branch past 0x476C shifts with it.
   force_active:
+    - fn_2_408C
+    - fn_2_4098
     - fn_2_476C
 - object: files/movieD.rel
   hash: 6e2773a99ec5b05d5634d09521246e3e28bd6de9

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/selector_core.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/selector_core.c
+++ b/src/autosaveD/selector_core.c
@@ -1,0 +1,56 @@
+#include "types.h"
+
+struct RenderState {
+	s32 values[32];
+	s32 count;
+	s32 index;
+	s32 wrap_enabled;
+};
+
+extern "C" void fn_2_40F0(RenderState* state);
+
+extern "C" void fn_2_4074(RenderState* state, s32 index)
+{
+	if (index <= 0) {
+		return;
+	}
+	if (index >= 3) {
+		return;
+	}
+	state->index = index;
+}
+
+extern "C" void fn_2_408C(RenderState* state)
+{
+	state->wrap_enabled = 1;
+}
+
+extern "C" void fn_2_4098(RenderState* state, s32 value)
+{
+	for (int index = 0; index != state->count; index++) {
+		if (value == state->values[index]) {
+			state->index = index;
+			fn_2_40F0(state);
+			break;
+		}
+	}
+}
+
+extern "C" void fn_2_40F0(RenderState* state)
+{
+	if (state->wrap_enabled != 0) {
+		if (state->index < 0) {
+			state->index = state->count - 1;
+		}
+		if (state->count <= state->index) {
+			state->index = 0;
+		}
+	} else {
+		if (state->index < 0) {
+			state->index = 0;
+		}
+		if (state->count <= state->index) {
+			state->index = state->count - 1;
+		}
+	}
+}


### PR DESCRIPTION
Adds the autosave selector core, including validated index assignment, wrap enabling, value-to-index lookup, and index normalization with optional wrapping.

All four functions and the complete 236-byte .text section were verified byte-for-byte in objdiff at
100%. The object also passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The wrap setter and value lookup remain force-active because they have no static callers after
extraction but are externally reachable in the original module. Without retaining the lookup
function, the rebuilt REL is exactly 88 bytes short.