### PR TITLE
Match autosaveD widget slices

### DIFF
--- a/config/G9SE8P/autosaveD/splits.txt
+++ b/config/G9SE8P/autosaveD/splits.txt
@@ -34,7 +34,7 @@ autosaveD/quad_fill.c:
 	.text       start:0x000026C0 end:0x00002868
 	.rodata     start:0x00000320 end:0x00000328
 
-autosaveD/widget_slices.c:
+autosaveD/widget_slices.cpp:
 	.text       start:0x00002868 end:0x000031F0
 
 autosaveD/quad_submit.c:

--- a/config/G9SE8P/language_policy.json
+++ b/config/G9SE8P/language_policy.json
@@ -68,7 +68,6 @@
     "autosaveD/task_object.c",
     "autosaveD/task_runtime.c",
     "autosaveD/task_system.c",
-    "autosaveD/widget_slices.c",
     "autosaveD/window_frame.c",
     "autosaveD/window_lifecycle.c"
   ],

--- a/configure.py
+++ b/configure.py
@@ -712,9 +712,9 @@ config.libs = [
                 extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
             ),
             Object(
-                NonMatching,
-                "autosaveD/widget_slices.c",
-                extra_cflags=["-lang=c++", "-opt noschedule,nopeephole"],
+                Matching,
+                "autosaveD/widget_slices.cpp",
+                extra_cflags=["-opt noschedule,nopeephole"],
             ),
             Object(
                 Matching,

--- a/src/autosaveD/widget_slices.cpp
+++ b/src/autosaveD/widget_slices.cpp
@@ -13,14 +13,13 @@
 // and the constants at 0x328 onwards do not form one contiguous range this
 // unit could claim.
 //
-// NonMatching, by six instructions in fn_2_2BC8. The three other functions
-// reproduce exactly and fn_2_2BC8 is the right length with the right
-// instructions in the right order and the same stack layout; two of its
-// floating point registers come out swapped, the corner width taking the
-// register the vertical extent gets in the original and the other way round.
-// Twenty-odd source forms were measured against it and none moves those two.
+// Three things about the shape of it are worth writing down.
 //
-// Two things about the shape of it are worth writing down.
+// CodeWarrior emits C++ functions in reverse definition order, so the four
+// definitions below are deliberately written from fn_2_2F94 back to
+// fn_2_2868. Their linked order is the original 0x2868 through 0x31F0.
+// force_active is required as well: two of these entry points have no direct
+// relocation in this build and the partial linker otherwise removes them.
 //
 // The size passed to each piece is a struct holding an array rather than two
 // named floats. That is not cosmetic: this compiler copies a struct of two
@@ -34,6 +33,11 @@
 // the corners read back out of the array they were just written to rather than
 // through a local: positions.piece[3].x reads positions.piece[1].x, and the
 // compiler forwards the register instead of reloading.
+//
+// fn_2_2BC8 is sensitive to where its two reused dimensions are assigned.
+// Assigning cornerX and c1 inside their first arithmetic expressions, while
+// assigning sumY at its second written use, gives the original f7/f3 live-range
+// coloring and exact load order.
 
 typedef struct Vec2 {
 	f32 x;
@@ -109,181 +113,7 @@ extern "C" void fn_2_31F0(
     void* context, Vec3* position, Vec2* size, TexCoords* texcoords, f32 scale);
 
 #pragma opt_common_subs off
-
-extern "C" void fn_2_2868(void* context, Vec3* position, Vec2* size)
-{
-	Size half;
-	TexCoordPair texcoords;
-	Positions positions;
-	f32 scale;
-	f32 u;
-
-	scale = lbl_2_rodata_328 / (*lbl_8042C9A4)->width;
-
-	half      = lbl_2_rodata_2C8;
-	half.v[0] = lbl_2_rodata_32C * size->x;
-	half.v[1] = size->y;
-	u         = size->x * lbl_2_rodata_330;
-
-	positions            = lbl_2_rodata_2D0;
-	positions.piece[0].x = position->x;
-	positions.piece[0].y = position->y;
-	positions.piece[0].z = position->z;
-	positions.piece[1].x = position->x + half.v[0];
-	positions.piece[1].y = position->y;
-	positions.piece[1].z = position->z;
-
-	texcoords                = lbl_2_rodata_300;
-	texcoords.piece[0].right = u;
-	texcoords.piece[1].left  = u;
-
-	fn_2_31F0(context, &positions.piece[0], (Vec2*)&half, &texcoords.piece[0], scale);
-	fn_2_31F0(context, &positions.piece[1], (Vec2*)&half, &texcoords.piece[1], scale);
-}
-
-extern "C" void fn_2_2A18(void* context, Vec3* position, Vec2* size)
-{
-	Size half;
-	TexCoordPair texcoords;
-	Positions positions;
-	f32 scale;
-	f32 u;
-
-	scale = lbl_2_rodata_328 / (*lbl_8042C9A4)->width;
-
-	half      = lbl_2_rodata_270;
-	half.v[0] = lbl_2_rodata_32C * size->x;
-	half.v[1] = size->y;
-	u         = size->x * lbl_2_rodata_330;
-
-	positions            = lbl_2_rodata_278;
-	positions.piece[0].x = position->x;
-	positions.piece[0].y = position->y;
-	positions.piece[0].z = position->z;
-	positions.piece[1].x = position->x + half.v[0];
-	positions.piece[1].y = position->y;
-	positions.piece[1].z = position->z;
-
-	texcoords                = lbl_2_rodata_2A8;
-	texcoords.piece[0].right = u;
-	texcoords.piece[1].left  = u;
-
-	fn_2_31F0(context, &positions.piece[0], (Vec2*)&half, &texcoords.piece[0], scale);
-	fn_2_31F0(context, &positions.piece[1], (Vec2*)&half, &texcoords.piece[1], scale);
-}
-
-extern "C" void fn_2_2BC8(void* context, Vec3* position, Vec2* size)
-{
-	Size corner;
-	Size vertical;
-	Size horizontal;
-	Size body;
-	PositionGrid positions;
-	TexCoordGrid texcoords;
-	f32 scale;
-	f32 sumY;
-	f32 c1;
-	f32 step;
-	f32 u;
-	f32 v;
-	TexCoords* leftTex;
-	Vec3* leftPos;
-	TexCoords* rightTex;
-	Vec3* rightPos;
-
-	scale = lbl_2_rodata_328 / (*lbl_8042C9A4)->width;
-
-	corner     = lbl_2_rodata_154;
-	vertical   = lbl_2_rodata_15C;
-	horizontal = lbl_2_rodata_164;
-
-	horizontal.v[0] = size->x - lbl_2_rodata_334;
-	body            = lbl_2_rodata_16C;
-	body.v[0]       = horizontal.v[0];
-	body.v[1]       = size->y - lbl_2_rodata_334;
-
-	u = size->x * lbl_2_rodata_330;
-	v = size->y * lbl_2_rodata_330;
-
-	positions            = lbl_2_rodata_174;
-	positions.piece[0].x = position->x;
-	positions.piece[0].y = position->y;
-	positions.piece[0].z = position->z;
-
-	positions.piece[1].x = (position->x + size->x) - corner.v[0];
-	positions.piece[1].y = position->y;
-	positions.piece[1].z = position->z;
-
-	positions.piece[2].x = position->x;
-	sumY                 = position->y + size->y;
-	c1                   = corner.v[1];
-	positions.piece[2].y = sumY - c1;
-	positions.piece[2].z = position->z;
-
-	positions.piece[3].x = positions.piece[1].x;
-	positions.piece[3].y = positions.piece[2].y;
-	positions.piece[3].z = position->z;
-
-	positions.piece[4].x = position->x;
-	positions.piece[4].y = position->y + c1;
-	positions.piece[4].z = position->z;
-
-	positions.piece[5].x = positions.piece[1].x;
-	positions.piece[5].y = positions.piece[4].y;
-	positions.piece[5].z = position->z;
-
-	positions.piece[6].x = position->x + corner.v[0];
-	positions.piece[6].y = position->y;
-	positions.piece[6].z = position->z;
-
-	positions.piece[7].x = positions.piece[6].x;
-	positions.piece[7].y = sumY - horizontal.v[1];
-	positions.piece[7].z = position->z;
-
-	positions.piece[8].x = positions.piece[6].x;
-	positions.piece[8].y = positions.piece[4].y;
-	positions.piece[8].z = position->z;
-
-	texcoords                 = lbl_2_rodata_1E0;
-	texcoords.piece[4].top    = v;
-	texcoords.piece[4].bottom = v;
-	texcoords.piece[5].top    = v;
-	texcoords.piece[5].bottom = v;
-	texcoords.piece[8].left   = u;
-	texcoords.piece[8].top    = v;
-	texcoords.piece[8].right  = u;
-	texcoords.piece[8].bottom = v;
-
-	fn_2_31F0(context, &positions.piece[0], (Vec2*)&corner, &texcoords.piece[0], scale);
-	fn_2_31F0(context, &positions.piece[1], (Vec2*)&corner, &texcoords.piece[1], scale);
-	fn_2_31F0(context, &positions.piece[2], (Vec2*)&corner, &texcoords.piece[2], scale);
-	fn_2_31F0(context, &positions.piece[3], (Vec2*)&corner, &texcoords.piece[3], scale);
-
-	leftTex  = &texcoords.piece[4];
-	leftPos  = &positions.piece[4];
-	rightTex = &texcoords.piece[5];
-	rightPos = &positions.piece[5];
-
-	while (positions.piece[4].y <= positions.piece[2].y - vertical.v[1]) {
-		fn_2_31F0(context, leftPos, (Vec2*)&vertical, leftTex, scale);
-		fn_2_31F0(context, rightPos, (Vec2*)&vertical, rightTex, scale);
-		positions.piece[4].y = positions.piece[4].y + vertical.v[1];
-		positions.piece[5].y = positions.piece[5].y + vertical.v[1];
-	}
-
-	step          = lbl_2_rodata_338;
-	vertical.v[1] = step;
-	while (positions.piece[4].y <= positions.piece[2].y) {
-		fn_2_31F0(context, leftPos, (Vec2*)&vertical, leftTex, scale);
-		fn_2_31F0(context, rightPos, (Vec2*)&vertical, rightTex, scale);
-		positions.piece[4].y = positions.piece[4].y + step;
-		positions.piece[5].y = positions.piece[5].y + step;
-	}
-
-	fn_2_31F0(context, &positions.piece[6], (Vec2*)&horizontal, &texcoords.piece[6], scale);
-	fn_2_31F0(context, &positions.piece[7], (Vec2*)&horizontal, &texcoords.piece[7], scale);
-	fn_2_31F0(context, &positions.piece[8], (Vec2*)&body, &texcoords.piece[8], scale);
-}
+#pragma force_active on
 
 extern "C" void fn_2_2F94(void* context, Vec3* position, Vec2* size)
 {
@@ -335,4 +165,178 @@ extern "C" void fn_2_2F94(void* context, Vec3* position, Vec2* size)
 	fn_2_31F0(context, &positions.piece[1], (Vec2*)&half, &texcoords.piece[1], scale);
 	fn_2_31F0(context, &positions.piece[2], (Vec2*)&half, &texcoords.piece[2], scale);
 	fn_2_31F0(context, &positions.piece[3], (Vec2*)&half, &texcoords.piece[3], scale);
+}
+extern "C" void fn_2_2BC8(void* context, Vec3* position, Vec2* size)
+{
+	Size corner;
+	Size vertical;
+	Size horizontal;
+	Size body;
+	PositionGrid positions;
+	TexCoordGrid texcoords;
+	f32 scale;
+	f32 cornerX;
+	f32 sumY;
+	f32 c1;
+	f32 step;
+	f32 u;
+	f32 v;
+	TexCoords* leftTex;
+	Vec3* leftPos;
+	TexCoords* rightTex;
+	Vec3* rightPos;
+
+	scale = lbl_2_rodata_328 / (*lbl_8042C9A4)->width;
+
+	corner     = lbl_2_rodata_154;
+	vertical   = lbl_2_rodata_15C;
+	horizontal = lbl_2_rodata_164;
+
+	horizontal.v[0] = size->x - lbl_2_rodata_334;
+	body            = lbl_2_rodata_16C;
+	body.v[0]       = horizontal.v[0];
+	body.v[1]       = size->y - lbl_2_rodata_334;
+
+	u = size->x * lbl_2_rodata_330;
+	v = size->y * lbl_2_rodata_330;
+
+	positions            = lbl_2_rodata_174;
+	positions.piece[0].x = position->x;
+	positions.piece[0].y = position->y;
+	positions.piece[0].z = position->z;
+
+	positions.piece[1].x = (position->x + size->x) - (cornerX = corner.v[0]);
+	positions.piece[1].y = position->y;
+	positions.piece[1].z = position->z;
+
+	positions.piece[2].x = position->x;
+	positions.piece[2].y = (position->y + size->y) - (c1 = corner.v[1]);
+	positions.piece[2].z = position->z;
+
+	positions.piece[3].x = positions.piece[1].x;
+	positions.piece[3].y = positions.piece[2].y;
+	positions.piece[3].z = position->z;
+
+	positions.piece[4].x = position->x;
+	positions.piece[4].y = position->y + c1;
+	positions.piece[4].z = position->z;
+
+	positions.piece[5].x = positions.piece[1].x;
+	positions.piece[5].y = positions.piece[4].y;
+	positions.piece[5].z = position->z;
+
+	positions.piece[6].x = position->x + cornerX;
+	positions.piece[6].y = position->y;
+	positions.piece[6].z = position->z;
+
+	positions.piece[7].x = positions.piece[6].x;
+	sumY                 = position->y + size->y;
+	positions.piece[7].y = sumY - horizontal.v[1];
+	positions.piece[7].z = position->z;
+
+	positions.piece[8].x = positions.piece[6].x;
+	positions.piece[8].y = positions.piece[4].y;
+	positions.piece[8].z = position->z;
+
+	texcoords                 = lbl_2_rodata_1E0;
+	texcoords.piece[4].top    = v;
+	texcoords.piece[4].bottom = v;
+	texcoords.piece[5].top    = v;
+	texcoords.piece[5].bottom = v;
+	texcoords.piece[8].left   = u;
+	texcoords.piece[8].top    = v;
+	texcoords.piece[8].right  = u;
+	texcoords.piece[8].bottom = v;
+
+	fn_2_31F0(context, &positions.piece[0], (Vec2*)&corner, &texcoords.piece[0], scale);
+	fn_2_31F0(context, &positions.piece[1], (Vec2*)&corner, &texcoords.piece[1], scale);
+	fn_2_31F0(context, &positions.piece[2], (Vec2*)&corner, &texcoords.piece[2], scale);
+	fn_2_31F0(context, &positions.piece[3], (Vec2*)&corner, &texcoords.piece[3], scale);
+
+	leftTex  = &texcoords.piece[4];
+	leftPos  = &positions.piece[4];
+	rightTex = &texcoords.piece[5];
+	rightPos = &positions.piece[5];
+
+	while (positions.piece[4].y <= positions.piece[2].y - vertical.v[1]) {
+		fn_2_31F0(context, leftPos, (Vec2*)&vertical, leftTex, scale);
+		fn_2_31F0(context, rightPos, (Vec2*)&vertical, rightTex, scale);
+		positions.piece[4].y = positions.piece[4].y + vertical.v[1];
+		positions.piece[5].y = positions.piece[5].y + vertical.v[1];
+	}
+
+	step          = lbl_2_rodata_338;
+	vertical.v[1] = step;
+	while (positions.piece[4].y <= positions.piece[2].y) {
+		fn_2_31F0(context, leftPos, (Vec2*)&vertical, leftTex, scale);
+		fn_2_31F0(context, rightPos, (Vec2*)&vertical, rightTex, scale);
+		positions.piece[4].y = positions.piece[4].y + step;
+		positions.piece[5].y = positions.piece[5].y + step;
+	}
+
+	fn_2_31F0(context, &positions.piece[6], (Vec2*)&horizontal, &texcoords.piece[6], scale);
+	fn_2_31F0(context, &positions.piece[7], (Vec2*)&horizontal, &texcoords.piece[7], scale);
+	fn_2_31F0(context, &positions.piece[8], (Vec2*)&body, &texcoords.piece[8], scale);
+}
+
+extern "C" void fn_2_2A18(void* context, Vec3* position, Vec2* size)
+{
+	Size half;
+	TexCoordPair texcoords;
+	Positions positions;
+	f32 scale;
+	f32 u;
+
+	scale = lbl_2_rodata_328 / (*lbl_8042C9A4)->width;
+
+	half      = lbl_2_rodata_270;
+	half.v[0] = lbl_2_rodata_32C * size->x;
+	half.v[1] = size->y;
+	u         = size->x * lbl_2_rodata_330;
+
+	positions            = lbl_2_rodata_278;
+	positions.piece[0].x = position->x;
+	positions.piece[0].y = position->y;
+	positions.piece[0].z = position->z;
+	positions.piece[1].x = position->x + half.v[0];
+	positions.piece[1].y = position->y;
+	positions.piece[1].z = position->z;
+
+	texcoords                = lbl_2_rodata_2A8;
+	texcoords.piece[0].right = u;
+	texcoords.piece[1].left  = u;
+
+	fn_2_31F0(context, &positions.piece[0], (Vec2*)&half, &texcoords.piece[0], scale);
+	fn_2_31F0(context, &positions.piece[1], (Vec2*)&half, &texcoords.piece[1], scale);
+}
+
+extern "C" void fn_2_2868(void* context, Vec3* position, Vec2* size)
+{
+	Size half;
+	TexCoordPair texcoords;
+	Positions positions;
+	f32 scale;
+	f32 u;
+
+	scale = lbl_2_rodata_328 / (*lbl_8042C9A4)->width;
+
+	half      = lbl_2_rodata_2C8;
+	half.v[0] = lbl_2_rodata_32C * size->x;
+	half.v[1] = size->y;
+	u         = size->x * lbl_2_rodata_330;
+
+	positions            = lbl_2_rodata_2D0;
+	positions.piece[0].x = position->x;
+	positions.piece[0].y = position->y;
+	positions.piece[0].z = position->z;
+	positions.piece[1].x = position->x + half.v[0];
+	positions.piece[1].y = position->y;
+	positions.piece[1].z = position->z;
+
+	texcoords                = lbl_2_rodata_300;
+	texcoords.piece[0].right = u;
+	texcoords.piece[1].left  = u;
+
+	fn_2_31F0(context, &positions.piece[0], (Vec2*)&half, &texcoords.piece[0], scale);
+	fn_2_31F0(context, &positions.piece[1], (Vec2*)&half, &texcoords.piece[1], scale);
 }


### PR DESCRIPTION
Adds the C++ implementation of the autosave widget slicing routines, covering the two-half, nine-slice, and four-quadrant layout paths.

All four functions and the complete owned text section were verified byte-for-byte in objdiff. The object passed the fresh-build, section-size, Matching-link, language-policy, autosaveD REL SHA-1, and all 18 artifact SHA-1 gates.

One matching-sensitive detail is that CodeWarrior emits the C++ functions in reverse definition order, so the definitions remain reversed under force_active to preserve their linked order and retain the two entry points without direct relocations. In fn_2_2BC8, assigning the corner dimensions inside their first arithmetic expressions while assigning the vertical sum at its second written use is likewise required for the original f7/f3 live-range coloring and load order.