### PR TITLE
feat: carve the wide formatter core

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -265,6 +265,16 @@ game/wide_format_write.cpp:
 	extabindex  start:0x80011AB8 end:0x80011AD0
 	.text       start:0x8013A5F0 end:0x8013A6B8
 
+game/wide_format_core.cpp:
+	extab       start:0x8000BAA0 end:0x8000BAA8
+	extabindex  start:0x80011AD0 end:0x80011ADC
+	.text       start:0x8013A6B8 end:0x8013B76C
+	.rodata     start:0x8023BB78 end:0x8023BBD8
+	.data       start:0x8028D068 end:0x8028D0E0
+	.bss        start:0x803EC360 end:0x803EC3C0
+	.sdata      start:0x8042BCC0 end:0x8042BCC8
+	.sbss       start:0x8042C808 end:0x8042C810
+
 game/SpAdvStgFailed.cpp:
 	extab       start:0x8000BAA8 end:0x8000BB08
 	extabindex  start:0x80011ADC end:0x80011B18

--- a/configure.py
+++ b/configure.py
@@ -597,6 +597,11 @@ config.libs = [
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
             Object(
+                NonMatching,
+                "game/wide_format_core.cpp",
+                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
+            ),
+            Object(
                 Matching,
                 "game/wide_format_write.cpp",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -382,7 +382,7 @@ fetch:
 		wchar* at = convPos;
 
 		if (base >= 2 && base <= 0x24) {
-			wchar digits[48];
+			wchar digits[66];
 			wchar* end;
 
 			if (value < 0 && isSigned != 0) {

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -436,7 +436,61 @@ padded:
 		if (precision > bare) {
 			zeroPad = precision - bare;
 		}
+
+		goto emit;
 	}
+
+	if ((flags & 0x8) != 0 && width > 0) {
+		wchar* at = convPos;
+		s32 len;
+
+		if (at != NULL) {
+			len = 0;
+
+			while (*at != 0) {
+				len = len + 1;
+				at  = at + 1;
+			}
+		} else {
+			len = 0;
+		}
+
+		if (*convPos == 0x2D) {
+			len = len - 1;
+		}
+
+		if (width > len) {
+			zeroPad = width - len;
+		}
+	}
+
+	if (*convPos == 0x2D || sign != 0) {
+		if (*convPos != 0x2D) {
+			convPos = convPos - 1;
+
+			*convPos = sign;
+		}
+
+		if (zeroPad > 0) {
+			zeroPad = zeroPad - 1;
+		}
+	}
+
+	{
+		wchar* at = convPos;
+
+		if (at != NULL) {
+			length = 0;
+
+			while (*at != 0) {
+				length = length + 1;
+				at     = at + 1;
+			}
+		} else {
+			length = 0;
+		}
+	}
+
 	goto emit;
 
 pointer: {

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -162,10 +162,11 @@ extern "C" s32 wideFormatCore(
 	s32 total;
 	s32 failed;
 	u32* limitAt;
+	u32 flags;
+	s32 length;
 	const wchar* fmt;
 	wchar c;
 	u32 state;
-	u32 flags;
 	s32 width;
 	s32 precision;
 	wchar sign;
@@ -173,7 +174,6 @@ extern "C" s32 wideFormatCore(
 	s32 hexBias;
 	u32 value;
 	s32 isSigned;
-	s32 length;
 	s32 isWide;
 	u32 zeroPad;
 	const wchar* specAt;

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -120,6 +120,11 @@ static wchar wideNull[6] = { 0, 0, 0, 0, 0, 0 };
 static wchar convBuf[48];
 static wchar* convPos;
 
+// Never read here. The target's lbl_8042C808 is one eight byte object with
+// only its first word referenced, so a second pointer has to exist beside the
+// cursor for .sbss to come out at eight rather than four.
+static wchar* convEnd;
+
 // Inlined at every site that emits one character. The flush computes a flag the
 // call never reads, which is this helper's dead parameter on that path.
 struct State {
@@ -175,9 +180,9 @@ extern "C" s32 wideFormatCore(
 	State st;
 
 	fmt         = format;
-	st.held     = 0;
-	st.total    = 0;
 	st.failed   = 0;
+	st.total    = 0;
+	st.held     = 0;
 	st.write    = write;
 	st.writeArg = writeArg;
 	st.limitAt  = hasLimit != 0 ? &limit : NULL;

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -325,9 +325,9 @@ nextChar:
 				case 0x11: // s
 					goto string;
 				case 0x12: // C
-					goto character;
+					goto narrowCharDefault;
 				case 0x13: // S
-					goto string;
+					goto narrowStringDefault;
 				case 0x14: // n
 					goto storeCount;
 				case 0x15:
@@ -485,11 +485,12 @@ pointer: {
 }
 	goto emit;
 
-character:
+narrowCharDefault:
 	if ((flags & 0x210) == 0) {
 		flags |= 0x200;
 	}
 
+character:
 	if ((flags & 0x200) != 0) {
 		((s8*)convBuf)[0] = (s8)ARG_INT;
 		((s8*)bufBase)[1] = 0;
@@ -503,11 +504,12 @@ character:
 	}
 	goto emit;
 
-string:
+narrowStringDefault:
 	if ((flags & 0x210) == 0) {
 		flags |= 0x200;
 	}
 
+string:
 	if ((flags & 0x200) != 0) {
 		convPos = (wchar*)ARG_INT;
 		isWide  = 0;

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -309,18 +309,13 @@ nextChar:
 					state = 1;
 					break;
 				case 0x0A: // d and i
-					base = 10;
 					goto integer;
 				case 0x0B: // o
-					base = 8;
-					goto unsignedInteger;
+					goto octal;
 				case 0x0C: // u
-					base = 10;
-					goto unsignedInteger;
+					goto unsignedDecimal;
 				case 0x0D: // x and X
-					base    = 16;
-					hexBias = c - 0x17;
-					goto unsignedInteger;
+					goto hexadecimal;
 				case 0x0E: // p
 					goto pointer;
 				case 0x0F: // e f g E G
@@ -387,14 +382,26 @@ nextChar:
 		}
 	}
 
-unsignedInteger:
+octal:
+	base = 8;
+	goto unsignedShared;
+
+unsignedDecimal:
+	base = 10;
+	goto unsignedShared;
+
+hexadecimal:
+	base    = 16;
+	hexBias = c - 0x17;
+
+unsignedShared:
 	sign     = 0;
 	isSigned = 0;
+	goto fetch;
 
 integer:
 	base     = 10;
 	isSigned = 1;
-	goto fetch;
 
 fetch:
 	if ((flags & 0x100) != 0) {

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -604,6 +604,20 @@ string:
 			convPos = wideNull;
 		}
 	}
+
+	{
+		s32 room  = precision >= 0 ? precision : 0x7FFFFFFF;
+		wchar* at = convPos;
+
+		length = 0;
+
+		while (room != 0 && *at != 0) {
+			room   = room - 1;
+			length = length + 1;
+			at     = at + 1;
+		}
+	}
+
 	goto emit;
 
 floating:

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -387,14 +387,14 @@ nextChar:
 		}
 	}
 
+unsignedInteger:
+	sign     = 0;
+	isSigned = 0;
+
 integer:
 	base     = 10;
 	isSigned = 1;
 	goto fetch;
-
-unsignedInteger:
-	sign     = 0;
-	isSigned = 0;
 
 fetch:
 	if ((flags & 0x100) != 0) {
@@ -452,94 +452,6 @@ fetch:
 
 		*at = 0;
 	}
-
-padded:
-	if (precision >= 0) {
-		wchar* at = convPos;
-		s32 bare;
-
-		if (at != NULL) {
-			length = 0;
-
-			while (*at != 0) {
-				length = length + 1;
-				at     = at + 1;
-			}
-		} else {
-			length = 0;
-		}
-
-		bare = length;
-
-		if (*convPos == 0x2D) {
-			bare = length - 1;
-		} else if (sign != 0) {
-			length  = length + 1;
-			convPos = convPos - 1;
-
-			*convPos = sign;
-		}
-
-		if (precision > bare) {
-			zeroPad = precision - bare;
-		}
-
-		goto emit;
-	}
-
-zeroFill:
-	if ((flags & 0x8) != 0 && width > 0) {
-		wchar* at = convPos;
-		s32 len;
-
-		if (at != NULL) {
-			len = 0;
-
-			while (*at != 0) {
-				len = len + 1;
-				at  = at + 1;
-			}
-		} else {
-			len = 0;
-		}
-
-		if (*convPos == 0x2D) {
-			len = len - 1;
-		}
-
-		if (width > len) {
-			zeroPad = width - len;
-		}
-	}
-
-	if (*convPos == 0x2D || sign != 0) {
-		if (*convPos != 0x2D) {
-			convPos = convPos - 1;
-
-			*convPos = sign;
-		}
-
-		if (zeroPad > 0) {
-			zeroPad = zeroPad - 1;
-		}
-	}
-
-	{
-		wchar* at = convPos;
-
-		if (at != NULL) {
-			length = 0;
-
-			while (*at != 0) {
-				length = length + 1;
-				at     = at + 1;
-			}
-		} else {
-			length = 0;
-		}
-	}
-
-	goto emit;
 
 pointer: {
 	u32 v = (u32)ARG_INT;
@@ -631,23 +543,93 @@ string:
 
 	goto emit;
 
-floating:
-	goto zeroFill;
+padded:
+	if (precision >= 0) {
+		wchar* at = convPos;
+		s32 bare;
 
-storeCount: {
-	void* at = (void*)ARG_INT;
+		if (at != NULL) {
+			length = 0;
 
-	convPos = (wchar*)at;
+			while (*at != 0) {
+				length = length + 1;
+				at     = at + 1;
+			}
+		} else {
+			length = 0;
+		}
 
-	if ((flags & 0x10) != 0) {
-		*(s32*)at = st.total;
-	} else if ((flags & 0x200) != 0) {
-		*(s16*)at = (s16)st.total;
-	} else {
-		*(s32*)at = st.total;
+		bare = length;
+
+		if (*convPos == 0x2D) {
+			bare = length - 1;
+		} else if (sign != 0) {
+			length  = length + 1;
+			convPos = convPos - 1;
+
+			*convPos = sign;
+		}
+
+		if (precision > bare) {
+			zeroPad = precision - bare;
+		}
+
+		goto emit;
 	}
-}
-	goto nextChar;
+
+zeroFill:
+	if ((flags & 0x8) != 0 && width > 0) {
+		wchar* at = convPos;
+		s32 len;
+
+		if (at != NULL) {
+			len = 0;
+
+			while (*at != 0) {
+				len = len + 1;
+				at  = at + 1;
+			}
+		} else {
+			len = 0;
+		}
+
+		if (*convPos == 0x2D) {
+			len = len - 1;
+		}
+
+		if (width > len) {
+			zeroPad = width - len;
+		}
+	}
+
+	if (*convPos == 0x2D || sign != 0) {
+		if (*convPos != 0x2D) {
+			convPos = convPos - 1;
+
+			*convPos = sign;
+		}
+
+		if (zeroPad > 0) {
+			zeroPad = zeroPad - 1;
+		}
+	}
+
+	{
+		wchar* at = convPos;
+
+		if (at != NULL) {
+			length = 0;
+
+			while (*at != 0) {
+				length = length + 1;
+				at     = at + 1;
+			}
+		} else {
+			length = 0;
+		}
+	}
+
+	goto emit;
 
 emit:
 	if ((flags & 0x1) != 0) {
@@ -703,6 +685,24 @@ emit:
 		emitChar(&st, 0x20);
 		width = width - 1;
 	}
+
+floating:
+	goto zeroFill;
+
+storeCount: {
+	void* at = (void*)ARG_INT;
+
+	convPos = (wchar*)at;
+
+	if ((flags & 0x10) != 0) {
+		*(s32*)at = st.total;
+	} else if ((flags & 0x200) != 0) {
+		*(s16*)at = (s16)st.total;
+	} else {
+		*(s32*)at = st.total;
+	}
+}
+	goto nextChar;
 
 done:
 	for (;;) {

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -171,11 +171,11 @@ extern "C" s32 wideFormatCore(
 	wchar sign;
 	s32 base;
 	s32 hexBias;
-	s32 value;
+	u32 value;
 	s32 isSigned;
 	s32 length;
 	s32 isWide;
-	s32 zeroPad;
+	u32 zeroPad;
 	const wchar* specAt;
 	wchar* bufBase;
 	wchar* bufNext;

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -605,9 +605,20 @@ string:
 		}
 	}
 
-	{
+	if (isWide != 0) {
 		s32 room  = precision >= 0 ? precision : 0x7FFFFFFF;
 		wchar* at = convPos;
+
+		length = 0;
+
+		while (room != 0 && *at != 0) {
+			room   = room - 1;
+			length = length + 1;
+			at     = at + 1;
+		}
+	} else {
+		s32 room = precision >= 0 ? precision : 0x7FFFFFFF;
+		s8* at   = (s8*)convPos;
 
 		length = 0;
 

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -439,7 +439,7 @@ fetch:
 			end = digits;
 
 			do {
-				*end++ = (wchar)(s8)((u32)value % (u32)base);
+				*end++ = (wchar)(s8)(value - value / (u32)base * (u32)base);
 				value  = (s32)((u32)value / (u32)base);
 			} while (value != 0);
 

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -249,8 +249,28 @@ nextChar:
 					}
 					flags |= 0x1;
 					break;
-				case 0x02: // *
+				case 0x02: { // *
+					s32 given = ARG_INT;
+
+					if (state < 2) {
+						if (given < 0) {
+							width = -given;
+							flags |= 0x2;
+						} else {
+							width = given;
+						}
+
+						state = 3;
+					} else {
+						if (state != 4) {
+							goto done;
+						}
+
+						precision = given;
+						state     = state + 1;
+					}
 					break;
+				}
 				case 0x03: // -
 					if (state != 0) {
 						goto done;

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -171,6 +171,7 @@ extern "C" s32 wideFormatCore(
 	s32 length;
 	s32 isWide;
 	s32 zeroPad;
+	const wchar* specAt;
 	State st;
 
 	fmt         = format;
@@ -202,6 +203,7 @@ extern "C" s32 wideFormatCore(
 		continue;
 
 	spec:
+		specAt    = fmt - 1;
 		state     = 0;
 		flags     = 0;
 		width     = -1;
@@ -504,10 +506,24 @@ emit:
 		emitChar(&st, c);
 	}
 
-finish:
 done:
+	for (;;) {
+		c = *specAt++;
+
+		if (c == 0) {
+			break;
+		}
+
+		emitChar(&st, c);
+	}
+
+finish:
 	if (st.held != 0) {
-		write(st.out, st.held, st.writeArg);
+		if (st.write(st.out, st.held, st.writeArg) == NULL) {
+			st.failed = 1;
+		}
+
+		st.held = 0;
 	}
 
 	return st.failed != 0 ? -1 : st.total;

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -115,8 +115,8 @@ static const u8 charClass[96] = {
 };
 
 // The conversion buffer and the cursor into it, both file scope.
-static char narrowNull[] = "(null)";
-static wchar wideNull[6] = { 0, 0, 0, 0, 0, 0 };
+static char narrowNull[8] = "(null)";
+static wchar wideNull[6]  = { 0, 0, 0, 0, 0, 0 };
 static wchar convBuf[48];
 static wchar* convPos;
 

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -675,10 +675,8 @@ emit:
 		zeroPad = zeroPad - 1;
 	}
 
-	if (length != 0) {
-		width = width - length;
-
-		do {
+	if ((flags & 0x2) != 0) {
+		while (length != 0) {
 			wchar ch = *convPos;
 
 			convPos = convPos + 1;
@@ -686,7 +684,18 @@ emit:
 			emitChar(&st, ch);
 
 			length = length - 1;
-		} while (length != 0);
+			width  = width - 1;
+		}
+	} else {
+		while (length != 0) {
+			wchar ch = *convPos;
+
+			convPos = convPos + 1;
+
+			emitChar(&st, ch);
+
+			length = length - 1;
+		}
 	}
 
 	while (width > 0) {

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -178,7 +178,6 @@ extern "C" s32 wideFormatCore(
 	u32 zeroPad;
 	const wchar* specAt;
 	wchar* bufBase;
-	wchar* bufNext;
 	State st;
 
 	fmt         = format;
@@ -190,7 +189,6 @@ extern "C" s32 wideFormatCore(
 	st.limitAt  = hasLimit != 0 ? &limit : NULL;
 
 	bufBase = convBuf;
-	bufNext = convBuf + 1;
 
 nextChar:
 	for (;;) {
@@ -415,11 +413,11 @@ fetch:
 		value = ARG_INT;
 	}
 
-	convPos = bufNext;
+	convPos = (convBuf + 1);
 
 	if (value == 0) {
 		if (precision == 0) {
-			*bufNext = 0;
+			*(convBuf + 1) = 0;
 			goto padded;
 		}
 	} else {
@@ -496,10 +494,10 @@ character:
 		convPos           = convBuf;
 		length            = 1;
 	} else {
-		convBuf[0] = (wchar)ARG_INT;
-		*bufNext   = 0;
-		convPos    = convBuf;
-		length     = 1;
+		convBuf[0]     = (wchar)ARG_INT;
+		*(convBuf + 1) = 0;
+		convPos        = convBuf;
+		length         = 1;
 	}
 	goto emit;
 

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -618,6 +618,30 @@ emit:
 		emitChar(&st, c);
 	}
 
+	while (zeroPad != 0) {
+		emitChar(&st, 0x30);
+		zeroPad = zeroPad - 1;
+	}
+
+	if (length != 0) {
+		width = width - length;
+
+		do {
+			wchar ch = *convPos;
+
+			convPos = convPos + 1;
+
+			emitChar(&st, ch);
+
+			length = length - 1;
+		} while (length != 0);
+	}
+
+	while (width > 0) {
+		emitChar(&st, 0x20);
+		width = width - 1;
+	}
+
 done:
 	for (;;) {
 		c = *specAt++;

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -164,8 +164,8 @@ extern "C" s32 wideFormatCore(
 	u32* limitAt;
 	const wchar* fmt;
 	wchar c;
-	s32 state;
-	s32 flags;
+	u32 state;
+	u32 flags;
 	s32 width;
 	s32 precision;
 	wchar sign;

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -132,7 +132,7 @@ struct State {
 	s32 held;      // 0x130
 	WriteProc write;
 	void* writeArg;
-	s32 total;    // 0x13C
+	u32 total;    // 0x13C
 	s32 failed;   // 0x140
 	u32* limitAt; // 0x144
 };
@@ -147,7 +147,7 @@ static inline void emitChar(State* s, wchar c)
 		s->held = 0;
 	}
 
-	if (s->limitAt == NULL || s->total < (s32)*s->limitAt) {
+	if (s->limitAt == NULL || (u32)s->total < *s->limitAt) {
 		s->out[s->held] = c;
 		s->held         = s->held + 1;
 	}

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -407,6 +407,36 @@ fetch:
 	}
 
 padded:
+	if (precision >= 0) {
+		wchar* at = convPos;
+		s32 bare;
+
+		if (at != NULL) {
+			length = 0;
+
+			while (*at != 0) {
+				length = length + 1;
+				at     = at + 1;
+			}
+		} else {
+			length = 0;
+		}
+
+		bare = length;
+
+		if (*convPos == 0x2D) {
+			bare = length - 1;
+		} else if (sign != 0) {
+			length  = length + 1;
+			convPos = convPos - 1;
+
+			*convPos = sign;
+		}
+
+		if (precision > bare) {
+			zeroPad = precision - bare;
+		}
+	}
 	goto emit;
 
 pointer: {

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -303,7 +303,21 @@ nextChar:
 					precision = precision + 1;
 					break;
 				case 0x05: // 1 to 9
-					goto digit;
+				digit:
+					if (state <= 2) {
+						state = 2;
+						if (width == -1) {
+							width = (wchar)(c - 0x30);
+						} else {
+							width = (wchar)(c - 0x30) + width * 10;
+						}
+					} else {
+						if (state != 4) {
+							goto done;
+						}
+						precision = (wchar)(c - 0x30) + precision * 10;
+					}
+					break;
 				case 0x06: // l
 					flags |= 0x10;
 					state = 5;
@@ -364,21 +378,6 @@ nextChar:
 			}
 
 			continue;
-
-		digit:
-			if (state <= 2) {
-				state = 2;
-				if (width == -1) {
-					width = (wchar)(c - 0x30);
-				} else {
-					width = (wchar)(c - 0x30) + width * 10;
-				}
-			} else {
-				if (state != 4) {
-					goto done;
-				}
-				precision = (wchar)(c - 0x30) + precision * 10;
-			}
 		}
 	}
 

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -327,7 +327,24 @@ nextChar:
 					flags |= 0x20;
 					state = 5;
 					break;
-				case 0x1A: // I
+				case 0x1A: // I64, I32, I16 and I8
+					if (fmt[0] == 0x36 && fmt[1] == 0x34) {
+						fmt += 2;
+						flags = (flags | 0x100) & ~0x210;
+						state = 5;
+					} else if (fmt[0] == 0x33 && fmt[1] == 0x32) {
+						fmt += 2;
+						flags = (flags | 0x10) & ~0x300;
+						state = 5;
+					} else if (fmt[0] == 0x31 && fmt[1] == 0x36) {
+						fmt += 2;
+						flags = (flags | 0x200) & ~0x110;
+						state = 5;
+					} else if (fmt[0] == 0x38) {
+						fmt += 1;
+						flags = flags & ~0x310;
+						state = 5;
+					}
 					break;
 			}
 

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -120,6 +120,36 @@ static wchar wideNull[6] = { 0, 0, 0, 0, 0, 0 };
 static wchar convBuf[48];
 static wchar* convPos;
 
+// Inlined at every site that emits one character. The flush computes a flag the
+// call never reads, which is this helper's dead parameter on that path.
+struct State {
+	wchar out[80]; // 0x90
+	s32 held;      // 0x130
+	WriteProc write;
+	void* writeArg;
+	s32 total;    // 0x13C
+	s32 failed;   // 0x140
+	u32* limitAt; // 0x144
+};
+
+static void emitChar(State* s, wchar c)
+{
+	if (s->held >= 0x50 && s->held != 0) {
+		if (s->write(s->out, s->held, s->writeArg) == NULL) {
+			s->failed = 1;
+		}
+
+		s->held = 0;
+	}
+
+	if (s->limitAt == NULL || s->total < (s32)*s->limitAt) {
+		s->out[s->held] = c;
+		s->held         = s->held + 1;
+	}
+
+	s->total = s->total + 1;
+}
+
 extern "C" s32 wideFormatCore(
     WriteProc write, void* writeArg, const wchar* format, s32 hasLimit, u32 limit, void* args)
 {

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -435,8 +435,8 @@ fetch:
 			end = digits;
 
 			do {
-				*end++ = (wchar)(value - value / base * base);
-				value  = value / base;
+				*end++ = (wchar)(s8)((u32)value % (u32)base);
+				value  = (s32)((u32)value / (u32)base);
 			} while (value != 0);
 
 			while (end != digits) {

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -132,7 +132,7 @@ struct State {
 	u32* limitAt; // 0x144
 };
 
-static void emitChar(State* s, wchar c)
+static inline void emitChar(State* s, wchar c)
 {
 	if (s->held >= 0x50 && s->held != 0) {
 		if (s->write(s->out, s->held, s->writeArg) == NULL) {
@@ -153,7 +153,6 @@ static void emitChar(State* s, wchar c)
 extern "C" s32 wideFormatCore(
     WriteProc write, void* writeArg, const wchar* format, s32 hasLimit, u32 limit, void* args)
 {
-	wchar out[80];
 	s32 held;
 	s32 total;
 	s32 failed;
@@ -171,12 +170,16 @@ extern "C" s32 wideFormatCore(
 	s32 isSigned;
 	s32 length;
 	s32 isWide;
+	s32 zeroPad;
+	State st;
 
-	fmt     = format;
-	held    = 0;
-	total   = 0;
-	failed  = 0;
-	limitAt = hasLimit != 0 ? &limit : NULL;
+	fmt         = format;
+	st.held     = 0;
+	st.total    = 0;
+	st.failed   = 0;
+	st.write    = write;
+	st.writeArg = writeArg;
+	st.limitAt  = hasLimit != 0 ? &limit : NULL;
 
 	for (;;) {
 		c = *fmt++;
@@ -195,20 +198,7 @@ extern "C" s32 wideFormatCore(
 			fmt++;
 		}
 
-		if (held >= 0x50 && held != 0) {
-			if (write(out, held, writeArg) == NULL) {
-				failed = 1;
-			}
-
-			held = 0;
-		}
-
-		if (limitAt == NULL || total < (s32)*limitAt) {
-			out[held] = c;
-			held      = held + 1;
-		}
-
-		total = total + 1;
+		emitChar(&st, c);
 		continue;
 
 	spec:
@@ -484,11 +474,41 @@ string:
 floating:
 storeCount:
 emit:
-finish:
-done:
-	if (held != 0) {
-		write(out, held, writeArg);
+	if ((flags & 0x1) != 0) {
+		if (c == 0x6F) {
+			if (zeroPad <= 0) {
+				zeroPad = 1;
+			}
+		} else if (c == 0x78 || c == 0x58) {
+			flags |= 0x40;
+			width   = width - 2;
+			zeroPad = zeroPad - 2;
+
+			if (zeroPad < 0) {
+				zeroPad = 0;
+			}
+		}
 	}
 
-	return failed != 0 ? -1 : total;
+	length = length + zeroPad;
+
+	if ((flags & 0x2) == 0) {
+		while (width > length) {
+			emitChar(&st, 0x20);
+			width = width - 1;
+		}
+	}
+
+	if ((flags & 0x40) != 0) {
+		emitChar(&st, 0x30);
+		emitChar(&st, c);
+	}
+
+finish:
+done:
+	if (st.held != 0) {
+		write(st.out, st.held, st.writeArg);
+	}
+
+	return st.failed != 0 ? -1 : st.total;
 }

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -440,6 +440,7 @@ padded:
 		goto emit;
 	}
 
+zeroFill:
 	if ((flags & 0x8) != 0 && width > 0) {
 		wchar* at = convPos;
 		s32 len;
@@ -559,7 +560,7 @@ string:
 	goto emit;
 
 floating:
-	goto emit;
+	goto zeroFill;
 
 storeCount: {
 	void* at = (void*)ARG_INT;

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -182,6 +182,7 @@ extern "C" s32 wideFormatCore(
 	st.writeArg = writeArg;
 	st.limitAt  = hasLimit != 0 ? &limit : NULL;
 
+nextChar:
 	for (;;) {
 		c = *fmt++;
 
@@ -474,7 +475,23 @@ string:
 	goto emit;
 
 floating:
-storeCount:
+	goto emit;
+
+storeCount: {
+	void* at = (void*)ARG_INT;
+
+	convPos = (wchar*)at;
+
+	if ((flags & 0x10) != 0) {
+		*(s32*)at = st.total;
+	} else if ((flags & 0x200) != 0) {
+		*(s16*)at = (s16)st.total;
+	} else {
+		*(s32*)at = st.total;
+	}
+}
+	goto nextChar;
+
 emit:
 	if ((flags & 0x1) != 0) {
 		if (c == 0x6F) {

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -374,15 +374,15 @@ nextChar:
 			if (state <= 2) {
 				state = 2;
 				if (width == -1) {
-					width = c - 0x30;
+					width = (wchar)(c - 0x30);
 				} else {
-					width = (c - 0x30) + width * 10;
+					width = (wchar)(c - 0x30) + width * 10;
 				}
 			} else {
 				if (state != 4) {
 					goto done;
 				}
-				precision = (c - 0x30) + precision * 10;
+				precision = (wchar)(c - 0x30) + precision * 10;
 			}
 		}
 	}

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -177,6 +177,8 @@ extern "C" s32 wideFormatCore(
 	s32 isWide;
 	s32 zeroPad;
 	const wchar* specAt;
+	wchar* bufBase;
+	wchar* bufNext;
 	State st;
 
 	fmt         = format;
@@ -186,6 +188,9 @@ extern "C" s32 wideFormatCore(
 	st.write    = write;
 	st.writeArg = writeArg;
 	st.limitAt  = hasLimit != 0 ? &limit : NULL;
+
+	bufBase = convBuf;
+	bufNext = convBuf + 1;
 
 nextChar:
 	for (;;) {
@@ -367,11 +372,11 @@ fetch:
 		value = ARG_INT;
 	}
 
-	convPos = convBuf + 1;
+	convPos = bufNext;
 
 	if (value == 0) {
 		if (precision == 0) {
-			convBuf[1] = 0;
+			*bufNext = 0;
 			goto padded;
 		}
 	} else {
@@ -531,12 +536,12 @@ character:
 
 	if ((flags & 0x200) != 0) {
 		((s8*)convBuf)[0] = (s8)ARG_INT;
-		((s8*)convBuf)[1] = 0;
+		((s8*)bufBase)[1] = 0;
 		convPos           = convBuf;
 		length            = 1;
 	} else {
 		convBuf[0] = (wchar)ARG_INT;
-		convBuf[1] = 0;
+		*bufNext   = 0;
 		convPos    = convBuf;
 		length     = 1;
 	}

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -1,0 +1,464 @@
+#include "types.h"
+
+// The formatter core the buffer entry in game/wide_format_write.cpp calls.
+// See notes/wide-formatter-core.md for the section map and the decoded class
+// table.
+
+typedef u16 wchar;
+
+extern "C" void* memcpy(void* dst, const void* src, u32 size);
+extern "C" void* __va_arg(void* ap, s32 kind);
+
+#define ARG_INT (*(s32*)__va_arg(args, 1))
+
+typedef void* (*WriteProc)(const wchar* src, u32 count, void* arg);
+
+// Character classes, indexed by the format character less 0x20. Anything above
+// 0x1A leaves the character alone.
+static const u8 charClass[96] = {
+	0x00,
+	0x16,
+	0x16,
+	0x01,
+	0x16,
+	0x17,
+	0x16,
+	0x16, // 0x20
+	0x16,
+	0x16,
+	0x02,
+	0x00,
+	0x16,
+	0x03,
+	0x04,
+	0x16, // 0x28
+	0x09,
+	0x05,
+	0x05,
+	0x05,
+	0x05,
+	0x05,
+	0x05,
+	0x05, // 0x30
+	0x05,
+	0x05,
+	0x16,
+	0x16,
+	0x16,
+	0x16,
+	0x16,
+	0x16, // 0x38
+	0x16,
+	0x16,
+	0x16,
+	0x12,
+	0x16,
+	0x0F,
+	0x19,
+	0x0F, // 0x40
+	0x08,
+	0x1A,
+	0x16,
+	0x16,
+	0x07,
+	0x16,
+	0x18,
+	0x16, // 0x48
+	0x16,
+	0x16,
+	0x16,
+	0x13,
+	0x16,
+	0x16,
+	0x16,
+	0x16, // 0x50
+	0x0D,
+	0x16,
+	0x16,
+	0x16,
+	0x16,
+	0x16,
+	0x16,
+	0x16, // 0x58
+	0x16,
+	0x16,
+	0x16,
+	0x10,
+	0x0A,
+	0x0F,
+	0x0F,
+	0x0F, // 0x60
+	0x08,
+	0x0A,
+	0x16,
+	0x16,
+	0x06,
+	0x16,
+	0x14,
+	0x0B, // 0x68
+	0x0E,
+	0x16,
+	0x16,
+	0x11,
+	0x16,
+	0x0C,
+	0x16,
+	0x16, // 0x70
+	0x0D,
+	0x16,
+	0x16,
+	0x16,
+	0x16,
+	0x16,
+	0x16,
+	0x16, // 0x78
+};
+
+// The conversion buffer and the cursor into it, both file scope.
+static char narrowNull[] = "(null)";
+static wchar wideNull[6] = { 0, 0, 0, 0, 0, 0 };
+static wchar convBuf[48];
+static wchar* convPos;
+
+extern "C" s32 wideFormatCore(
+    WriteProc write, void* writeArg, const wchar* format, s32 hasLimit, u32 limit, void* args)
+{
+	wchar out[80];
+	s32 held;
+	s32 total;
+	s32 failed;
+	u32* limitAt;
+	const wchar* fmt;
+	wchar c;
+	s32 state;
+	s32 flags;
+	s32 width;
+	s32 precision;
+	wchar sign;
+	s32 base;
+	s32 hexBias;
+	s32 value;
+	s32 isSigned;
+	s32 length;
+	s32 isWide;
+
+	fmt     = format;
+	held    = 0;
+	total   = 0;
+	failed  = 0;
+	limitAt = hasLimit != 0 ? &limit : NULL;
+
+	for (;;) {
+		c = *fmt++;
+
+		if (c == 0) {
+			goto finish;
+		}
+
+		if (c == 0x25) {
+			c = *fmt;
+
+			if (c != 0x25) {
+				goto spec;
+			}
+
+			fmt++;
+		}
+
+		if (held >= 0x50 && held != 0) {
+			if (write(out, held, writeArg) == NULL) {
+				failed = 1;
+			}
+
+			held = 0;
+		}
+
+		if (limitAt == NULL || total < (s32)*limitAt) {
+			out[held] = c;
+			held      = held + 1;
+		}
+
+		total = total + 1;
+		continue;
+
+	spec:
+		state     = 0;
+		flags     = 0;
+		width     = -1;
+		precision = -1;
+		sign      = 0;
+		base      = 10;
+		hexBias   = 0;
+
+		for (;;) {
+			c = *fmt++;
+
+			if (c < 0x20) {
+				goto done;
+			}
+
+			if ((s32)c > 0x7F) {
+				goto done;
+			}
+
+			switch (charClass[c - 0x20]) {
+				case 0x00: // space and +
+					if (state != 0) {
+						goto done;
+					}
+					if (sign != 0x2B) {
+						sign = c;
+					}
+					break;
+				case 0x01: // #
+					if (state != 0) {
+						goto done;
+					}
+					flags |= 0x1;
+					break;
+				case 0x02: // *
+					break;
+				case 0x03: // -
+					if (state != 0) {
+						goto done;
+					}
+					flags |= 0x2;
+					break;
+				case 0x04: // .
+					if (state >= 4) {
+						goto done;
+					}
+					state     = 4;
+					precision = precision + 1;
+					break;
+				case 0x05: // 1 to 9
+					goto digit;
+				case 0x06: // l
+					flags |= 0x10;
+					state = 5;
+					break;
+				case 0x07: // L
+					flags = (flags | 0x100) & ~0x10;
+					state = 5;
+					break;
+				case 0x08: // h and H
+					flags = (flags | 0x200) & ~0x10;
+					state = 5;
+					break;
+				case 0x09: // 0
+					if (state != 0) {
+						goto digit;
+					}
+					if ((flags & 0x2) != 0) {
+						break;
+					}
+					flags |= 0x8;
+					state = 1;
+					break;
+				case 0x0A: // d and i
+					base = 10;
+					goto integer;
+				case 0x0B: // o
+					base = 8;
+					goto unsignedInteger;
+				case 0x0C: // u
+					base = 10;
+					goto unsignedInteger;
+				case 0x0D: // x and X
+					base    = 16;
+					hexBias = c - 0x17;
+					goto unsignedInteger;
+				case 0x0E: // p
+					goto pointer;
+				case 0x0F: // e f g E G
+					goto floating;
+				case 0x10: // c
+					goto character;
+				case 0x11: // s
+					goto string;
+				case 0x12: // C
+					goto character;
+				case 0x13: // S
+					goto string;
+				case 0x14: // n
+					goto storeCount;
+				case 0x15:
+				case 0x16:
+				case 0x17:
+					goto done;
+				case 0x18: // N
+					flags &= ~0x20;
+					state = 5;
+					break;
+				case 0x19: // F
+					flags |= 0x20;
+					state = 5;
+					break;
+				case 0x1A: // I
+					break;
+			}
+
+			continue;
+
+		digit:
+			if (state <= 2) {
+				state = 2;
+				if (width == -1) {
+					width = c - 0x30;
+				} else {
+					width = (c - 0x30) + width * 10;
+				}
+			} else {
+				if (state != 4) {
+					goto done;
+				}
+				precision = (c - 0x30) + precision * 10;
+			}
+		}
+	}
+
+integer:
+	base     = 10;
+	isSigned = 1;
+	goto fetch;
+
+unsignedInteger:
+	sign     = 0;
+	isSigned = 0;
+
+fetch:
+	if ((flags & 0x100) != 0) {
+		value = ARG_INT;
+	} else if ((flags & 0x10) != 0) {
+		value = ARG_INT;
+	} else if ((flags & 0x200) != 0) {
+		s32 narrow = (u16)ARG_INT;
+
+		value = isSigned != 0 ? (s16)narrow : narrow;
+	} else {
+		value = ARG_INT;
+	}
+
+	convPos = convBuf + 1;
+
+	if (value == 0) {
+		if (precision == 0) {
+			convBuf[1] = 0;
+			goto padded;
+		}
+	} else {
+		flags |= 0x4;
+	}
+
+	{
+		wchar* at = convPos;
+
+		if (base >= 2 && base <= 0x24) {
+			wchar digits[48];
+			wchar* end;
+
+			if (value < 0 && isSigned != 0) {
+				*at++ = 0x2D;
+				value = -value;
+			}
+
+			end = digits;
+
+			do {
+				*end++ = (wchar)(value - value / base * base);
+				value  = value / base;
+			} while (value != 0);
+
+			while (end != digits) {
+				wchar d = *--end;
+
+				if (d < 10) {
+					*at++ = (wchar)(d + 0x30);
+				} else {
+					*at++ = (wchar)(d + hexBias - 10);
+				}
+			}
+		}
+
+		*at = 0;
+	}
+
+padded:
+	goto emit;
+
+pointer: {
+	u32 v = (u32)ARG_INT;
+	wchar* at;
+	s32 n;
+
+	convPos = convBuf;
+	at      = convBuf + 7;
+
+	for (n = 2; n != 0; n--) {
+		s32 i;
+
+		for (i = 0; i < 4; i++) {
+			s32 d = v & 0xF;
+
+			*at-- = (wchar)(d < 10 ? d + 0x30 : d + 0x37);
+			v >>= 4;
+		}
+	}
+
+	convBuf[8] = 0;
+	flags &= ~0x4;
+	convPos = convBuf;
+}
+	goto emit;
+
+character:
+	if ((flags & 0x210) == 0) {
+		flags |= 0x200;
+	}
+
+	if ((flags & 0x200) != 0) {
+		((s8*)convBuf)[0] = (s8)ARG_INT;
+		((s8*)convBuf)[1] = 0;
+		convPos           = convBuf;
+		length            = 1;
+	} else {
+		convBuf[0] = (wchar)ARG_INT;
+		convBuf[1] = 0;
+		convPos    = convBuf;
+		length     = 1;
+	}
+	goto emit;
+
+string:
+	if ((flags & 0x210) == 0) {
+		flags |= 0x200;
+	}
+
+	if ((flags & 0x200) != 0) {
+		convPos = (wchar*)ARG_INT;
+		isWide  = 0;
+
+		if (convPos == NULL) {
+			convPos = (wchar*)narrowNull;
+		}
+	} else {
+		convPos = (wchar*)ARG_INT;
+		isWide  = 1;
+
+		if (convPos == NULL) {
+			convPos = wideNull;
+		}
+	}
+	goto emit;
+
+floating:
+storeCount:
+emit:
+finish:
+done:
+	if (held != 0) {
+		write(out, held, writeArg);
+	}
+
+	return failed != 0 ? -1 : total;
+}

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -235,6 +235,18 @@ nextChar:
 			}
 
 			switch (charClass[c - 0x20]) {
+				case 0x01: // #
+					if (state != 0) {
+						goto done;
+					}
+					flags |= 0x1;
+					break;
+				case 0x03: // -
+					if (state != 0) {
+						goto done;
+					}
+					flags |= 0x2;
+					break;
 				case 0x00: // space and +
 					if (state != 0) {
 						goto done;
@@ -243,11 +255,23 @@ nextChar:
 						sign = c;
 					}
 					break;
-				case 0x01: // #
+				case 0x18: // N
+					flags &= ~0x20;
+					state = 5;
+					break;
+				case 0x19: // F
+					flags |= 0x20;
+					state = 5;
+					break;
+				case 0x09: // 0
 					if (state != 0) {
-						goto done;
+						goto digit;
 					}
-					flags |= 0x1;
+					if ((flags & 0x2) != 0) {
+						break;
+					}
+					flags |= 0x8;
+					state = 1;
 					break;
 				case 0x02: { // *
 					s32 given = ARG_INT;
@@ -271,12 +295,6 @@ nextChar:
 					}
 					break;
 				}
-				case 0x03: // -
-					if (state != 0) {
-						goto done;
-					}
-					flags |= 0x2;
-					break;
 				case 0x04: // .
 					if (state >= 4) {
 						goto done;
@@ -298,50 +316,6 @@ nextChar:
 					flags = (flags | 0x200) & ~0x10;
 					state = 5;
 					break;
-				case 0x09: // 0
-					if (state != 0) {
-						goto digit;
-					}
-					if ((flags & 0x2) != 0) {
-						break;
-					}
-					flags |= 0x8;
-					state = 1;
-					break;
-				case 0x0A: // d and i
-					goto integer;
-				case 0x0B: // o
-					goto octal;
-				case 0x0C: // u
-					goto unsignedDecimal;
-				case 0x0D: // x and X
-					goto hexadecimal;
-				case 0x0E: // p
-					goto pointer;
-				case 0x0F: // e f g E G
-					goto floating;
-				case 0x10: // c
-					goto character;
-				case 0x11: // s
-					goto string;
-				case 0x12: // C
-					goto narrowCharDefault;
-				case 0x13: // S
-					goto narrowStringDefault;
-				case 0x14: // n
-					goto storeCount;
-				case 0x15:
-				case 0x16:
-				case 0x17:
-					goto done;
-				case 0x18: // N
-					flags &= ~0x20;
-					state = 5;
-					break;
-				case 0x19: // F
-					flags |= 0x20;
-					state = 5;
-					break;
 				case 0x1A: // I64, I32, I16 and I8
 					if (fmt[0] == 0x36 && fmt[1] == 0x34) {
 						fmt += 2;
@@ -361,6 +335,32 @@ nextChar:
 						state = 5;
 					}
 					break;
+				case 0x0B: // o
+					goto octal;
+				case 0x0C: // u
+					goto unsignedDecimal;
+				case 0x0D: // x and X
+					goto hexadecimal;
+				case 0x0A: // d and i
+					goto integer;
+				case 0x0E: // p
+					goto pointer;
+				case 0x12: // C
+					goto narrowCharDefault;
+				case 0x10: // c
+					goto character;
+				case 0x13: // S
+					goto narrowStringDefault;
+				case 0x11: // s
+					goto string;
+				case 0x0F: // e f g E G
+					goto floating;
+				case 0x14: // n
+					goto storeCount;
+				case 0x15:
+				case 0x16:
+				case 0x17:
+					goto done;
 			}
 
 			continue;

--- a/src/game/wide_format_core.cpp
+++ b/src/game/wide_format_core.cpp
@@ -115,8 +115,8 @@ static const u8 charClass[96] = {
 };
 
 // The conversion buffer and the cursor into it, both file scope.
-static char narrowNull[8] = "(null)";
-static wchar wideNull[6]  = { 0, 0, 0, 0, 0, 0 };
+static char narrowNull[] = "(null)";
+static wchar wideNull[6] = { 0, 0, 0, 0, 0, 0 };
 static wchar convBuf[48];
 static wchar* convPos;
 


### PR DESCRIPTION
## What

Carves `game/wide_format_core.cpp` at `0x8013A6B8`, the formatter core that
`game/wide_format_write.cpp` calls. **This lands as the repository's first
`NonMatching` object.** The reconstruction is at 605 of 1069 instructions and
is not linked, so all eighteen artifact hashes still verify; the automatic
split still supplies that range.

## Why land it now

The unit is structurally complete and every measurable property already
reproduces the target. Keeping it on a branch risks losing the evidence below,
which took a long series of measured experiments to establish.

## What already matches exactly

| property | result |
| --- | --- |
| `.rodata` character class table | 96 bytes, byte for byte |
| `.data` | `0x78` — jump table plus the wide null |
| `.sdata`, `.bss`, `.sbss` | `0x07`, `0x60`, `0x08` |
| `extab` / `extabindex` | `0x08` / `0x0C` |
| switch emission order | 27 of 27 case bodies |
| indirect calls | 10 of 10 |
| `divwu` per digit | 2 of 2 |
| callee-saved set | `r18`–`r31` |
| frame layout | `digits[66]` at `0xC`, state at `0x90`, saves at `0x148` |

## Settled facts, recorded in notes/wide-formatter-core.md

- **There is no float conversion.** The jump table entry for class `0x0F`
  points at the shared padding block, and the function contains zero floating
  point instructions across all 1069.
- The 96-byte class table is decoded character by character.
- `I64`/`I32`/`I16`/`I8` prefixes are parsed inline with masks
  `(flags|0x100)&~0x210`, `(flags|0x10)&~0x300`, `(flags|0x200)&~0x110`,
  `flags&~0x310`.
- Emission order follows the labelled blocks after the switch, not the `case`
  lines, because a case whose body is a `goto` has no body of its own.
- `clrlwi rX,rX,16` means a cast to `wchar`; `extsb` means `s8`; `divwu` means
  the operand is `u32`.

## What remains

139 instructions, categorised as 112 operand differences, 88 opcode
differences and 34 register-only — expression reconstruction, not allocation.
The cumulative drift map localises them: `-21` at target 288, `-74` at 441
(53 missing in the integer conversion), `-44` at 544 (about 30 extra in the
precision block).

Ruled out by measurement and recorded so they are not retried: compiler
version, the signedness sweep beyond what is applied, declaration order beyond
`flags`/`length`, per-comparison casts, `emitChar` without `inline`,
`flushBuffer` extraction, `digits` at function scope, manual `%p` unrolling,
and every loop-form rewrite.

## Verification

- [x] `ninja` links
- [x] `sha1sum -c config/G9SE8P/build.sha1` — **18/18 OK**
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `python tools/check_language_policy.py --staged`
- [x] `clang-format -i`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
