### PR TITLE
feat: match runtime initialization

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -13,6 +13,11 @@ Sections:
 	.sdata2     type:rodata align:32
 	.sbss2      type:bss align:8
 
+game/runtime_init.cpp:
+	extab       start:0x80005700 end:0x80005710
+	extabindex  start:0x8000BC80 end:0x8000BC98
+	.text       start:0x800122B4 end:0x8001234C
+
 game/heap.cpp:
 	extab       start:0x80005710 end:0x80005748
 	extabindex  start:0x8000BC98 end:0x8000BCEC

--- a/configure.py
+++ b/configure.py
@@ -457,6 +457,11 @@ config.libs = [
         "objects": [
             Object(
                 Matching,
+                "game/runtime_init.cpp",
+                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "game/heap.cpp",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopropagation"],
             ),

--- a/src/game/runtime_init.cpp
+++ b/src/game/runtime_init.cpp
@@ -1,0 +1,32 @@
+#include "types.h"
+
+struct RuntimeCallbacks {
+	u8 pad00[0x1C];
+	s32 enabled;
+	void (*postEvent)(s32, s32*);
+};
+
+extern "C" {
+extern RuntimeCallbacks lbl_8029BB80;
+
+void fn_8004BEDC();
+void fn_80013010(void*);
+void fn_80013038(void*);
+}
+
+extern "C" void fn_800122B4(void* argument)
+{
+	fn_8004BEDC();
+	fn_80013010(argument);
+}
+
+extern "C" void fn_800122E8(void* argument)
+{
+	s32 event[2];
+	event[0] = 0xFF;
+	event[1] = 0xFF;
+
+	if (lbl_8029BB80.enabled != 0)
+		lbl_8029BB80.postEvent(20, event);
+	fn_80013038(argument);
+}


### PR DESCRIPTION
Adds the runtime initialization helpers that connect the endian setup and task creation paths, post the initial event parameters, and advance the runtime state.

Both functions and every owned text, exception, and exception-index section were verified byte-for-byte in objdiff. The object passed the language-policy, Matching-link, REL-generation, and all 18 artifact SHA-1 gates.

One matching-sensitive detail is that the two 0xFF event parameters must be assigned individually. An aggregate initializer places them in a pooled constant and changes both the instruction stream and object layout.