### PR TITLE
ci: run the private build on main without a second review

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,20 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     # Approval protects the package credentials before any submitted code can run.
-    environment: private-build
+    #
+    # A push does not need it. "Protect Main" requires a pull request to move
+    # main and lists no bypass actors, so a push is always a merge of commits
+    # whose build was approved on the pull request. Asking twice left every
+    # merge parked on a review nobody was waiting to give, which hides a real
+    # failure among the ones nobody clicked.
+    #
+    # private-build-auto carries the same credentials with no reviewer, and is
+    # restricted to the main branch. That restriction is the load-bearing part.
+    # A pull request runs the workflow from its own head branch, so naming the
+    # unreviewed environment is something any branch could do; the branch policy
+    # is what refuses it. What guards /orig is the credential being reachable
+    # only from a gated or main-only environment, not the approval click.
+    environment: ${{ github.event_name == 'pull_request' && 'private-build' || 'private-build-auto' }}
     container:
       image: ghcr.io/jovinull/sonicheroes-build:main
       credentials:


### PR DESCRIPTION
## What

Points the `private_build` job at `private-build` on pull requests and at a new
`private-build-auto` on every other event.

## Why

Merges were leaving runs parked on "private-build needs approval to start
deploying changes" — nine of them, oldest ten hours old. Only a manual click
releases that, and a permanently pending queue means a genuine failure on main
is indistinguishable from the ones nobody clicked.

`Protect Main` carries a `pull_request` rule with no bypass actors, so main
only moves through a pull request whose private build already cleared the gate.

## Security

`private-build-auto` has the same two secrets, no reviewer, and a deployment
branch policy naming only `main`.

The branch policy is the part that matters. A pull request runs the workflow
from its own head branch, so naming the unreviewed environment is something any
branch could do — the policy is what refuses it. The property that actually
guards `/orig` is that the credentials are reachable only from a gated
environment or from `main`; the approval click is downstream of that.

| path | result |
|---|---|
| push to `main` | `private-build-auto`, ref matches, no approval |
| PR branch naming `private-build-auto` | refused by the branch policy, no secrets |
| PR | `private-build`, gate unchanged |
| direct push to `main` | refused by `Protect Main` for everyone |

Rejected alternative: dropping the PAT for `GITHUB_TOKEN` with `packages: read`.
That token works from any workflow in the repository, so a branch that deleted
the `environment:` line would pull the image unreviewed. It replaces a boundary
a collaborator cannot edit with one they can.

## Verification

- [x] `python -m unittest tools.test_check_language_policy` (36 tests)
- [x] `python tools/check_language_policy.py --staged`
- [x] workflow parses; `environment` is a single-line expression with no
      embedded newline
- [ ] this run still requests approval
- [ ] the merge push runs unattended

**Do not merge until `GHCR_USERNAME` and `GHCR_TOKEN` are set on
`private-build-auto`.** Without them the push build repeats the empty-credentials
failure.

No `src/`, `config/` or `configure.py` change, so no objdiff or artifact impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)