### PR TITLE
feat: match autosave widget rendering

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/widget_rendering.c:
+	.text       start:0x000032F8 end:0x0000346C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/config/G9SE8P/config.yml
+++ b/config/G9SE8P/config.yml
@@ -51,6 +51,7 @@ modules:
   # so here. Without this the module comes out 0x10 short and every relative
   # branch past 0x476C shifts with it.
   force_active:
+    - fn_2_340C
     - fn_2_476C
 - object: files/movieD.rel
   hash: 6e2773a99ec5b05d5634d09521246e3e28bd6de9

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/widget_rendering.c",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/widget_rendering.c
+++ b/src/autosaveD/widget_rendering.c
@@ -1,0 +1,81 @@
+#include "types.h"
+
+typedef struct AutosaveWindow {
+	u8 unk_0x0[0x6C];
+	s32 state;
+} AutosaveWindow;
+
+typedef struct WindowConfig {
+	u32 unk_0x0;
+	u32 unk_0x4;
+	u32 tick_0;
+	u32 tick_1;
+} WindowConfig;
+
+typedef struct Color {
+	u8 red;
+	u8 green;
+	u8 blue;
+	u8 alpha;
+} Color;
+
+typedef struct MainState {
+	u8 unk_0x0[4];
+	u32 tick_0;
+	u32 tick_1;
+} MainState;
+
+extern void* lbl_2_bss_54[5];
+extern MainState lbl_8029BB80;
+
+extern void fn_2_25A8();
+extern void fn_80194234(s32 channel, void* resource);
+extern void fn_2_2F94(void* context, const void* position, const void* size);
+extern void fn_2_2868(void* context, const void* position, const void* size);
+extern void fn_2_24FC(void* context);
+extern void fn_2_26C0(void* window, const WindowConfig* config, const Color* color);
+
+void fn_2_32F8(void* context, const void* position, const void* size)
+{
+	fn_2_25A8(context, position, size);
+	fn_80194234(1, lbl_2_bss_54[4]);
+	fn_2_2F94(context, position, size);
+	fn_2_24FC(context);
+}
+
+void fn_2_3368(void* context, const void* position, const void* size, s32 selected)
+{
+	fn_2_25A8(context, position, size, selected);
+
+	if (selected != 0) {
+		fn_80194234(1, lbl_2_bss_54[0]);
+	} else {
+		fn_80194234(1, lbl_2_bss_54[1]);
+	}
+
+	fn_2_2868(context, position, size);
+	fn_2_24FC(context);
+}
+
+s32 fn_2_3404(const AutosaveWindow* window)
+{
+	return window->state;
+}
+
+void fn_2_340C(void* window)
+{
+	WindowConfig config;
+	Color color;
+
+	config.unk_0x0 = 0;
+	config.unk_0x4 = 0;
+	config.tick_0  = lbl_8029BB80.tick_0;
+	config.tick_1  = lbl_8029BB80.tick_1;
+
+	color.red   = 0;
+	color.green = 0;
+	color.blue  = 0;
+	color.alpha = 0xA0;
+
+	fn_2_26C0(window, &config, &color);
+}


### PR DESCRIPTION
Adds the autosave widget-rendering core, including overlay rendering, selected-state rendering, window-state retrieval, and default window configuration.

All four functions and the complete 372-byte .text section were verified byte-for-byte in objdiff at 100%. The object also passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The default configuration helper remains force-active because it has no static caller after extraction but is retained in the original module. The adjacent quad-submission helper remains separate because compiler metadata identifies it as C++, while this translation unit is C.