### PR TITLE
feat: match autosave menu selectors

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -6,5 +6,8 @@ Sections:
 	.data       type:data align:8
 	.bss        type:bss align:8
 
+autosaveD/menu_selectors.c:
+	.text       start:0x00004344 end:0x0000476C
+
 autosaveD/table.c:
 	.text       start:0x0000476C end:0x000047F0

--- a/config/G9SE8P/config.yml
+++ b/config/G9SE8P/config.yml
@@ -45,12 +45,14 @@ modules:
   hash: 120e89d6ca861f63ecf9c8f2d282bab5b500ab17
   symbols: config/G9SE8P/autosaveD/symbols.txt
   splits: config/G9SE8P/autosaveD/splits.txt
-  # Nothing inside the module references fn_2_476C, so mwld drops it once the
-  # translation unit that holds it is compiled rather than emitted by dtk: dtk
+  # Nothing inside the module references these entry points, so mwld drops them
+  # once their translation units are compiled rather than emitted by dtk: dtk
   # exports every symbol in the objects it writes, a hand written one has to say
-  # so here. Without this the module comes out 0x10 short and every relative
-  # branch past 0x476C shifts with it.
+  # so here. Without this the module is shortened and later code shifts with it.
   force_active:
+    - fn_2_4344
+    - fn_2_4500
+    - fn_2_45B8
     - fn_2_476C
 - object: files/movieD.rel
   hash: 6e2773a99ec5b05d5634d09521246e3e28bd6de9

--- a/configure.py
+++ b/configure.py
@@ -430,6 +430,11 @@ config.libs = [
         [
             Object(
                 Matching,
+                "autosaveD/menu_selectors.c",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "autosaveD/table.c",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/autosaveD/menu_selectors.c
+++ b/src/autosaveD/menu_selectors.c
@@ -1,0 +1,130 @@
+#include "types.h"
+
+typedef struct Selector {
+	s32 items[32];
+	s32 count;
+	s32 index;
+	s32 wrap;
+} Selector;
+
+extern u8 lbl_80303EC8[];
+
+extern s32 fn_800A92E0(void* input, s32 button, s32 port);
+extern void fn_2_40F0(Selector* selector);
+
+s32 fn_2_4344(Selector* selector, s32 port)
+{
+	if (port == -1) {
+		port = 0;
+	}
+
+	switch (selector->index) {
+		case 0:
+			if (fn_800A92E0(lbl_80303EC8, 2, port)) {
+				selector->index = 2;
+			}
+			if (fn_800A92E0(lbl_80303EC8, 4, port)) {
+				selector->index = 1;
+			}
+			break;
+		case 1:
+			if (fn_800A92E0(lbl_80303EC8, 8, port)) {
+				selector->index = 0;
+			}
+			if (fn_800A92E0(lbl_80303EC8, 2, port)) {
+				selector->index = 3;
+			}
+			break;
+		case 2:
+			if (fn_800A92E0(lbl_80303EC8, 1, port)) {
+				selector->index = 0;
+			}
+			if (fn_800A92E0(lbl_80303EC8, 4, port)) {
+				selector->index = 3;
+			}
+			break;
+		case 3:
+			if (fn_800A92E0(lbl_80303EC8, 8, port)) {
+				selector->index = 2;
+			}
+			if (fn_800A92E0(lbl_80303EC8, 1, port)) {
+				selector->index = 1;
+			}
+			break;
+	}
+
+	fn_2_40F0(selector);
+
+	if (selector->index == -1) {
+		return -1;
+	}
+
+	return selector->items[selector->index];
+}
+
+s32 fn_2_4500(Selector* selector, s32 port)
+{
+	if (port == -1) {
+		port = 0;
+	}
+
+	if (fn_800A92E0(lbl_80303EC8, 1, port)) {
+		selector->index--;
+	} else if (fn_800A92E0(lbl_80303EC8, 2, port)) {
+		selector->index++;
+	}
+
+	fn_2_40F0(selector);
+
+	if (selector->index == -1) {
+		return -1;
+	}
+
+	return selector->items[selector->index];
+}
+
+s32 fn_2_45B8(Selector* selector)
+{
+	if (fn_800A92E0(lbl_80303EC8, 8, 0)) {
+		selector->index--;
+	} else if (fn_800A92E0(lbl_80303EC8, 4, 0)) {
+		selector->index++;
+	}
+
+	fn_2_40F0(selector);
+
+	if (fn_800A92E0(lbl_80303EC8, 8, 1)) {
+		selector->index--;
+	} else if (fn_800A92E0(lbl_80303EC8, 4, 1)) {
+		selector->index++;
+	}
+
+	fn_2_40F0(selector);
+
+	if (selector->index == -1) {
+		return -1;
+	}
+
+	return selector->items[selector->index];
+}
+
+s32 fn_2_46B4(Selector* selector, s32 port)
+{
+	if (port == -1) {
+		port = 0;
+	}
+
+	if (fn_800A92E0(lbl_80303EC8, 8, port)) {
+		selector->index--;
+	} else if (fn_800A92E0(lbl_80303EC8, 4, port)) {
+		selector->index++;
+	}
+
+	fn_2_40F0(selector);
+
+	if (selector->index == -1) {
+		return -1;
+	}
+
+	return selector->items[selector->index];
+}


### PR DESCRIPTION
Adds the autosave menu-selection handlers, including fixed two-by-two grid navigation, horizontal navigation, dual- controller navigation, and the standard linear selector path.

All four functions and the complete 1,064-byte .text section were verified byte-for-byte in objdiff at 100%. The object also passed the forced fresh-build, section-size, Matching-link, DOL SHA-1, and all 17 REL SHA-1 gates.

The three externally invoked menu handlers remain force-active because they have no static callers inside the autosave REL; the standard selector path is retained naturally by an internal call. The adjacent table routines remain separate because their deleting-destructor shape identifies the following code as a C++ translation-unit boundary.