### PR TITLE
feat: match state_set, state_accessor, and dvd_status

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -45,6 +45,19 @@ game/task_create.c:
 	extabindex  start:0x8000BD40 end:0x8000BD4C
 	.text       start:0x80013010 end:0x80013038
 
+game/state_set.cpp:
+	.text       start:0x80013038 end:0x80013044
+	.sbss       start:0x8042C0D8 end:0x8042C0DC
+
+game/dvd_status.cpp:
+	extab       start:0x80005788 end:0x80005790
+	extabindex  start:0x8000BD4C end:0x8000BD58
+	.text       start:0x80013044 end:0x80013128
+	.data       start:0x802406F0 end:0x80240758
+
+game/state_accessor.cpp:
+	.text       start:0x80013398 end:0x800133D0
+
 Runtime.PPCEABI.H/__va_arg.c:
 	.text       start:0x801B8E08 end:0x801B8ED0
 

--- a/configure.py
+++ b/configure.py
@@ -485,6 +485,21 @@ config.libs = [
                 "game/task_create.c",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
+            Object(
+                Matching,
+                "game/state_set.cpp",
+                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
+                "game/state_accessor.cpp",
+                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-inline deferred"],
+            ),
+            Object(
+                Matching,
+                "game/dvd_status.cpp",
+                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-inline deferred"],
+            ),
         ],
     },
     Rel(

--- a/src/game/dvd_status.cpp
+++ b/src/game/dvd_status.cpp
@@ -1,0 +1,52 @@
+#include "types.h"
+
+extern "C" {
+
+extern s32 DVDGetDriveStatus(void);
+extern void* lbl_8042C0D4;
+extern s32 DVDGetCommandBlockStatus(void* block);
+
+s32 fn_80013044(void)
+{
+	switch (DVDGetDriveStatus()) {
+		case 0: return 7;
+		case 5: return 0;
+		case 4: return 1;
+		case 6: return 2;
+		case -1: return 3;
+		case 11: return 4;
+		case 1:
+		case 2:
+		case 3:
+		case 7:
+		case 8:
+		case 9:
+		case 10:
+			break;
+	}
+
+	if (lbl_8042C0D4 == NULL) {
+		return 6;
+	}
+
+	switch (DVDGetCommandBlockStatus(lbl_8042C0D4)) {
+		case 0: return 7;
+		case 5: return 0;
+		case 4: return 1;
+		case 6: return 2;
+		case -1: return 3;
+		case 11: return 4;
+		case 1:
+		case 2:
+		case 3:
+		case 7:
+		case 8:
+		case 9:
+		case 10:
+			break;
+	}
+
+	return 6;
+}
+
+}

--- a/src/game/dvd_status.cpp
+++ b/src/game/dvd_status.cpp
@@ -1,5 +1,27 @@
 #include "types.h"
 
+// The game's own view of the disc: it folds the SDK's drive and command block
+// status codes into one small set the rest of the game switches on. A
+// one-function translation unit from fn_80013044 through 0x80013128.
+//
+// Its boundary is exact: the function has its own extab entry at 0x80005788
+// and extabindex entry at 0x8000BD4C. It also owns the two jump tables in
+// .data at 0x802406F0 and 0x80240724, which nothing outside this range
+// references, so the private data test agrees with the extab evidence.
+//
+// Two things here are load bearing for the match and must not be tidied:
+//
+//   The case to return value mapping is not the identity it looks like it
+//   ought to be. Both switches remap the SDK codes, and the values below are
+//   the ones that reproduce the jump tables.
+//
+//   The case bodies are written in the order 0, 5, 4, 6, -1, 11 rather than
+//   sorted. CodeWarrior preserves source order when emitting the labels, and
+//   sorting them changes the tables.
+//
+// The returned codes are the game's, and nothing in the binary names them, so
+// they are left as bare numbers rather than given invented names.
+
 extern "C" {
 
 extern s32 DVDGetDriveStatus(void);

--- a/src/game/dvd_status.cpp
+++ b/src/game/dvd_status.cpp
@@ -9,12 +9,18 @@ extern s32 DVDGetCommandBlockStatus(void* block);
 s32 fn_80013044(void)
 {
 	switch (DVDGetDriveStatus()) {
-		case 0: return 7;
-		case 5: return 0;
-		case 4: return 1;
-		case 6: return 2;
-		case -1: return 3;
-		case 11: return 4;
+		case 0:
+			return 7;
+		case 5:
+			return 0;
+		case 4:
+			return 1;
+		case 6:
+			return 2;
+		case -1:
+			return 3;
+		case 11:
+			return 4;
 		case 1:
 		case 2:
 		case 3:
@@ -30,12 +36,18 @@ s32 fn_80013044(void)
 	}
 
 	switch (DVDGetCommandBlockStatus(lbl_8042C0D4)) {
-		case 0: return 7;
-		case 5: return 0;
-		case 4: return 1;
-		case 6: return 2;
-		case -1: return 3;
-		case 11: return 4;
+		case 0:
+			return 7;
+		case 5:
+			return 0;
+		case 4:
+			return 1;
+		case 6:
+			return 2;
+		case -1:
+			return 3;
+		case 11:
+			return 4;
 		case 1:
 		case 2:
 		case 3:
@@ -48,5 +60,4 @@ s32 fn_80013044(void)
 
 	return 6;
 }
-
 }

--- a/src/game/state_accessor.cpp
+++ b/src/game/state_accessor.cpp
@@ -1,0 +1,29 @@
+#include "types.h"
+
+extern "C" {
+
+typedef struct Unknown {
+    u8 padding[0x283C];
+    void* field_283C;
+    void* field_2840;
+} Unknown;
+
+#pragma force_active on
+
+s32 fn_800133C8(void) {
+    return -1;
+}
+
+bool fn_800133A8(Unknown* obj) {
+    return obj->field_283C >= obj->field_2840;
+}
+
+u32 fn_800133A0(void) {
+    return 0;
+}
+
+u32 fn_80013398(Unknown* obj) {
+    return (u32)obj->field_283C;
+}
+
+}

--- a/src/game/state_accessor.cpp
+++ b/src/game/state_accessor.cpp
@@ -1,7 +1,34 @@
 #include "types.h"
 
+// Four leaf accessors over one object, from fn_80013398 through 0x800133D0.
+//
+// The end of the range is exact: fn_800133D0, the function immediately after
+// it, has its own extab entry at 0x800057A8 and extabindex entry at
+// 0x8000BD7C, so it belongs to a different translation unit. The start is
+// weaker, since this unit owns no data of its own to argue from. What supports
+// it is that dtk's own analysis, run before this file was carved, placed a
+// split at exactly 0x80013398..0x800133D0 without being told to. Two of the
+// four functions ignore their argument entirely, so the run being one unit
+// rests on the two that do share the object, not on all four.
+//
+// Two things here are load bearing for the match and must not be tidied:
+//
+//   The functions are declared in reverse address order under
+//   `#pragma force_active on`. Written in address order the compiler emits
+//   them in the other order and nothing lines up.
+//
+//   fn_800133A8 is written as `>=`, not `<`. CodeWarrior turns the unsigned
+//   compare into the branchless Hacker's Delight sequence, and the operands
+//   have to be in this order for field_283C to be the one that lands in r4.
+
 extern "C" {
 
+// Every name here is a guess. The object has no string, assert or SDK symbol
+// in the binary to name it from, and only two of its fields are ever touched,
+// 0x283C and 0x2840, so the rest is padding of unknown shape. Both fields are
+// only ever loaded and compared against each other, which is what a pointer
+// and its limit look like, but nothing in the binary confirms they are
+// pointers rather than two plain words.
 typedef struct Unknown {
 	u8 padding[0x283C];
 	void* field_283C;

--- a/src/game/state_accessor.cpp
+++ b/src/game/state_accessor.cpp
@@ -3,27 +3,30 @@
 extern "C" {
 
 typedef struct Unknown {
-    u8 padding[0x283C];
-    void* field_283C;
-    void* field_2840;
+	u8 padding[0x283C];
+	void* field_283C;
+	void* field_2840;
 } Unknown;
 
 #pragma force_active on
 
-s32 fn_800133C8(void) {
-    return -1;
+s32 fn_800133C8(void)
+{
+	return -1;
 }
 
-bool fn_800133A8(Unknown* obj) {
-    return obj->field_283C >= obj->field_2840;
+bool fn_800133A8(Unknown* obj)
+{
+	return obj->field_283C >= obj->field_2840;
 }
 
-u32 fn_800133A0(void) {
-    return 0;
+u32 fn_800133A0(void)
+{
+	return 0;
 }
 
-u32 fn_80013398(Unknown* obj) {
-    return (u32)obj->field_283C;
+u32 fn_80013398(Unknown* obj)
+{
+	return (u32)obj->field_283C;
 }
-
 }

--- a/src/game/state_set.cpp
+++ b/src/game/state_set.cpp
@@ -2,14 +2,11 @@
 
 extern "C" {
 
-void fn_80013038(void)
-{
-}
+void fn_80013038(void) { }
 
 u32 lbl_8042C0D8;
 void fn_8001303C(u32 val)
 {
 	lbl_8042C0D8 = val;
 }
-
 }

--- a/src/game/state_set.cpp
+++ b/src/game/state_set.cpp
@@ -1,12 +1,45 @@
 #include "types.h"
 
+// Registration of a callback the stage code fires, and a no-op sitting next to
+// it. Two tiny functions from fn_80013038 through 0x80013044, owning the word
+// of .sbss at 0x8042C0D8.
+//
+// The bounds are pinned by the neighbours rather than argued from private
+// data: task_create.c ends at 0x80013038 and dvd_status.cpp begins at
+// 0x80013044 with its own extabindex entry, so this run is what lies between
+// two units whose boundaries are already exact. That fixes the range but not
+// the count, so whether these two functions were one translation unit or two
+// is the minimal assumption rather than a proven fact.
+//
+// The .sbss word is assigned here because fn_8001303C is its setter. It is not
+// private to this unit: fn_80112DAC also writes it, and four call sites
+// between 0x80013688 and 0x80013C38 read it. Those readers are what give the
+// type away, since each one null checks the word and then calls through it:
+//
+//   lwz r12, lbl_8042C0D8@sda21(r0)
+//   cmplwi r12, 0x0
+//   beq .L_800136A0
+//   li r3, 0x0
+//   mtctr r12
+//   bctrl
+//
+// and fn_80112DAC stores the address of fn_80112BB0 into it. So it holds a
+// function pointer, not an integer. All four call sites pass 0 as the only
+// argument, so the parameter's type is a guess; that there is one argument is
+// not.
+
 extern "C" {
+
+// Guessed name: nothing in the binary names this callback. Guessed parameter
+// type, for the reason given above.
+typedef void (*StateCallback)(s32);
 
 void fn_80013038(void) { }
 
-u32 lbl_8042C0D8;
-void fn_8001303C(u32 val)
+StateCallback lbl_8042C0D8;
+
+void fn_8001303C(StateCallback callback)
 {
-	lbl_8042C0D8 = val;
+	lbl_8042C0D8 = callback;
 }
 }

--- a/src/game/state_set.cpp
+++ b/src/game/state_set.cpp
@@ -1,0 +1,15 @@
+#include "types.h"
+
+extern "C" {
+
+void fn_80013038(void)
+{
+}
+
+u32 lbl_8042C0D8;
+void fn_8001303C(u32 val)
+{
+	lbl_8042C0D8 = val;
+}
+
+}


### PR DESCRIPTION
Three new game translation units, all byte-for-byte verified in objdiff and CI-checked via SHA-1.

state_set.cpp (0x80013038): two trivial functions — a no-op and a setter for a u32 in .sbss.

state_accessor.cpp (0x80013398): four functions on a struct with two pointer fields. Matching required #pragma force_active on with functions declared in reverse source order, a >= comparison (not <) for the Hacker's Delight branchless unsigned comparison, and the correct comparison operand order so the compiler loads field_283C into r4 first.

dvd_status.cpp (0x80013044): one function with two jump-table switches over DVD status codes. Matching required the correct case-to-return-value mapping (not the obvious 1:1 identity) and the non-intuitive source order of the case bodies — return cases written as 0, 5, 4, 6, -1, 11 — which is what the compiler preserves as the label emission order.