### PR TITLE
fix: unblock the local Windows build

### DIFF
--- a/src/dolphin/ar/arq.c
+++ b/src/dolphin/ar/arq.c
@@ -141,7 +141,7 @@ void ARQInit(void)
 	// One chained assignment, not two statements: the chain stores the Lo
 	// queue first, matching the original's store order (the two stores are
 	// byte-identical apart from their sda21 offsets, so objdiff scores the
-	// swapped pair 100% — only linking catches it).
+	// swapped pair 100% - only linking catches it).
 	__ARQRequestQueueHi = __ARQRequestQueueLo = NULL;
 	__ARQChunkSize                            = ARQ_CHUNK_SIZE_DEFAULT;
 

--- a/src/dolphin/os/OSAlarm.c
+++ b/src/dolphin/os/OSAlarm.c
@@ -78,7 +78,7 @@ static OSResetFunctionInfo ResetFunctionInfo = {
 };
 
 // Arms the decrementer for the alarm at the head of the queue. Inlined into
-// every caller, so it has no body in the binary — which requires the
+// every caller, so it has no body in the binary - which requires the
 // `inline` keyword: MWCC emits an out-of-line body for a plain static even
 // when every call site is inlined, and that body is 152 stray .text bytes.
 static inline void SetTimer(OSAlarm* alarm)

--- a/src/rel/invoke_collision_dtor.cpp
+++ b/src/rel/invoke_collision_dtor.cpp
@@ -10,7 +10,7 @@
 // constant, so it owns no rodata.
 //
 // The run is the same in the nine stage modules that carry this revision of the
-// engine core — 01D, 03D, 05D, 07D, 09D, 11D, 31D, 32D and 33D — which is the
+// engine core - 01D, 03D, 05D, 07D, 09D, 11D, 31D, 32D and 33D - which is the
 // same set rel/system_object1_object.cpp records. The other stage modules are a
 // different revision this far in.
 //

--- a/tools/project.py
+++ b/tools/project.py
@@ -723,10 +723,10 @@ def generate_build_ninja(
         mwcc_sjis_extab_implicit.append(transform_dep)
 
     mwcc_align_cmd = (
-        f"{mwcc_cmd} && $python {section_align_tool} $out .data $data_section_alignment"
+        f"{CHAIN}{mwcc_cmd} && $python {section_align_tool} $out .data $data_section_alignment"
     )
     mwcc_sjis_align_cmd = (
-        f"{mwcc_sjis_cmd} && $python {section_align_tool} $out .data $data_section_alignment"
+        f"{CHAIN}{mwcc_sjis_cmd} && $python {section_align_tool} $out .data $data_section_alignment"
     )
     mwcc_align_implicit = [*mwcc_implicit, section_align_tool]
     mwcc_sjis_align_implicit = [*mwcc_sjis_implicit, section_align_tool]


### PR DESCRIPTION
## What

Two independent defects that each stop `ninja` on Windows. Neither is visible
in CI, which builds on Linux.

## 1. `&&` reaching the compiler as an argument

`tools/project.py` chains the compile with `set_elf_section_alignment.py` using
`&&` but omits the `CHAIN` prefix. ninja uses a shell on POSIX and
`CreateProcess` directly on Windows, so the operator is passed through:

    ### mwcceppc.exe Usage Error:
    #   Specified file '&&' not found

Every object with `data_section_alignment` fails. `mwcc_extab_cmd` above already
prefixes `CHAIN` for exactly this reason.

## 2. UTF-8 em dashes in comments

Three comments contain `—` (`E2 80 94`). The Windows compile runs behind
`sjiswrap`, which validates the source as Shift JIS and rejects it:

    sjiswrap: File src\rel\invoke_collision_dtor.cpp contains Shift JIS
    encoding errors

Replaced with hyphens. Comments only.

## Verification

Both fixes applied, on Windows:

- [x] `python configure.py --version G9SE8P` then `ninja` completes
- [x] `sha1sum -c config/G9SE8P/build.sha1` — **18/18 OK**
- [x] `python -m unittest tools.test_check_language_policy` (36 tests, via the
      commit hook)
- [x] `python tools/check_language_policy.py --staged`

Before these, a Windows checkout cannot complete a build at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)