### PR TITLE
feat: match autosave state selector

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/state_selector.c:
+	.text       start:0x00003FAC end:0x00004344
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/config/G9SE8P/config.yml
+++ b/config/G9SE8P/config.yml
@@ -45,12 +45,14 @@ modules:
   hash: 120e89d6ca861f63ecf9c8f2d282bab5b500ab17
   symbols: config/G9SE8P/autosaveD/symbols.txt
   splits: config/G9SE8P/autosaveD/splits.txt
-  # Nothing inside the module references fn_2_476C, so mwld drops it once the
-  # translation unit that holds it is compiled rather than emitted by dtk: dtk
+  # Nothing inside the module references these entry points, so mwld drops them
+  # once their translation units are compiled rather than emitted by dtk: dtk
   # exports every symbol in the objects it writes, a hand written one has to say
-  # so here. Without this the module comes out 0x10 short and every relative
-  # branch past 0x476C shifts with it.
+  # so here. Without this the module is shortened and later code shifts with it.
   force_active:
+    - fn_2_408C
+    - fn_2_4098
+    - fn_2_4160
     - fn_2_476C
 - object: files/movieD.rel
   hash: 6e2773a99ec5b05d5634d09521246e3e28bd6de9

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/state_selector.c",
+                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/state_selector.c
+++ b/src/autosaveD/state_selector.c
@@ -1,0 +1,191 @@
+#include "types.h"
+
+struct GlobalState {
+	u32 unk_0x0;
+	u32 tick_high;
+	u32 tick_low;
+};
+
+struct AutosaveState {
+	s32 unk_0x0;
+	s32 unk_0x4;
+	s32 unk_0x8;
+	s32 unk_0xC;
+	s32 unk_0x10;
+	f32 unk_0x14;
+	f32 unk_0x18;
+	f32 unk_0x1C;
+	f32 unk_0x20;
+	f32 unk_0x24;
+	s32 unk_0x28;
+	u32 unk_0x2C;
+	u32 tick_high;
+	u32 tick_low;
+	s32 unk_0x38;
+	s32 unk_0x3C;
+	s32 unk_0x40;
+};
+
+struct Selector {
+	s32 items[32];
+	s32 count;
+	s32 index;
+	s32 wrap;
+};
+
+extern u8 lbl_803E8150[];
+extern u8 lbl_80303EC8[];
+extern GlobalState lbl_8029BB80;
+extern const f32 lbl_2_rodata_348;
+
+extern "C" void fn_8012FF6C(void* resource);
+extern "C" void fn_2_3E4C(void);
+extern "C" void fn_2_3EC0(void);
+extern "C" void fn_801301C8(void* resource);
+extern "C" s32 fn_800A92E0(void* input, s32 button, s32 port);
+extern "C" void fn_2_40F0(Selector* selector);
+
+extern "C" void fn_2_3FAC(void)
+{
+	fn_8012FF6C(lbl_803E8150);
+	fn_2_3E4C();
+}
+
+extern "C" void fn_2_3FD8(void)
+{
+	fn_2_3EC0();
+	fn_801301C8(lbl_803E8150);
+}
+
+extern "C" void fn_2_4004(AutosaveState* state)
+{
+	state->unk_0x0   = 0;
+	state->unk_0x4   = 0;
+	state->unk_0x8   = 0;
+	state->unk_0xC   = 0;
+	state->unk_0x10  = 0;
+	state->unk_0x14  = lbl_2_rodata_348;
+	state->unk_0x18  = lbl_2_rodata_348;
+	state->unk_0x1C  = lbl_2_rodata_348;
+	state->unk_0x20  = lbl_2_rodata_348;
+	state->unk_0x24  = lbl_2_rodata_348;
+	state->unk_0x28  = 0;
+	state->unk_0x2C  = 0;
+	state->tick_high = lbl_8029BB80.tick_high;
+	state->tick_low  = lbl_8029BB80.tick_low;
+	state->unk_0x38  = 0;
+	state->unk_0x3C = state->unk_0x40 = 1;
+}
+
+extern "C" void fn_2_4070(void* window) { }
+
+extern "C" void fn_2_4074(Selector* selector, s32 index)
+{
+	if (index <= 0) {
+		return;
+	}
+	if (index >= 3) {
+		return;
+	}
+	selector->index = index;
+}
+
+extern "C" void fn_2_408C(Selector* selector)
+{
+	selector->wrap = 1;
+}
+
+extern "C" void fn_2_4098(Selector* selector, s32 value)
+{
+	s32 i;
+
+	for (i = 0; i != selector->count; i++) {
+		if (selector->items[i] == value) {
+			selector->index = i;
+			fn_2_40F0(selector);
+			break;
+		}
+	}
+}
+
+#pragma dont_inline on
+extern "C" void fn_2_40F0(Selector* selector)
+{
+	if (selector->wrap) {
+		if (selector->index < 0) {
+			selector->index = selector->count - 1;
+		}
+		if (selector->count > selector->index) {
+			return;
+		}
+		selector->index = 0;
+	} else {
+		if (selector->index < 0) {
+			selector->index = 0;
+		}
+		if (selector->count > selector->index) {
+			return;
+		}
+		selector->index = selector->count - 1;
+	}
+}
+#pragma dont_inline reset
+
+extern "C" s32 fn_2_4160(Selector* selector, s32 firstRowLength, s32 secondRowLength, s32 port)
+{
+	s32 currentIndex;
+
+	if (port == -1) {
+		port = 0;
+	}
+
+	{
+		Selector* state  = selector;
+		s32 canMoveUp    = 1;
+		s32 canMoveDown  = 1;
+		s32 canMoveLeft  = 1;
+		s32 canMoveRight = 1;
+		u32 isFirstRow;
+
+		currentIndex = state->index;
+		isFirstRow   = currentIndex < firstRowLength;
+
+		if (isFirstRow) {
+			canMoveUp = 0;
+		}
+		if (!isFirstRow) {
+			canMoveDown = 0;
+		}
+		if (*(volatile s32*)&state->index == 0 || currentIndex == firstRowLength) {
+			canMoveLeft = 0;
+		}
+		if (currentIndex == firstRowLength - 1
+		    || currentIndex == firstRowLength + secondRowLength - 1) {
+			canMoveRight = 0;
+		}
+
+		if (canMoveUp && fn_800A92E0(lbl_80303EC8, 8, port)) {
+			state->index -= firstRowLength;
+			while (state->index >= firstRowLength) {
+				state->index--;
+			}
+		} else if (canMoveDown && fn_800A92E0(lbl_80303EC8, 4, port)) {
+			state->index += firstRowLength;
+			while (state->index < firstRowLength) {
+				state->index++;
+			}
+		} else if (canMoveLeft && fn_800A92E0(lbl_80303EC8, 1, port)) {
+			state->index--;
+		} else if (canMoveRight && fn_800A92E0(lbl_80303EC8, 2, port)) {
+			state->index++;
+		}
+
+		fn_2_40F0(state);
+
+		if (state->index == -1) {
+			return -1;
+		}
+
+		return state->items[state->index];
+	}
+}


### PR DESCRIPTION
Adds the autosave state and selector runtime, including module startup and shutdown, state initialization, the empty window callback, selector index management, value lookup, bounds normalization, and variable two-row grid navigation.

All nine functions and the complete 920-byte .text section were verified byte-for-byte in objdiff at 100%. The object also passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The selector bounds helper remains explicitly non-inline because MetroWerks otherwise folds it into the grid-navigation function when both are compiled in the same C++ translation unit. Three externally reached selector entry points remain force-active because they have no static callers inside the REL. The shared zero-float constant remains with the module’s existing data owner because it is referenced by both this unit and the neighboring window-lifecycle unit.