### PR TITLE
ci: gate the private build on pull requests only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,13 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     # Approval protects the package credentials before any submitted code can run.
-    environment: private-build
+    #
+    # Only the pull request needs it. "Protect Main" requires a pull request to
+    # move main and lists no bypass actors, so a push here is always a merge of
+    # commits that already cleared this gate once. Asking again stalls the run
+    # on a review that nobody is waiting to give, and the queue of unapproved
+    # main builds hides a real failure rather than catching one.
+    environment: ${{ github.event_name == 'pull_request' && 'private-build' || '' }}
     container:
       image: ghcr.io/jovinull/sonicheroes-build:main
       credentials:


### PR DESCRIPTION
## What

Applies the `private-build` required review to pull requests only. The push
event on `main` no longer requests a deployment approval.

## Why

Every merge left a run parked on "Waiting for review: private-build needs
approval to start deploying changes". Nine of them had accumulated, the oldest
from ten hours earlier, and nothing releases that state except a manual click.

The review does not buy anything on that event. The `Protect Main` ruleset is
active on `refs/heads/main` with a `pull_request` rule and an empty bypass actor
list, so `main` cannot move except through a pull request. A push is therefore
always the merge of commits whose private build already passed this gate, and
approving it a second time re-reviews code that was reviewed and merged.

The cost is not only the clicking. A queue of permanently pending main builds
means a real failure on main is indistinguishable from the ones nobody has
gotten around to, which is the opposite of what the check exists for.

## Security

No path to the credentials or to `/orig` is widened.

- Fork pull requests never reach the job. The condition on `private_build`
  skips it when the head repository is not this one, and `build_gate` fails
  them with an explicit message.
- Repository pull requests, the only untrusted-code path that can run here,
  keep the gate exactly as before.
- Direct pushes to `main` are refused by `Protect Main` for everyone, admins
  included.

## Verification

- [x] `python -m unittest tools.test_check_language_policy` (36 tests)
- [x] `python tools/check_language_policy.py --staged`
- [x] workflow parses; `environment` resolves to the literal
      `${{ github.event_name == 'pull_request' && 'private-build' || '' }}`
- [ ] this pull request's own run still requests approval, confirming the gate
      survives on the event that needs it
- [ ] the merge push runs without an approval prompt

The last two are what this change is about and can only be observed on this
pull request and its merge. No source or config under `src/`, `config/` or
`configure.py` is touched, so there is no objdiff or artifact impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
