### PR TITLE
feat: match autosave task runtime

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/task_runtime.c:
+	.text       start:0x0000136C end:0x00001454
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/task_runtime.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/task_runtime.c
+++ b/src/autosaveD/task_runtime.c
@@ -1,0 +1,57 @@
+#include "types.h"
+
+struct Task {
+	u8 padding[4];
+	u16 flags;
+};
+
+extern "C" u8 lbl_2_data_A8[0x18];
+extern "C" void* lbl_8042C148;
+
+extern "C" void fn_2_3FAC(void);
+extern "C" void fn_2_3FD8(void);
+extern "C" void fn_80126254(void);
+extern "C" void fn_801262DC(void);
+extern "C" void fn_8012CA94(void* state);
+extern "C" void fn_8012CB70(void* state);
+extern "C" void fn_800189A4(void* heap, void* memory);
+extern "C" void* fn_80018A34(void* heap, u32 size);
+
+extern "C" void fn_2_136C(void)
+{
+	fn_2_3FAC();
+	fn_80126254();
+	fn_8012CA94(lbl_2_data_A8);
+}
+
+extern "C" void fn_2_139C(void)
+{
+	fn_8012CB70(lbl_2_data_A8);
+	fn_801262DC();
+	fn_2_3FD8();
+}
+
+extern "C" void fn_2_13CC(void) { }
+
+extern "C" void fn_2_13D0(void) { }
+
+extern "C" void fn_2_13D4(void) { }
+
+extern "C" void fn_2_13D8(void) { }
+
+extern "C" void fn_2_13DC(void) { }
+
+extern "C" void fn_2_13E0(Task* task)
+{
+	task->flags |= 1;
+}
+
+extern "C" void fn_2_13F4(void* memory)
+{
+	fn_800189A4(lbl_8042C148, memory);
+}
+
+extern "C" void* fn_2_1424(u32 size)
+{
+	return fn_80018A34(lbl_8042C148, size);
+}


### PR DESCRIPTION
Adds the autosave task runtime, including module initialization and shutdown, the five task callback no-ops, task destruction marking, and the shared heap allocation and release wrappers.

All ten functions and the complete 232-byte .text section were verified byte-for-byte in objdiff at 100%. The object also passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

These routines remain together because they occupy one contiguous runtime span and share the module, task, and heap lifecycle rather than being emitted as individual function-sized objects.