### PR TITLE
Revert "ci: gate the private build on pull requests only"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,7 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     # Approval protects the package credentials before any submitted code can run.
-    #
-    # Only the pull request needs it. "Protect Main" requires a pull request to
-    # move main and lists no bypass actors, so a push here is always a merge of
-    # commits that already cleared this gate once. Asking again stalls the run
-    # on a review that nobody is waiting to give, and the queue of unapproved
-    # main builds hides a real failure rather than catching one.
-    environment: ${{ github.event_name == 'pull_request' && 'private-build' || '' }}
+    environment: private-build
     container:
       image: ghcr.io/jovinull/sonicheroes-build:main
       credentials:


### PR DESCRIPTION
Restores `environment: private-build` unconditionally.

The conditional environment made the workflow invalid on `push`:

    The template is not valid. .github/workflows/build.yml
    (Line: 29, Col: 19): Unexpected value ''
    (Line: 30, Col: 19): Unexpected value ''

Two separate reasons, either of which is fatal:

- `GHCR_USERNAME` and `GHCR_TOKEN` are environment secrets scoped to
  `private-build`. The repository holds no Actions secrets of its own, so
  dropping the environment empties the `container.credentials` block rather
  than merely skipping the review.
- `environment` does not accept an empty string in the first place.

The pull request run passed because the expression evaluated to
`private-build` on that event, so only the push path was exercised, and only
after merge. Reverting to unblock main while a working approach is chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)