### PR TITLE
ci: harden source language policy gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -96,8 +96,10 @@ big=$(git diff --cached --numstat --diff-filter=AM -z \
 [ -n "$big" ] && fail "These staged binaries are over 512 KB:" "$big"
 
 # 5. Language policy. The staged form does not need a configured build tree and
-#    catches newly added game-owned C files plus unreviewed deferred-inline
-#    overrides. CI performs the complete configured-command audit.
+#    catches added or renamed game-owned C files, noncanonical C++ extensions
+#    and unreviewed deferred-inline overrides. CI performs the complete
+#    configured-command audit.
+python3 -m unittest tools.test_check_language_policy || exit 1
 python3 tools/check_language_policy.py --staged || exit 1
 
 # 6. Formatting. Only runs if clang-format is installed, so a contributor

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,7 +18,7 @@
 #   5. the reviewed C/C++ and inline policy
 #   6. source formatting
 
-staged=$(git diff --cached --name-only --diff-filter=AM)
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
 [ -z "$staged" ] && exit 0
 
 fail() {

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,7 @@ Evidence and references:
      commits and tests them from a repository-owned integration branch. -->
 
 - [ ] `python tools/check_language_policy.py`
+- [ ] `python -m unittest tools.test_check_language_policy`
 - [ ] `clang-format -i` on changed files under `src/` and `include/`
 - [ ] objdiff result recorded below
 - [ ] `ninja` passes and the artifact SHA-1 checks remain valid

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,8 @@ Describe the one logical unit changed by this pull request.
 
 - [ ] I identified the source language and linkage from evidence, not from the
       current file extension or a byte match alone.
+- [ ] If this is a C path, I distinguished positive C source evidence from a
+      reviewed C ABI boundary whose historical file language is unresolved.
 - [ ] I recorded whether names/types came from GameCube, PS2, PC or a known
       library reference, and marked guesses as guesses.
 - [ ] If I used PS2 metadata, I kept the executable and tool output local and

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
         python configure.py --map --version ${{ matrix.version }} \
             --binutils /binutils --compilers /compilers
         ninja build/${{ matrix.version }}/config.json
+        python -m unittest tools.test_check_language_policy
         python tools/check_language_policy.py
         ninja all_source progress build/${{ matrix.version }}/report.json
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ Every configured source must be under a reviewed game-code or known-library
 prefix; do not create a new top-level source area to bypass the language policy.
 Uncertain C classifications stay unchanged and under review rather than being
 added to the policy as new pending debt.
+Source paths must be canonical, and every C/C++ file under `src/` must have one
+configured compiler command; dormant or path-traversing units are rejected.
 The `.c` files that receive `-lang=c++` are either matching legacy paths or an
 explicitly reviewed vendor compatibility exception, not a pattern for new
 work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,10 @@ Read [the source-language policy](docs/language-policy.md) before creating a
 game-code translation unit.
 
 Sonic Heroes' own game code is C++ by default. New game-owned translation units
-use `.cpp` and compile as C++. A new `.c` file is accepted only for a reviewed C
-boundary or known C library and must be added to the explicit policy allowlist.
+use the canonical `.cpp` extension and compile as C++; `.cc`, `.cxx` and
+case variants are rejected so the policy has one unambiguous convention. A new
+`.c` file is accepted only for a reviewed C boundary or known C library and
+must be added to the explicit policy allowlist.
 The `.c` files that receive `-lang=c++` are either matching legacy paths or an
 explicitly reviewed vendor compatibility exception, not a pattern for new
 work.
@@ -64,8 +66,9 @@ Do not apply `-inline deferred` globally. It changes inlining and function
 emission order. A deferred override needs the source-order evidence and
 before/after objdiff required by the language policy.
 
-Run `python tools/check_language_policy.py` after `python configure.py`. The
-commit hook also refuses newly added game-owned `.c` files that have no reviewed
+Run `python -m unittest tools.test_check_language_policy` and
+`python tools/check_language_policy.py` after `python configure.py`. The commit
+hook also refuses added or renamed game-owned `.c` files that have no reviewed
 C classification.
 
 The hook protects only clones where `core.hooksPath` is enabled. The repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,11 @@ Sonic Heroes' own game code is C++ by default. New game-owned translation units
 use the canonical `.cpp` extension and compile as C++; `.cc`, `.cxx` and
 case variants are rejected so the policy has one unambiguous convention. A new
 `.c` file is accepted only for a reviewed C boundary or known C library and
-must be added to the explicit policy allowlist.
+must be added to the explicit policy allowlist. `confirmed_c_sources` is for
+positive source-language evidence; `reviewed_c_boundary_sources` is for a
+matching C ABI boundary whose historical source language cannot be proved from
+the available artifacts. Do not present the second category as proof of
+original C source.
 Every configured source must be under a reviewed game-code or known-library
 prefix; do not create a new top-level source area to bypass the language policy.
 Uncertain C classifications stay unchanged and under review rather than being

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,10 @@ use the canonical `.cpp` extension and compile as C++; `.cc`, `.cxx` and
 case variants are rejected so the policy has one unambiguous convention. A new
 `.c` file is accepted only for a reviewed C boundary or known C library and
 must be added to the explicit policy allowlist.
+Every configured source must be under a reviewed game-code or known-library
+prefix; do not create a new top-level source area to bypass the language policy.
+Uncertain C classifications stay unchanged and under review rather than being
+added to the policy as new pending debt.
 The `.c` files that receive `-lang=c++` are either matching legacy paths or an
 explicitly reviewed vendor compatibility exception, not a pattern for new
 work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,9 @@ Every configured source must be under a reviewed game-code or known-library
 prefix; do not create a new top-level source area to bypass the language policy.
 Uncertain C classifications stay unchanged and under review rather than being
 added to the policy as new pending debt.
-Source paths must be canonical, and every C/C++ file under `src/` must have one
-configured compiler command; dormant or path-traversing units are rejected.
+Source paths must be canonical, and every C/C++ file under `src/` must appear
+in at least one configured compiler command. Repeated commands for a source
+must agree; dormant, conflicting or path-traversing units are rejected.
 The `.c` files that receive `-lang=c++` are either matching legacy paths or an
 explicitly reviewed vendor compatibility exception, not a pattern for new
 work.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Then:
 
 ```sh
 python configure.py
+python -m unittest tools.test_check_language_policy
 python tools/check_language_policy.py
 ninja
 ```

--- a/config/G9SE8P/language_policy.json
+++ b/config/G9SE8P/language_policy.json
@@ -6,6 +6,11 @@
     "movieD/",
     "rel/"
   ],
+  "library_prefixes": [
+    "MSL_C/",
+    "Runtime.PPCEABI.H/",
+    "dolphin/"
+  ],
   "confirmed_c_sources": [
     "advertiseD/prolog.c",
     "autosaveD/prolog.c",

--- a/config/G9SE8P/language_policy.json
+++ b/config/G9SE8P/language_policy.json
@@ -12,9 +12,11 @@
     "dolphin/"
   ],
   "confirmed_c_sources": [
+    "game/main.c"
+  ],
+  "reviewed_c_boundary_sources": [
     "advertiseD/prolog.c",
     "autosaveD/prolog.c",
-    "game/main.c",
     "movieD/cri/sfxahn.c",
     "movieD/cri/sfxcnv.c",
     "movieD/cri/sfxset.c",

--- a/docs/language-audit.md
+++ b/docs/language-audit.md
@@ -14,8 +14,13 @@ The initial configured-command audit found 134 game-owned sources:
 
 - 115 compiled as C++ through `.c` plus `-lang=c++`;
 - 19 compiled as C;
-- 9 of those C sources pending stronger language evidence;
+- 9 of those C sources were initially pending stronger language evidence;
 - no approved `-inline deferred` source.
+
+Those nine initial decisions are now closed: `game/main.c` has positive C
+source evidence and the other eight are explicitly recorded as reviewed C ABI
+boundaries whose historical file language remains unresolved. The current
+policy therefore has no `pending_c_evidence` entry.
 
 The protected `advertiseD` and `autosaveD` areas are not changed while their
 owners have active work. Their 42 legacy C++ paths remain in the queue until a

--- a/docs/language-audit.md
+++ b/docs/language-audit.md
@@ -260,6 +260,52 @@ Evidence and validation:
 - the reviewed C form keeps all 18 configured artifact hashes exact without a
   deferred-inline override or register-forcing workaround.
 
+### Reviewed C ABI and middleware boundaries
+
+The policy distinguishes positive C source evidence from an existing boundary
+that is reviewed in C mode but cannot be assigned a historical file language
+honestly. `game/main.c` is the sole `confirmed_c_sources` entry. The following
+eight paths are instead `reviewed_c_boundary_sources`:
+
+- `advertiseD/prolog.c`
+- `autosaveD/prolog.c`
+- `movieD/prolog.c`
+- `rel/prolog.c`
+- `movieD/cri/sfxahn.c`
+- `movieD/cri/sfxcnv.c`
+- `movieD/cri/sfxset.c`
+- `movieD/cri/sud.c`
+
+GameCube validation:
+
+- all eight compile in the configured C mode and match their owned GameCube
+  code, data and relocations;
+- the four module prologs were also compiled as C++ inside an explicit
+  `extern "C"` boundary in an isolated output directory;
+- for every prolog, `.text`, owned `.data`, relocation entries and functional
+  symbols were identical to the C object; only the local ELF `STT_FILE` source
+  marker changed;
+- therefore the linked GameCube binary cannot distinguish C source from C++
+  source with C linkage for those prologs.
+
+Cross-platform validation used only local symbol metadata from the North
+American retail PS2 executable and `stdump` v2.1:
+
+- `stdump identify` found `.symtab` but no `.mdebug`/DWARF source-file table,
+  and `stdump files` returned no file records;
+- the PS2 overlay exposes mangled prolog names for the advertise, autosave and
+  movie modules, establishing C++ linkage for those PS2 counterparts but not
+  for the platform-specific GameCube entry stubs;
+- the SFX/SUD symbols expose a C ABI and correlate the middleware families, but
+  without a source-file/language record they do not prove a historical `.c`
+  filename.
+
+The result is intentionally conservative. These paths remain matching C ABI
+boundaries and are not silently relabeled as historically confirmed C. A new
+entry in this category still requires a reviewed rationale and complete
+GameCube validation; the category is not a general escape hatch for new C
+files.
+
 ## Remaining queue
 
 After the GameCube platform-main decision:
@@ -269,7 +315,9 @@ After the GameCube platform-main decision:
 - 42 belong to the protected `advertiseD`/`autosaveD` areas;
 - 5 protected sources have direct C++ evidence but remain in C mode until their
   active changes are coordinated;
-- no C-compiled game source still awaits a language decision;
+- no C-compiled game source is silently unclassified: one has positive C
+  evidence and eight are explicitly reviewed C ABI boundaries that do not
+  claim a historical source extension;
 - `movieD/cri/sfx.c` is a reviewed C-path/C++-compiler-mode exception, not a
   migration candidate;
 - one source, `game/state_accessor.cpp`, has a reviewed `-inline deferred`

--- a/docs/language-policy.md
+++ b/docs/language-policy.md
@@ -123,8 +123,12 @@ substitute for reviewing the evidence or matching the GameCube object.
   Metrowerks compiler commands, so dormant and path-traversing units cannot sit
   outside the audit.
 - A new `.c` file under `game`, `rel`, `advertiseD`, `autosaveD` or `movieD`
-  must be added to the reviewed C allowlist in
-  `config/G9SE8P/language_policy.json`.
+  must be added to the appropriate reviewed C list in
+  `config/G9SE8P/language_policy.json`. Use `confirmed_c_sources` only when
+  positive evidence establishes C source. Use `reviewed_c_boundary_sources`
+  for a matching C ABI or middleware boundary whose historical source
+  language remains indistinguishable; that category records uncertainty
+  rather than converting it into a false C claim.
 - `pending_c_evidence` must remain empty. If classification is uncertain, leave
   the existing source untouched and resolve the evidence before changing its
   language-policy category.
@@ -196,6 +200,12 @@ as C only because an active protected-area change must be integrated first.
 This is migration debt, not a C allowlist and not permission to edit another
 contributor's work. No new path may be added merely to make CI pass.
 
+An existing reviewed C ABI boundary is not migration debt by itself. Its
+allowlist entry says that the present C mode and linkage are reviewed and
+matching; it does not claim that the unavailable original file necessarily had
+a `.c` extension. Rename such a boundary only when stronger source evidence
+establishes C++ and the GameCube object and final artifacts remain exact.
+
 A protected C++/C-mode source must be migrated after coordinating with the
 active owner. The integration change reconstructs the C++ class or method
 shape, uses `.cpp`, updates build and split paths, and must preserve the
@@ -239,6 +249,8 @@ For language, linkage or inline changes:
 - keep the change to one logical translation unit or one mechanical module;
 - state the evidence and whether it is GameCube, PS2, PC or known-library
   evidence;
+- for a C path, distinguish positive C source evidence from a reviewed C ABI
+  boundary whose historical file language remains unresolved;
 - show the before/after objdiff result;
 - do not turn matching objects into non-matching objects in a mechanical
   language-only change;

--- a/docs/language-policy.md
+++ b/docs/language-policy.md
@@ -115,9 +115,15 @@ substitute for reviewing the evidence or matching the GameCube object.
 - New game-owned translation units use the canonical `.cpp` extension and
   compile as C++. Alternative C++ extensions such as `.cc` and `.cxx` are
   rejected to keep the convention machine-checkable.
+- Every configured source must belong to a reviewed game-code prefix or a
+  known-library prefix in `language_policy.json`. A new top-level directory is
+  not an escape hatch from the language rule.
 - A new `.c` file under `game`, `rel`, `advertiseD`, `autosaveD` or `movieD`
   must be added to the reviewed C allowlist in
   `config/G9SE8P/language_policy.json`.
+- `pending_c_evidence` must remain empty. If classification is uncertain, leave
+  the existing source untouched and resolve the evidence before changing its
+  language-policy category.
 - Do not use `extern "C"` merely to keep a C-shaped reconstruction when the
   evidence identifies a C++ method. C linkage remains appropriate for real C
   boundaries and for temporary unknown symbols, but the reason must be clear.

--- a/docs/language-policy.md
+++ b/docs/language-policy.md
@@ -112,7 +112,9 @@ substitute for reviewing the evidence or matching the GameCube object.
 
 ## New source
 
-- New game-owned translation units use `.cpp` and compile as C++.
+- New game-owned translation units use the canonical `.cpp` extension and
+  compile as C++. Alternative C++ extensions such as `.cc` and `.cxx` are
+  rejected to keep the convention machine-checkable.
 - A new `.c` file under `game`, `rel`, `advertiseD`, `autosaveD` or `movieD`
   must be added to the reviewed C allowlist in
   `config/G9SE8P/language_policy.json`.
@@ -216,7 +218,9 @@ The approved deferred list is deliberately narrow. At present,
 `game/state_accessor.cpp` is the only reviewed entry. A source must be added to
 `deferred_sources` in the policy file in the same reviewed change that records
 the evidence, and stale entries must be removed with the flag they approved.
-Multiple object-level `-inline` overrides are rejected as ambiguous.
+Multiple object-level `-inline` overrides are rejected as ambiguous. Inline
+modes are compared as exact comma-separated tokens: `nodeferred` is not a
+deferred override.
 
 ## Pull-request requirements
 
@@ -228,8 +232,8 @@ For language, linkage or inline changes:
 - show the before/after objdiff result;
 - do not turn matching objects into non-matching objects in a mechanical
   language-only change;
-- run `python tools/check_language_policy.py`, `ninja` and the artifact SHA-1
-  check.
+- run `python -m unittest tools.test_check_language_policy`,
+  `python tools/check_language_policy.py`, `ninja` and the artifact SHA-1 check.
 
 Existing matching work is a test oracle, not disposable work. Refactor it
 incrementally when evidence improves the source reconstruction, preserving the

--- a/docs/language-policy.md
+++ b/docs/language-policy.md
@@ -118,6 +118,10 @@ substitute for reviewing the evidence or matching the GameCube object.
 - Every configured source must belong to a reviewed game-code prefix or a
   known-library prefix in `language_policy.json`. A new top-level directory is
   not an escape hatch from the language rule.
+- Source paths must be canonical relative paths. The checker also requires an
+  exact inventory match between C/C++ files under `src/` and configured
+  Metrowerks compiler commands, so dormant and path-traversing units cannot sit
+  outside the audit.
 - A new `.c` file under `game`, `rel`, `advertiseD`, `autosaveD` or `movieD`
   must be added to the reviewed C allowlist in
   `config/G9SE8P/language_policy.json`.
@@ -184,13 +188,13 @@ translation-unit boundary. A one-function source may remain a reconstruction
 fragment until cross-references, private data, alignment, map/debug metadata or
 correlated platform evidence establishes the enclosing unit.
 
-Guesses stay marked as guesses. The policy file separates confirmed C sources
-from sources that are temporarily allowed to remain C while evidence is being
-collected. It separately records `protected_cpp_c_sources`: sources with direct
-C++ evidence that still compile as C only because an active protected-area
-change must be integrated first. This is migration debt, not a C allowlist and
-not permission to edit another contributor's work. No new path may be added to
-either temporary list merely to make CI pass.
+Guesses stay marked as guesses, but they do not enter the build policy as new C
+debt: `pending_c_evidence` must stay empty, and uncertainty is resolved before
+changing a source classification. The policy separately records
+`protected_cpp_c_sources`: sources with direct C++ evidence that still compile
+as C only because an active protected-area change must be integrated first.
+This is migration debt, not a C allowlist and not permission to edit another
+contributor's work. No new path may be added merely to make CI pass.
 
 A protected C++/C-mode source must be migrated after coordinating with the
 active owner. The integration change reconstructs the C++ class or method

--- a/tools/check_language_policy.py
+++ b/tools/check_language_policy.py
@@ -374,11 +374,19 @@ def audit_staged_sources(policy: dict[str, Any]) -> list[str]:
         if suffix != ".c":
             continue
         if source in pending_c:
-            errors.append(f"{source}: a new source cannot enter as pending C evidence; use .cpp")
+            errors.append(
+                f"{source}: a staged source cannot remain pending C evidence; "
+                "resolve the classification before changing it"
+            )
         elif source in protected_cpp_c:
-            errors.append(f"{source}: a new source cannot enter as protected migration debt; use .cpp")
+            errors.append(
+                f"{source}: protected C++/C-mode work must be coordinated and "
+                "migrated to .cpp"
+            )
         elif source in legacy_cpp:
-            errors.append(f"{source}: a new C++ source cannot enter with a .c extension; use .cpp")
+            errors.append(
+                f"{source}: staged legacy C++ work must migrate from .c to .cpp"
+            )
         elif source not in confirmed_c and source not in cpp_mode_c:
             errors.append(
                 f"{source}: new game-owned .c source is forbidden; use .cpp or add reviewed C evidence"

--- a/tools/check_language_policy.py
+++ b/tools/check_language_policy.py
@@ -29,6 +29,7 @@ def load_policy(path: Path) -> dict[str, Any]:
         "managed_prefixes",
         "library_prefixes",
         "confirmed_c_sources",
+        "reviewed_c_boundary_sources",
         "pending_c_evidence",
         "protected_cpp_c_sources",
         "c_sources_compiled_as_cpp",
@@ -74,6 +75,7 @@ def load_policy(path: Path) -> dict[str, Any]:
 
     source_keys = (
         "confirmed_c_sources",
+        "reviewed_c_boundary_sources",
         "pending_c_evidence",
         "protected_cpp_c_sources",
         "c_sources_compiled_as_cpp",
@@ -89,6 +91,7 @@ def load_policy(path: Path) -> dict[str, Any]:
 
     groups = (
         set(policy["confirmed_c_sources"]),
+        set(policy["reviewed_c_boundary_sources"]),
         set(policy["pending_c_evidence"]),
         set(policy["protected_cpp_c_sources"]),
         set(policy["c_sources_compiled_as_cpp"]),
@@ -96,6 +99,7 @@ def load_policy(path: Path) -> dict[str, Any]:
     )
     labels = (
         "confirmed C",
+        "reviewed C ABI boundary",
         "pending C",
         "protected C++/C-mode debt",
         "reviewed C/C++ mode",
@@ -247,9 +251,10 @@ def audit_configured_build(policy: dict[str, Any]) -> list[str]:
     prefixes = policy["managed_prefixes"]
     library_prefixes = policy["library_prefixes"]
     confirmed_c = set(policy["confirmed_c_sources"])
+    reviewed_c_boundaries = set(policy["reviewed_c_boundary_sources"])
     pending_c = set(policy["pending_c_evidence"])
     protected_cpp_c = set(policy["protected_cpp_c_sources"])
-    allowed_c = confirmed_c | pending_c | protected_cpp_c
+    allowed_c = confirmed_c | reviewed_c_boundaries | pending_c | protected_cpp_c
     cpp_mode_c = set(policy["c_sources_compiled_as_cpp"])
     legacy_cpp = set(policy["legacy_cpp_c_sources"])
     deferred = set(policy["deferred_sources"])
@@ -329,6 +334,7 @@ def audit_configured_build(policy: dict[str, Any]) -> list[str]:
             "language policy OK: "
             f"{len(managed)} managed sources "
             f"({cpp_count} C++, {c_count} C, "
+            f"{len(reviewed_c_boundaries)} reviewed C ABI boundaries, "
             f"{len(pending_c)} pending evidence, "
             f"{len(protected_cpp_c)} protected C++/C-mode debt, "
             f"{len(cpp_mode_c)} reviewed C/C++-mode, "
@@ -349,6 +355,7 @@ def audit_staged_sources(policy: dict[str, Any]) -> list[str]:
     prefixes = policy["managed_prefixes"]
     library_prefixes = policy["library_prefixes"]
     confirmed_c = set(policy["confirmed_c_sources"])
+    reviewed_c_boundaries = set(policy["reviewed_c_boundary_sources"])
     pending_c = set(policy["pending_c_evidence"])
     protected_cpp_c = set(policy["protected_cpp_c_sources"])
     cpp_mode_c = set(policy["c_sources_compiled_as_cpp"])
@@ -387,7 +394,11 @@ def audit_staged_sources(policy: dict[str, Any]) -> list[str]:
             errors.append(
                 f"{source}: staged legacy C++ work must migrate from .c to .cpp"
             )
-        elif source not in confirmed_c and source not in cpp_mode_c:
+        elif (
+            source not in confirmed_c
+            and source not in reviewed_c_boundaries
+            and source not in cpp_mode_c
+        ):
             errors.append(
                 f"{source}: new game-owned .c source is forbidden; use .cpp or add reviewed C evidence"
             )

--- a/tools/check_language_policy.py
+++ b/tools/check_language_policy.py
@@ -10,7 +10,7 @@ import json
 import re
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -44,12 +44,10 @@ def load_policy(path: Path) -> dict[str, Any]:
 
     for key in ("managed_prefixes", "library_prefixes"):
         for prefix in policy[key]:
-            parts = Path(prefix).parts
             if (
                 not prefix
                 or not prefix.endswith("/")
-                or prefix.startswith("/")
-                or ".." in parts
+                or not is_canonical_relative_path(prefix.removesuffix("/"))
             ):
                 raise ValueError(
                     f"{path}: {key} entries must be relative directory prefixes: {prefix!r}"
@@ -73,6 +71,21 @@ def load_policy(path: Path) -> dict[str, Any]:
             f"{path}: pending C evidence is not permitted; resolve the classification "
             "before changing the source policy"
         )
+
+    source_keys = (
+        "confirmed_c_sources",
+        "pending_c_evidence",
+        "protected_cpp_c_sources",
+        "c_sources_compiled_as_cpp",
+        "legacy_cpp_c_sources",
+        "deferred_sources",
+    )
+    for key in source_keys:
+        for source in policy[key]:
+            if not is_canonical_relative_path(source):
+                raise ValueError(f"{path}: {key} contains a non-canonical path: {source!r}")
+            if not is_managed(source, managed_prefixes):
+                raise ValueError(f"{path}: {key} entry is outside managed game code: {source}")
 
     groups = (
         set(policy["confirmed_c_sources"]),
@@ -110,6 +123,17 @@ def load_policy(path: Path) -> dict[str, Any]:
 
 def is_managed(source: str, prefixes: list[str]) -> bool:
     return any(source.startswith(prefix) for prefix in prefixes)
+
+
+def is_canonical_relative_path(value: str) -> bool:
+    path = PurePosixPath(value)
+    return (
+        bool(value)
+        and "\\" not in value
+        and not path.is_absolute()
+        and ".." not in path.parts
+        and path.as_posix() == value
+    )
 
 
 def is_cpp_style_suffix(suffix: str) -> bool:
@@ -171,6 +195,16 @@ def parse_source_commands() -> dict[str, dict[str, Any]]:
     return commands
 
 
+def physical_source_paths() -> set[str]:
+    source_root = ROOT / "src"
+    return {
+        path.relative_to(source_root).as_posix()
+        for path in source_root.rglob("*")
+        if path.is_file()
+        and (path.suffix == ".c" or is_cpp_style_suffix(path.suffix))
+    }
+
+
 def static_inline_overrides(errors: list[str], policy: dict[str, Any]) -> None:
     tree = ast.parse(CONFIGURE.read_text(encoding="utf-8"), filename=str(CONFIGURE))
     prefixes = policy["managed_prefixes"]
@@ -221,7 +255,16 @@ def audit_configured_build(policy: dict[str, Any]) -> list[str]:
     deferred = set(policy["deferred_sources"])
 
     managed = {source: record for source, record in commands.items() if is_managed(source, prefixes)}
+    physical_sources = physical_source_paths()
+    for source in sorted(physical_sources - commands.keys()):
+        errors.append(f"{source}: source file has no configured compiler command")
+    for source in sorted(commands.keys() - physical_sources):
+        errors.append(f"{source}: compiler command does not reference a source file")
+
     for source in sorted(commands):
+        if not is_canonical_relative_path(source):
+            errors.append(f"{source}: configured source path is not canonical")
+            continue
         if not is_managed(source, prefixes) and not is_managed(source, library_prefixes):
             errors.append(
                 f"{source}: configured source is outside reviewed game/library prefixes"

--- a/tools/check_language_policy.py
+++ b/tools/check_language_policy.py
@@ -27,6 +27,7 @@ def load_policy(path: Path) -> dict[str, Any]:
 
     list_keys = (
         "managed_prefixes",
+        "library_prefixes",
         "confirmed_c_sources",
         "pending_c_evidence",
         "protected_cpp_c_sources",
@@ -40,6 +41,38 @@ def load_policy(path: Path) -> dict[str, Any]:
             raise ValueError(f"{path}: {key} must be a list of strings")
         if values != sorted(set(values)):
             raise ValueError(f"{path}: {key} must be sorted and contain no duplicates")
+
+    for key in ("managed_prefixes", "library_prefixes"):
+        for prefix in policy[key]:
+            parts = Path(prefix).parts
+            if (
+                not prefix
+                or not prefix.endswith("/")
+                or prefix.startswith("/")
+                or ".." in parts
+            ):
+                raise ValueError(
+                    f"{path}: {key} entries must be relative directory prefixes: {prefix!r}"
+                )
+
+    managed_prefixes = policy["managed_prefixes"]
+    library_prefixes = policy["library_prefixes"]
+    for managed_prefix in managed_prefixes:
+        for library_prefix in library_prefixes:
+            if (
+                managed_prefix.startswith(library_prefix)
+                or library_prefix.startswith(managed_prefix)
+            ):
+                raise ValueError(
+                    f"{path}: managed and library prefixes overlap: "
+                    f"{managed_prefix}, {library_prefix}"
+                )
+
+    if policy["pending_c_evidence"]:
+        raise ValueError(
+            f"{path}: pending C evidence is not permitted; resolve the classification "
+            "before changing the source policy"
+        )
 
     groups = (
         set(policy["confirmed_c_sources"]),
@@ -79,6 +112,10 @@ def is_managed(source: str, prefixes: list[str]) -> bool:
     return any(source.startswith(prefix) for prefix in prefixes)
 
 
+def is_cpp_style_suffix(suffix: str) -> bool:
+    return suffix == ".C" or suffix.lower() in CPP_STYLE_SUFFIXES
+
+
 def inline_mode_enabled(value: str, mode: str) -> bool:
     """Return whether an exact comma-separated inline mode is enabled."""
     modes = {part for part in re.sub(r"\s+", "", value).split(",") if part}
@@ -114,7 +151,7 @@ def parse_source_commands() -> dict[str, dict[str, Any]]:
         languages = language_pattern.findall(line)
         if languages:
             language = languages[-1]
-        elif source.endswith((".cpp", ".cc", ".cxx")):
+        elif is_cpp_style_suffix(Path(source).suffix):
             language = "c++"
         else:
             language = "c"
@@ -174,6 +211,7 @@ def audit_configured_build(policy: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     commands = parse_source_commands()
     prefixes = policy["managed_prefixes"]
+    library_prefixes = policy["library_prefixes"]
     confirmed_c = set(policy["confirmed_c_sources"])
     pending_c = set(policy["pending_c_evidence"])
     protected_cpp_c = set(policy["protected_cpp_c_sources"])
@@ -183,6 +221,11 @@ def audit_configured_build(policy: dict[str, Any]) -> list[str]:
     deferred = set(policy["deferred_sources"])
 
     managed = {source: record for source, record in commands.items() if is_managed(source, prefixes)}
+    for source in sorted(commands):
+        if not is_managed(source, prefixes) and not is_managed(source, library_prefixes):
+            errors.append(
+                f"{source}: configured source is outside reviewed game/library prefixes"
+            )
     actual_legacy: set[str] = set()
     actual_deferred: set[str] = set()
 
@@ -261,6 +304,7 @@ def audit_staged_sources(policy: dict[str, Any]) -> list[str]:
         text=True,
     )
     prefixes = policy["managed_prefixes"]
+    library_prefixes = policy["library_prefixes"]
     confirmed_c = set(policy["confirmed_c_sources"])
     pending_c = set(policy["pending_c_evidence"])
     protected_cpp_c = set(policy["protected_cpp_c_sources"])
@@ -271,12 +315,17 @@ def audit_staged_sources(policy: dict[str, Any]) -> list[str]:
         if not path.startswith("src/"):
             continue
         source = path.removeprefix("src/")
-        if not is_managed(source, prefixes):
-            continue
         suffix = Path(source).suffix
-        if suffix != ".cpp" and (
-            suffix == ".C" or suffix.lower() in CPP_STYLE_SUFFIXES
-        ):
+        if not is_managed(source, prefixes):
+            if (
+                not is_managed(source, library_prefixes)
+                and (suffix == ".c" or is_cpp_style_suffix(suffix))
+            ):
+                errors.append(
+                    f"{source}: source path is outside reviewed game/library prefixes"
+                )
+            continue
+        if suffix != ".cpp" and is_cpp_style_suffix(suffix):
             errors.append(f"{source}: game-owned C++ source must use the .cpp extension")
             continue
         if suffix != ".c":

--- a/tools/check_language_policy.py
+++ b/tools/check_language_policy.py
@@ -18,6 +18,7 @@ ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_POLICY = ROOT / "config/G9SE8P/language_policy.json"
 CONFIGURE = ROOT / "configure.py"
 PROTECTED_PREFIXES = ("advertiseD/", "autosaveD/")
+CPP_STYLE_SUFFIXES = {".cc", ".cp", ".cpp", ".cxx", ".c++"}
 
 
 def load_policy(path: Path) -> dict[str, Any]:
@@ -76,6 +77,12 @@ def load_policy(path: Path) -> dict[str, Any]:
 
 def is_managed(source: str, prefixes: list[str]) -> bool:
     return any(source.startswith(prefix) for prefix in prefixes)
+
+
+def inline_mode_enabled(value: str, mode: str) -> bool:
+    """Return whether an exact comma-separated inline mode is enabled."""
+    modes = {part for part in re.sub(r"\s+", "", value).split(",") if part}
+    return mode in modes
 
 
 def parse_source_commands() -> dict[str, dict[str, Any]]:
@@ -156,7 +163,10 @@ def static_inline_overrides(errors: list[str], policy: dict[str, Any]) -> None:
         inline_flags = [flag for flag in flags if flag.startswith("-inline ")]
         if len(inline_flags) > 1:
             errors.append(f"{source}: multiple object-level -inline overrides: {inline_flags}")
-        if any("deferred" in flag for flag in inline_flags) and source not in deferred:
+        if any(
+            inline_mode_enabled(flag.removeprefix("-inline "), "deferred")
+            for flag in inline_flags
+        ) and source not in deferred:
             errors.append(f"{source}: uses deferred inline without reviewed policy evidence")
 
 
@@ -190,13 +200,15 @@ def audit_configured_build(policy: dict[str, Any]) -> list[str]:
                 actual_legacy.add(source)
                 if source not in legacy_cpp and source not in cpp_mode_c:
                     errors.append(f"{source}: new C++ source uses .c; new game code must use .cpp")
+            elif not source.endswith(".cpp"):
+                errors.append(f"{source}: game-owned C++ source must use the .cpp extension")
         else:
             errors.append(f"{source}: unknown effective language {language!r}")
 
         if len(inline_modes) > 2:
             errors.append(f"{source}: ambiguous inline flags in compiler command: {inline_modes}")
         effective_inline = inline_modes[-1] if inline_modes else ""
-        if "deferred" in effective_inline:
+        if inline_mode_enabled(effective_inline, "deferred"):
             actual_deferred.add(source)
             if source not in deferred:
                 errors.append(f"{source}: effective deferred inline mode has no reviewed evidence")
@@ -239,10 +251,10 @@ def audit_configured_build(policy: dict[str, Any]) -> list[str]:
     return errors
 
 
-def audit_staged_additions(policy: dict[str, Any]) -> list[str]:
+def audit_staged_sources(policy: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only", "--diff-filter=A"],
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
         cwd=ROOT,
         check=True,
         capture_output=True,
@@ -259,7 +271,15 @@ def audit_staged_additions(policy: dict[str, Any]) -> list[str]:
         if not path.startswith("src/"):
             continue
         source = path.removeprefix("src/")
-        if not is_managed(source, prefixes) or not source.endswith(".c"):
+        if not is_managed(source, prefixes):
+            continue
+        suffix = Path(source).suffix
+        if suffix != ".cpp" and (
+            suffix == ".C" or suffix.lower() in CPP_STYLE_SUFFIXES
+        ):
+            errors.append(f"{source}: game-owned C++ source must use the .cpp extension")
+            continue
+        if suffix != ".c":
             continue
         if source in pending_c:
             errors.append(f"{source}: a new source cannot enter as pending C evidence; use .cpp")
@@ -290,7 +310,7 @@ def main() -> int:
 
     try:
         policy = load_policy(args.policy)
-        errors = audit_staged_additions(policy) if args.staged else audit_configured_build(policy)
+        errors = audit_staged_sources(policy) if args.staged else audit_configured_build(policy)
     except (OSError, ValueError, RuntimeError, subprocess.CalledProcessError) as exc:
         print(f"language policy check failed: {exc}", file=sys.stderr)
         return 1

--- a/tools/test_check_language_policy.py
+++ b/tools/test_check_language_policy.py
@@ -15,6 +15,9 @@ from unittest.mock import patch
 import tools.check_language_policy as checker
 
 
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+
+
 def make_policy(**overrides: list[str]) -> dict[str, list[str]]:
     policy = {
         "managed_prefixes": ["game/"],
@@ -67,6 +70,15 @@ class PolicyValidationTests(unittest.TestCase):
         policy = make_policy(confirmed_c_sources=["dolphin/unit.c"])
         with self.assertRaisesRegex(ValueError, "outside managed game code"):
             self.load_policy(policy)
+
+
+class HookContractTests(unittest.TestCase):
+    def test_rename_only_commit_reaches_language_policy_check(self) -> None:
+        hook = (REPOSITORY_ROOT / ".githooks/pre-commit").read_text(encoding="utf-8")
+        self.assertIn(
+            "staged=$(git diff --cached --name-only --diff-filter=ACMR)",
+            hook,
+        )
 
 
 class StagedPolicyTests(unittest.TestCase):

--- a/tools/test_check_language_policy.py
+++ b/tools/test_check_language_policy.py
@@ -23,6 +23,7 @@ def make_policy(**overrides: list[str]) -> dict[str, list[str]]:
         "managed_prefixes": ["game/"],
         "library_prefixes": ["dolphin/"],
         "confirmed_c_sources": [],
+        "reviewed_c_boundary_sources": [],
         "pending_c_evidence": [],
         "protected_cpp_c_sources": [],
         "c_sources_compiled_as_cpp": [],
@@ -84,6 +85,16 @@ class PolicyValidationTests(unittest.TestCase):
             c_sources_compiled_as_cpp=["game/unit.c"],
         )
         with self.assertRaisesRegex(ValueError, "confirmed C and reviewed C/C\\+\\+ mode overlap"):
+            self.load_policy(policy)
+
+    def test_confirmed_and_boundary_classifications_cannot_overlap(self) -> None:
+        policy = make_policy(
+            confirmed_c_sources=["game/unit.c"],
+            reviewed_c_boundary_sources=["game/unit.c"],
+        )
+        with self.assertRaisesRegex(
+            ValueError, "confirmed C and reviewed C ABI boundary overlap"
+        ):
             self.load_policy(policy)
 
     def test_protected_debt_must_stay_in_protected_areas(self) -> None:
@@ -208,6 +219,16 @@ class StagedPolicyTests(unittest.TestCase):
         self.run_git("add", "-A")
 
         policy = make_policy(confirmed_c_sources=["game/unit.c"])
+        self.assertEqual(self.staged_errors(policy), [])
+
+    def test_reviewed_c_boundary_rename_is_allowed(self) -> None:
+        source = self.write_source("game/unit.cpp")
+        self.run_git("add", ".")
+        self.run_git("commit", "-q", "-m", "baseline")
+        source.rename(source.with_suffix(".c"))
+        self.run_git("add", "-A")
+
+        policy = make_policy(reviewed_c_boundary_sources=["game/unit.c"])
         self.assertEqual(self.staged_errors(policy), [])
 
     def test_nodeferred_is_not_treated_as_deferred(self) -> None:
@@ -401,6 +422,13 @@ class ConfiguredPolicyTests(unittest.TestCase):
             errors,
             ["game/unit.c: game-owned C source is not in the reviewed allowlist"],
         )
+
+    def test_reviewed_configured_c_boundary_is_allowed(self) -> None:
+        errors = self.configured_errors(
+            {"game/unit.c": {"language": "c", "inline_modes": ["auto"]}},
+            policy=make_policy(reviewed_c_boundary_sources=["game/unit.c"]),
+        )
+        self.assertEqual(errors, [])
 
     def test_stale_confirmed_c_entry_is_rejected(self) -> None:
         errors = self.configured_errors(

--- a/tools/test_check_language_policy.py
+++ b/tools/test_check_language_policy.py
@@ -58,6 +58,16 @@ class PolicyValidationTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "managed and library prefixes overlap"):
             self.load_policy(policy)
 
+    def test_policy_source_paths_must_be_canonical(self) -> None:
+        policy = make_policy(confirmed_c_sources=["game/../escape.c"])
+        with self.assertRaisesRegex(ValueError, "contains a non-canonical path"):
+            self.load_policy(policy)
+
+    def test_policy_sources_must_be_managed_game_code(self) -> None:
+        policy = make_policy(confirmed_c_sources=["dolphin/unit.c"])
+        with self.assertRaisesRegex(ValueError, "outside managed game code"):
+            self.load_policy(policy)
+
 
 class StagedPolicyTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -207,9 +217,17 @@ class ConfiguredPolicyTests(unittest.TestCase):
         self,
         commands: dict[str, dict[str, object]],
         policy: dict[str, list[str]] | None = None,
+        physical_sources: set[str] | None = None,
     ) -> list[str]:
+        if physical_sources is None:
+            physical_sources = set(commands)
         with (
             patch.object(checker, "parse_source_commands", return_value=commands),
+            patch.object(
+                checker,
+                "physical_source_paths",
+                return_value=physical_sources,
+            ),
             contextlib.redirect_stdout(io.StringIO()),
         ):
             return checker.audit_configured_build(policy or make_policy())
@@ -240,6 +258,37 @@ class ConfiguredPolicyTests(unittest.TestCase):
             {"dolphin/unit.c": {"language": "c", "inline_modes": ["auto"]}}
         )
         self.assertEqual(errors, [])
+
+    def test_physical_source_without_compiler_command_is_rejected(self) -> None:
+        errors = self.configured_errors(
+            {"game/unit.cpp": {"language": "c++", "inline_modes": ["auto"]}},
+            physical_sources={"game/dormant.cpp", "game/unit.cpp"},
+        )
+        self.assertEqual(
+            errors,
+            ["game/dormant.cpp: source file has no configured compiler command"],
+        )
+
+    def test_compiler_command_without_source_file_is_rejected(self) -> None:
+        errors = self.configured_errors(
+            {"game/missing.cpp": {"language": "c++", "inline_modes": ["auto"]}},
+            physical_sources=set(),
+        )
+        self.assertEqual(
+            errors,
+            ["game/missing.cpp: compiler command does not reference a source file"],
+        )
+
+    def test_noncanonical_configured_path_is_rejected(self) -> None:
+        source = "dolphin/../new_module/unit.cpp"
+        errors = self.configured_errors(
+            {source: {"language": "c++", "inline_modes": ["auto"]}},
+            physical_sources={source},
+        )
+        self.assertEqual(
+            errors,
+            [f"{source}: configured source path is not canonical"],
+        )
 
     def test_effective_nodeferred_does_not_require_allowlist(self) -> None:
         errors = self.configured_errors(

--- a/tools/test_check_language_policy.py
+++ b/tools/test_check_language_policy.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import tools.check_language_policy as checker
+
+
+def make_policy(**overrides: list[str]) -> dict[str, list[str]]:
+    policy = {
+        "managed_prefixes": ["game/"],
+        "confirmed_c_sources": [],
+        "pending_c_evidence": [],
+        "protected_cpp_c_sources": [],
+        "c_sources_compiled_as_cpp": [],
+        "legacy_cpp_c_sources": [],
+        "deferred_sources": [],
+    }
+    policy.update(overrides)
+    return policy
+
+
+def clean_git_environment() -> dict[str, str]:
+    """Keep nested repositories isolated from a calling Git hook."""
+    return {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    }
+
+
+class StagedPolicyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.configure = self.root / "configure.py"
+        self.configure.write_text("", encoding="utf-8")
+        self.run_git("init", "-q")
+        self.run_git("config", "user.name", "Policy Test")
+        self.run_git("config", "user.email", "policy@example.invalid")
+        self.root_patch = patch.object(checker, "ROOT", self.root)
+        self.configure_patch = patch.object(checker, "CONFIGURE", self.configure)
+        self.root_patch.start()
+        self.configure_patch.start()
+
+    def tearDown(self) -> None:
+        self.configure_patch.stop()
+        self.root_patch.stop()
+        self.temporary.cleanup()
+
+    def run_git(self, *arguments: str) -> None:
+        subprocess.run(
+            ["git", "-c", "core.hooksPath=/dev/null", *arguments],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=clean_git_environment(),
+        )
+
+    def write_source(self, relative: str, content: str = "void unit(void) {}") -> Path:
+        path = self.root / "src" / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def staged_errors(self, policy: dict[str, list[str]]) -> list[str]:
+        with (
+            patch.dict(os.environ, clean_git_environment(), clear=True),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            return checker.audit_staged_sources(policy)
+
+    def test_rename_from_cpp_to_c_is_checked(self) -> None:
+        source = self.write_source("game/unit.cpp")
+        self.run_git("add", ".")
+        self.run_git("commit", "-q", "-m", "baseline")
+        source.rename(source.with_suffix(".c"))
+        self.run_git("add", "-A")
+
+        self.assertEqual(
+            self.staged_errors(make_policy()),
+            [
+                "game/unit.c: new game-owned .c source is forbidden; "
+                "use .cpp or add reviewed C evidence"
+            ],
+        )
+
+    def test_noncanonical_cpp_extensions_are_rejected(self) -> None:
+        self.write_source("game/one.cc")
+        self.write_source("game/two.cxx")
+        self.write_source("game/three.C")
+        self.run_git("add", ".")
+
+        self.assertEqual(
+            self.staged_errors(make_policy()),
+            [
+                "game/one.cc: game-owned C++ source must use the .cpp extension",
+                "game/three.C: game-owned C++ source must use the .cpp extension",
+                "game/two.cxx: game-owned C++ source must use the .cpp extension",
+            ],
+        )
+
+    def test_canonical_cpp_addition_is_allowed(self) -> None:
+        self.write_source("game/unit.cpp")
+        self.run_git("add", ".")
+        self.assertEqual(self.staged_errors(make_policy()), [])
+
+    def test_reviewed_c_rename_is_allowed(self) -> None:
+        source = self.write_source("game/unit.cpp")
+        self.run_git("add", ".")
+        self.run_git("commit", "-q", "-m", "baseline")
+        source.rename(source.with_suffix(".c"))
+        self.run_git("add", "-A")
+
+        policy = make_policy(confirmed_c_sources=["game/unit.c"])
+        self.assertEqual(self.staged_errors(policy), [])
+
+    def test_nodeferred_is_not_treated_as_deferred(self) -> None:
+        self.configure.write_text(
+            'Object(Matching, "game/unit.cpp", extra_cflags=["-inline nodeferred"])\n',
+            encoding="utf-8",
+        )
+        self.assertEqual(self.staged_errors(make_policy()), [])
+
+    def test_deferred_still_requires_reviewed_policy(self) -> None:
+        self.configure.write_text(
+            'Object(Matching, "game/unit.cpp", '
+            'extra_cflags=["-inline noauto,deferred"])\n',
+            encoding="utf-8",
+        )
+        self.assertEqual(
+            self.staged_errors(make_policy()),
+            ["game/unit.cpp: uses deferred inline without reviewed policy evidence"],
+        )
+
+    def test_reviewed_deferred_is_allowed(self) -> None:
+        self.configure.write_text(
+            'Object(Matching, "game/unit.cpp", '
+            'extra_cflags=["-inline noauto,deferred"])\n',
+            encoding="utf-8",
+        )
+        policy = make_policy(deferred_sources=["game/unit.cpp"])
+        self.assertEqual(self.staged_errors(policy), [])
+
+
+class ConfiguredPolicyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.configure = Path(self.temporary.name) / "configure.py"
+        self.configure.write_text("", encoding="utf-8")
+        self.configure_patch = patch.object(checker, "CONFIGURE", self.configure)
+        self.configure_patch.start()
+
+    def tearDown(self) -> None:
+        self.configure_patch.stop()
+        self.temporary.cleanup()
+
+    def configured_errors(
+        self,
+        commands: dict[str, dict[str, object]],
+        policy: dict[str, list[str]] | None = None,
+    ) -> list[str]:
+        with (
+            patch.object(checker, "parse_source_commands", return_value=commands),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            return checker.audit_configured_build(policy or make_policy())
+
+    def test_configured_cpp_requires_cpp_extension(self) -> None:
+        errors = self.configured_errors(
+            {"game/unit.cc": {"language": "c++", "inline_modes": ["auto"]}}
+        )
+        self.assertEqual(
+            errors,
+            ["game/unit.cc: game-owned C++ source must use the .cpp extension"],
+        )
+
+    def test_effective_nodeferred_does_not_require_allowlist(self) -> None:
+        errors = self.configured_errors(
+            {
+                "game/unit.cpp": {
+                    "language": "c++",
+                    "inline_modes": ["auto", "nodeferred"],
+                }
+            }
+        )
+        self.assertEqual(errors, [])
+
+    def test_effective_deferred_requires_allowlist(self) -> None:
+        errors = self.configured_errors(
+            {
+                "game/unit.cpp": {
+                    "language": "c++",
+                    "inline_modes": ["auto", "deferred,noauto"],
+                }
+            }
+        )
+        self.assertEqual(
+            errors,
+            [
+                "game/unit.cpp: effective deferred inline mode has no "
+                "reviewed evidence"
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_check_language_policy.py
+++ b/tools/test_check_language_policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 import os
 import subprocess
 import tempfile
@@ -17,6 +18,7 @@ import tools.check_language_policy as checker
 def make_policy(**overrides: list[str]) -> dict[str, list[str]]:
     policy = {
         "managed_prefixes": ["game/"],
+        "library_prefixes": ["dolphin/"],
         "confirmed_c_sources": [],
         "pending_c_evidence": [],
         "protected_cpp_c_sources": [],
@@ -33,6 +35,28 @@ def clean_git_environment() -> dict[str, str]:
     return {
         key: value for key, value in os.environ.items() if not key.startswith("GIT_")
     }
+
+
+class PolicyValidationTests(unittest.TestCase):
+    def load_policy(self, policy: dict[str, list[str]]) -> dict[str, list[str]]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "language_policy.json"
+            path.write_text(json.dumps(policy), encoding="utf-8")
+            return checker.load_policy(path)
+
+    def test_empty_pending_evidence_is_allowed(self) -> None:
+        policy = make_policy()
+        self.assertEqual(self.load_policy(policy), policy)
+
+    def test_pending_evidence_is_rejected(self) -> None:
+        policy = make_policy(pending_c_evidence=["game/unit.c"])
+        with self.assertRaisesRegex(ValueError, "pending C evidence is not permitted"):
+            self.load_policy(policy)
+
+    def test_managed_and_library_prefixes_cannot_overlap(self) -> None:
+        policy = make_policy(library_prefixes=["game/vendor/"])
+        with self.assertRaisesRegex(ValueError, "managed and library prefixes overlap"):
+            self.load_policy(policy)
 
 
 class StagedPolicyTests(unittest.TestCase):
@@ -112,6 +136,23 @@ class StagedPolicyTests(unittest.TestCase):
         self.run_git("add", ".")
         self.assertEqual(self.staged_errors(make_policy()), [])
 
+    def test_source_outside_reviewed_prefixes_is_rejected(self) -> None:
+        self.write_source("new_module/unit.cpp")
+        self.run_git("add", ".")
+
+        self.assertEqual(
+            self.staged_errors(make_policy()),
+            [
+                "new_module/unit.cpp: source path is outside reviewed "
+                "game/library prefixes"
+            ],
+        )
+
+    def test_known_library_source_is_outside_game_policy(self) -> None:
+        self.write_source("dolphin/unit.c")
+        self.run_git("add", ".")
+        self.assertEqual(self.staged_errors(make_policy()), [])
+
     def test_reviewed_c_rename_is_allowed(self) -> None:
         source = self.write_source("game/unit.cpp")
         self.run_git("add", ".")
@@ -181,6 +222,24 @@ class ConfiguredPolicyTests(unittest.TestCase):
             errors,
             ["game/unit.cc: game-owned C++ source must use the .cpp extension"],
         )
+
+    def test_configured_source_outside_reviewed_prefixes_is_rejected(self) -> None:
+        errors = self.configured_errors(
+            {"new_module/unit.cpp": {"language": "c++", "inline_modes": ["auto"]}}
+        )
+        self.assertEqual(
+            errors,
+            [
+                "new_module/unit.cpp: configured source is outside reviewed "
+                "game/library prefixes"
+            ],
+        )
+
+    def test_configured_known_library_is_outside_game_policy(self) -> None:
+        errors = self.configured_errors(
+            {"dolphin/unit.c": {"language": "c", "inline_modes": ["auto"]}}
+        )
+        self.assertEqual(errors, [])
 
     def test_effective_nodeferred_does_not_require_allowlist(self) -> None:
         errors = self.configured_errors(

--- a/tools/test_check_language_policy.py
+++ b/tools/test_check_language_policy.py
@@ -71,6 +71,31 @@ class PolicyValidationTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "outside managed game code"):
             self.load_policy(policy)
 
+    def test_policy_lists_must_be_sorted_and_unique(self) -> None:
+        policy = make_policy(
+            confirmed_c_sources=["game/z.c", "game/a.c", "game/a.c"]
+        )
+        with self.assertRaisesRegex(ValueError, "must be sorted and contain no duplicates"):
+            self.load_policy(policy)
+
+    def test_source_classifications_cannot_overlap(self) -> None:
+        policy = make_policy(
+            confirmed_c_sources=["game/unit.c"],
+            c_sources_compiled_as_cpp=["game/unit.c"],
+        )
+        with self.assertRaisesRegex(ValueError, "confirmed C and reviewed C/C\\+\\+ mode overlap"):
+            self.load_policy(policy)
+
+    def test_protected_debt_must_stay_in_protected_areas(self) -> None:
+        policy = make_policy(protected_cpp_c_sources=["game/unit.c"])
+        with self.assertRaisesRegex(ValueError, "outside a protected area"):
+            self.load_policy(policy)
+
+    def test_legacy_debt_must_stay_in_protected_areas(self) -> None:
+        policy = make_policy(legacy_cpp_c_sources=["game/unit.c"])
+        with self.assertRaisesRegex(ValueError, "outside a protected area"):
+            self.load_policy(policy)
+
 
 class HookContractTests(unittest.TestCase):
     def test_rename_only_commit_reaches_language_policy_check(self) -> None:
@@ -212,6 +237,44 @@ class StagedPolicyTests(unittest.TestCase):
         policy = make_policy(deferred_sources=["game/unit.cpp"])
         self.assertEqual(self.staged_errors(policy), [])
 
+    def test_modified_protected_c_debt_is_blocked_until_migration(self) -> None:
+        source = self.write_source("autosaveD/unit.c")
+        self.run_git("add", ".")
+        self.run_git("commit", "-q", "-m", "baseline")
+        source.write_text("void unit(void) { int changed = 1; }\n", encoding="utf-8")
+        self.run_git("add", "-A")
+
+        policy = make_policy(
+            managed_prefixes=["autosaveD/"],
+            protected_cpp_c_sources=["autosaveD/unit.c"],
+        )
+        self.assertEqual(
+            self.staged_errors(policy),
+            [
+                "autosaveD/unit.c: protected C++/C-mode work must be "
+                "coordinated and migrated to .cpp"
+            ],
+        )
+
+    def test_modified_legacy_cpp_c_path_is_blocked_until_migration(self) -> None:
+        source = self.write_source("advertiseD/unit.c")
+        self.run_git("add", ".")
+        self.run_git("commit", "-q", "-m", "baseline")
+        source.write_text("void unit(void) { int changed = 1; }\n", encoding="utf-8")
+        self.run_git("add", "-A")
+
+        policy = make_policy(
+            managed_prefixes=["advertiseD/"],
+            legacy_cpp_c_sources=["advertiseD/unit.c"],
+        )
+        self.assertEqual(
+            self.staged_errors(policy),
+            [
+                "advertiseD/unit.c: staged legacy C++ work must migrate "
+                "from .c to .cpp"
+            ],
+        )
+
 
 class ConfiguredPolicyTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -327,6 +390,61 @@ class ConfiguredPolicyTests(unittest.TestCase):
             [
                 "game/unit.cpp: effective deferred inline mode has no "
                 "reviewed evidence"
+            ],
+        )
+
+    def test_unreviewed_configured_c_source_is_rejected(self) -> None:
+        errors = self.configured_errors(
+            {"game/unit.c": {"language": "c", "inline_modes": ["auto"]}}
+        )
+        self.assertEqual(
+            errors,
+            ["game/unit.c: game-owned C source is not in the reviewed allowlist"],
+        )
+
+    def test_stale_confirmed_c_entry_is_rejected(self) -> None:
+        errors = self.configured_errors(
+            {"game/unit.cpp": {"language": "c++", "inline_modes": ["auto"]}},
+            policy=make_policy(confirmed_c_sources=["game/missing.c"]),
+        )
+        self.assertEqual(
+            errors,
+            ["game/missing.c: C policy entry has no configured source"],
+        )
+
+    def test_stale_deferred_entry_is_rejected(self) -> None:
+        errors = self.configured_errors(
+            {"game/unit.cpp": {"language": "c++", "inline_modes": ["auto"]}},
+            policy=make_policy(deferred_sources=["game/unit.cpp"]),
+        )
+        self.assertEqual(
+            errors,
+            [
+                "game/unit.cpp: approved deferred entry is not effectively "
+                "compiled with deferred"
+            ],
+        )
+
+    def test_multiple_object_inline_overrides_are_rejected(self) -> None:
+        self.configure.write_text(
+            'Object(Matching, "game/unit.cpp", '
+            'extra_cflags=["-inline auto", "-inline deferred"])\n',
+            encoding="utf-8",
+        )
+        errors = self.configured_errors(
+            {
+                "game/unit.cpp": {
+                    "language": "c++",
+                    "inline_modes": ["auto", "deferred"],
+                }
+            },
+            policy=make_policy(deferred_sources=["game/unit.cpp"]),
+        )
+        self.assertEqual(
+            errors,
+            [
+                "game/unit.cpp: multiple object-level -inline overrides: "
+                "['-inline auto', '-inline deferred']"
             ],
         )
 


### PR DESCRIPTION
## Summary

- make the staged language-policy audit and its pre-commit entrypoint cover renames as well as additions
- require the canonical `.cpp` extension for game-owned C++ translation units
- compare `deferred` as an exact inline-mode token, so `nodeferred` is not a false positive
- classify every configured source root as game-owned or known-library code
- reject noncanonical/path-traversing source paths and unclassified top-level source areas
- require an exact inventory match between physical C/C++ files and configured compiler commands
- keep `pending_c_evidence` empty so uncertainty cannot become new build debt
- distinguish positive C source evidence from a reviewed C ABI boundary whose historical source language is unresolved
- add hermetic regression tests and run them in CI and the pre-commit hook
- document the checks in the contributor workflow

## Why

The current gate can be bypassed by renaming an existing `.cpp` source to `.c`, and substring matching treats `nodeferred` as `deferred`. The hook also exits early for a rename-only commit before invoking the checker. A configured source under a new top-level directory is outside the current managed-prefix audit, while path traversal could make a source appear to belong to a reviewed prefix. Dormant source files are not compared with the configured command inventory.

The previous taxonomy also grouped matching C ABI/middleware boundaries with positively confirmed C source. A byte match, current `.c` extension, unmangled symbol or C ABI does not by itself prove the historical source language. The updated policy records those cases separately instead of turning uncertainty into a C claim or automatic migration debt.

The updated gate closes each of those paths while preserving explicit known-library roots. Test repositories discard inherited `GIT_*` variables and disable hooks, keeping them isolated when the suite itself runs from a Git hook.

## Validation

- `python3 -m unittest tools.test_check_language_policy` — 36 tests pass
- tests also pass with inherited `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` variables deliberately set
- `.githooks/pre-commit` — passes on the staged changes
- isolated end-to-end rename `.cpp` → `.c` — hook exits 1 with the expected policy violation
- `python3 tools/check_language_policy.py` — 137 managed sources: 123 C++, 14 C, 8 reviewed C ABI boundaries, no pending evidence
- physical/configured inventory — 221 C/C++ paths on each side, no difference
- all eight reviewed boundaries: 170/170 report functions; code, data and units complete
- full build completed; direct artifact verification reports `18 files OK`
- `git diff --check` — passes
