### PR TITLE
ci: narrow code ownership to the CI execution surface

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,22 @@
 # Ownership of the paths that execute during a private build.
 #
-# A contributor with write access reviews and merges decompilation work on their
-# own: src/ and config/ are not listed here, and splits.txt and symbols.txt
-# change in nearly every unit that lands, so requiring a maintainer there would
-# remove the point of granting write access.
+# What is listed is code that runs inside the container holding the original
+# game files. A change to a workflow or to a build post-processor under tools/
+# can read /orig and send it somewhere, so those paths need the maintainer who
+# owns the private package and its credentials.
 #
-# What is listed is the code that runs inside the container holding the original
-# game files. A change to a workflow, a build post-processor or configure.py can
-# read /orig and send it somewhere, so those paths need the maintainer who owns
-# the private package and its credentials.
+# Decompilation work is deliberately not listed. src/ and config/ are reviewed
+# like any other change: splits.txt and symbols.txt move in nearly every unit
+# that lands, so claiming them here would mean no unit could be merged without
+# the package owner.
+#
+# configure.py is not listed either, for the same reason: every new translation
+# unit adds an Object entry to it, so owning the file would cover every
+# decompilation pull request and leave write access unable to merge any of them.
+# The tradeoff is explicit — configure.py runs in the build container, so a
+# reviewer approving a change to it should read the diff as build configuration
+# rather than skim it as data. The build logic it drives lives in tools/, which
+# is owned.
 
-/.github/     @Jovinull
-/tools/       @Jovinull
-/configure.py @Jovinull
+/.github/ @Jovinull
+/tools/   @Jovinull

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,13 +93,19 @@ frequent parallel commits do not create a mandatory rebase loop. Do not push
 game-code changes directly to `main`.
 
 `.github/CODEOWNERS` names a maintainer for the paths that execute during a
-private build: the workflows, the build post-processors under `tools/` and
-`configure.py`. A pull request touching those needs that maintainer's review,
-because code on those paths runs in the container holding the original game
-files and could copy them somewhere. Decompilation work is deliberately not
-covered: `src/` and `config/` are reviewed like any other change, so a
-contributor with write access can review and merge unit reconstructions without
-waiting on the package owner.
+private build: the workflows and the build post-processors under `tools/`. A
+pull request touching those needs that maintainer's review, because code on
+those paths runs in the container holding the original game files and could copy
+them somewhere.
+
+Decompilation work is deliberately not covered. `src/`, `config/` and
+`configure.py` are reviewed like any other change, so a contributor with write
+access can review and merge unit reconstructions without waiting on the package
+owner. `splits.txt`, `symbols.txt` and a `configure.py` object entry move in
+nearly every unit that lands, and claiming them would mean no reconstruction
+could be merged without the package owner. `configure.py` does run in the build
+container, so read a change to it as build configuration rather than skimming it
+as data; the build logic it drives lives in `tools/`, which is owned.
 
 The full build uses private original-game inputs. A same-repository pull request
 waits for approval from a reviewer on the protected `private-build` environment


### PR DESCRIPTION
Removes `/configure.py` from `.github/CODEOWNERS`, leaving `/.github/` and `/tools/`.

## Why

Every new translation unit adds an `Object` entry to `configure.py`. All seven pull requests in the #154 batch touched it, and so did both of #155 and #156. Owning the file therefore covered every decompilation pull request, which meant a contributor with write access could not merge any reconstruction without the package owner — the opposite of what granting write access is for.

## What is still owned

`/.github/` and `/tools/` remain owned, and that is where the exfiltration surface actually is: workflow files and the build post-processors that run inside the container holding the original game files. #155 adding `tools/fix_game_movie_object.py` is exactly the case the rule is meant to catch.

## The tradeoff, stated plainly

`configure.py` does execute in the build container, so a malicious change to it could read `/orig`. That risk is accepted rather than eliminated: in a decompilation pull request its diff is a few lines of build configuration, so an unexpected change there is visible to any reviewer reading it. `CONTRIBUTING.md` now says to read a `configure.py` change as build configuration rather than skim it as data.

The alternative — keeping the file owned — traded that residual risk for a review bottleneck on every unit, and made the write role effectively unable to close a decompilation pull request.