### PR TITLE
feat: match object default helpers

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -120,6 +120,9 @@ game/action_cont3.cpp:
 game/action_cont4.cpp:
 	.text       start:0x8001D754 end:0x8001D764
 
+game/object_defaults.cpp:
+	.text       start:0x8001ED40 end:0x8001ED60
+
 game/modeswitch.cpp:
 	extab       start:0x80005BA8 end:0x80005BC0
 	extabindex  start:0x8000C2A4 end:0x8000C2C8

--- a/configure.py
+++ b/configure.py
@@ -455,6 +455,7 @@ config.libs = [
         "cflags": cflags_base,
         "progress_category": "game",
         "objects": [
+            Object(Matching, "game/object_defaults.cpp"),
             Object(
                 Matching,
                 "game/skeleton.cpp",

--- a/src/game/object_defaults.cpp
+++ b/src/game/object_defaults.cpp
@@ -1,0 +1,30 @@
+#include "types.h"
+
+// Four adjacent virtual-style helpers operate on the same object layout. The
+// implicit object argument and paired scalar accessors identify C++ ownership.
+
+struct ObjectDefaults {
+	u8 pad00[0x28];
+	u32 state;
+};
+
+extern "C" {
+extern f32 lbl_8042CFE8;
+
+void fn_8001ED40(ObjectDefaults* object)
+{
+	object->state = 0;
+}
+
+void fn_8001ED4C() { }
+
+f32 fn_8001ED50()
+{
+	return lbl_8042CFE8;
+}
+
+f32 fn_8001ED58()
+{
+	return lbl_8042CFE8;
+}
+}


### PR DESCRIPTION
 Adds a compact C++ object-helper translation unit containing the default-state reset, empty virtual-style hook, and paired scalar accessors.

  All four functions and the complete owned text section were verified byte-for-byte in objdiff. The implicit object setter, adjacent no-op hook, paired accessors, and shared scalar
  reference establish the contiguous C++ helper boundary without relying on PS2 metadata for retail layout.

  The language-policy check and all 36 tests pass. The complete project links successfully, including every REL, and all 18 configured SHA-1 checks pass exactly.
