### PR TITLE
feat: match the checkpoint and goal ring field callbacks

### DIFF
--- a/config/G9SE8P/stage01D/splits.txt
+++ b/config/G9SE8P/stage01D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030
@@ -307,6 +310,9 @@ rel/propeller_register.cpp:
 
 rel/goal_ring_bind.cpp:
 	.text       start:0x0004D4F0 end:0x0004D54C
+
+rel/goal_ring_field.cpp:
+	.text       start:0x0004D54C end:0x0004D584
 
 rel/goal_ring_register.cpp:
 	.text       start:0x0004D584 end:0x0004D62C

--- a/config/G9SE8P/stage03D/splits.txt
+++ b/config/G9SE8P/stage03D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030
@@ -307,6 +310,9 @@ rel/propeller_register.cpp:
 
 rel/goal_ring_bind.cpp:
 	.text       start:0x0004D4F0 end:0x0004D54C
+
+rel/goal_ring_field.cpp:
+	.text       start:0x0004D54C end:0x0004D584
 
 rel/goal_ring_register.cpp:
 	.text       start:0x0004D584 end:0x0004D62C

--- a/config/G9SE8P/stage05D/splits.txt
+++ b/config/G9SE8P/stage05D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030
@@ -307,6 +310,9 @@ rel/propeller_register.cpp:
 
 rel/goal_ring_bind.cpp:
 	.text       start:0x0004D4F0 end:0x0004D54C
+
+rel/goal_ring_field.cpp:
+	.text       start:0x0004D54C end:0x0004D584
 
 rel/goal_ring_register.cpp:
 	.text       start:0x0004D584 end:0x0004D62C

--- a/config/G9SE8P/stage07D/splits.txt
+++ b/config/G9SE8P/stage07D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030
@@ -307,6 +310,9 @@ rel/propeller_register.cpp:
 
 rel/goal_ring_bind.cpp:
 	.text       start:0x0004D4F0 end:0x0004D54C
+
+rel/goal_ring_field.cpp:
+	.text       start:0x0004D54C end:0x0004D584
 
 rel/goal_ring_register.cpp:
 	.text       start:0x0004D584 end:0x0004D62C

--- a/config/G9SE8P/stage09D/splits.txt
+++ b/config/G9SE8P/stage09D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030
@@ -307,6 +310,9 @@ rel/propeller_register.cpp:
 
 rel/goal_ring_bind.cpp:
 	.text       start:0x0004D4F0 end:0x0004D54C
+
+rel/goal_ring_field.cpp:
+	.text       start:0x0004D54C end:0x0004D584
 
 rel/goal_ring_register.cpp:
 	.text       start:0x0004D584 end:0x0004D62C

--- a/config/G9SE8P/stage11D/splits.txt
+++ b/config/G9SE8P/stage11D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030
@@ -307,6 +310,9 @@ rel/propeller_register.cpp:
 
 rel/goal_ring_bind.cpp:
 	.text       start:0x0004D4F0 end:0x0004D54C
+
+rel/goal_ring_field.cpp:
+	.text       start:0x0004D54C end:0x0004D584
 
 rel/goal_ring_register.cpp:
 	.text       start:0x0004D584 end:0x0004D62C

--- a/config/G9SE8P/stage26D/splits.txt
+++ b/config/G9SE8P/stage26D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030

--- a/config/G9SE8P/stage27D/splits.txt
+++ b/config/G9SE8P/stage27D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030

--- a/config/G9SE8P/stage28D/splits.txt
+++ b/config/G9SE8P/stage28D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030

--- a/config/G9SE8P/stage31D/splits.txt
+++ b/config/G9SE8P/stage31D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030
@@ -307,6 +310,9 @@ rel/propeller_register.cpp:
 
 rel/goal_ring_bind.cpp:
 	.text       start:0x0004D4F0 end:0x0004D54C
+
+rel/goal_ring_field.cpp:
+	.text       start:0x0004D54C end:0x0004D584
 
 rel/goal_ring_register.cpp:
 	.text       start:0x0004D584 end:0x0004D62C

--- a/config/G9SE8P/stage32D/splits.txt
+++ b/config/G9SE8P/stage32D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030
@@ -307,6 +310,9 @@ rel/propeller_register.cpp:
 
 rel/goal_ring_bind.cpp:
 	.text       start:0x0004D4F0 end:0x0004D54C
+
+rel/goal_ring_field.cpp:
+	.text       start:0x0004D54C end:0x0004D584
 
 rel/goal_ring_register.cpp:
 	.text       start:0x0004D584 end:0x0004D62C

--- a/config/G9SE8P/stage33D/splits.txt
+++ b/config/G9SE8P/stage33D/splits.txt
@@ -170,6 +170,9 @@ rel/checkpoint_edit.cpp:
 rel/checkpoint_bind.cpp:
 	.text       start:0x00010A38 end:0x00010A94
 
+rel/checkpoint_field.cpp:
+	.text       start:0x00010A94 end:0x00010ACC
+
 rel/checkpoint_register.cpp:
 	.text       start:0x00010ACC end:0x00010B74
 	.ctors      start:0x0000002C end:0x00000030
@@ -307,6 +310,9 @@ rel/propeller_register.cpp:
 
 rel/goal_ring_bind.cpp:
 	.text       start:0x0004D4F0 end:0x0004D54C
+
+rel/goal_ring_field.cpp:
+	.text       start:0x0004D54C end:0x0004D584
 
 rel/goal_ring_register.cpp:
 	.text       start:0x0004D584 end:0x0004D62C

--- a/configure.py
+++ b/configure.py
@@ -1569,6 +1569,16 @@ config.libs = [
             ),
             Object(
                 Matching,
+                "rel/goal_ring_field.cpp",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
+                "rel/checkpoint_field.cpp",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "rel/checkpoint_bind.cpp",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/rel/checkpoint_field.cpp
+++ b/src/rel/checkpoint_field.cpp
@@ -1,0 +1,39 @@
+#include "types.h"
+
+// The field callback the checkpoint's bind hook installs. It replaces the last
+// byte of the object's four byte field with the one it is handed.
+//
+// The claim is .text 0x00010A94 to 0x00010ACC and nothing else. It reads no
+// constant, so it owns no rodata.
+//
+// The field is read whole, changed and written back rather than being poked in
+// place, which is why the original stages it through the frame: CodeWarrior
+// copies a four byte structure member by member.
+//
+// The run is the same in the twelve stage modules that carry it, checked by
+// normalising the disassembly and comparing across modules.
+
+typedef struct Field {
+	u8 a; // 0x00
+	u8 b; // 0x01
+	u8 c; // 0x02
+	u8 d; // 0x03
+} Field;  // 0x04
+
+typedef struct Checkpoint {
+	u8 unk0[0x04]; // 0x00
+	Field field;   // 0x04
+} Checkpoint;      // 0x08
+
+extern "C" void checkpointFieldCallback(Checkpoint* object, const u8* value)
+{
+	Field next = object->field;
+	u8 last    = *value;
+
+	next.d = last;
+
+	object->field.a = next.a;
+	object->field.b = next.b;
+	object->field.c = next.c;
+	object->field.d = last;
+}

--- a/src/rel/goal_ring_field.cpp
+++ b/src/rel/goal_ring_field.cpp
@@ -1,0 +1,39 @@
+#include "types.h"
+
+// The field callback the goal ring's bind hook installs. It replaces the last
+// byte of the object's four byte field with the one it is handed.
+//
+// The claim is .text 0x0004D54C to 0x0004D584 and nothing else. It reads no
+// constant, so it owns no rodata.
+//
+// The field is read whole, changed and written back rather than being poked in
+// place, which is why the original stages it through the frame: CodeWarrior
+// copies a four byte structure member by member.
+//
+// The run is the same in the nine stage modules that carry it, checked by
+// normalising the disassembly and comparing across modules.
+
+typedef struct Field {
+	u8 a; // 0x00
+	u8 b; // 0x01
+	u8 c; // 0x02
+	u8 d; // 0x03
+} Field;  // 0x04
+
+typedef struct GoalRing {
+	u8 unk0[0x04]; // 0x00
+	Field field;   // 0x04
+} GoalRing;        // 0x08
+
+extern "C" void goalRingFieldCallback(GoalRing* object, const u8* value)
+{
+	Field next = object->field;
+	u8 last    = *value;
+
+	next.d = last;
+
+	object->field.a = next.a;
+	object->field.b = next.b;
+	object->field.c = next.c;
+	object->field.d = last;
+}


### PR DESCRIPTION
## What

The field callbacks the checkpoint's and goal ring's bind hooks install, matched
in #204. The first is linked into twelve stage modules and the second into nine,
so the two sources account for 21 matched functions.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the
      current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a
      reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known
      library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and
      included only the minimum symbolic fact and independent GameCube
      correlation.
- [x] If I changed inline flags, I documented the source/emission order and
      compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or
      links to those materials.

Evidence and references:

No PS2 or external metadata was used.

Both replace the last byte of a four byte field with the one they are handed.
They were already named in #204 as the callbacks those bind hooks pass to
`fn_801527A4`, which is what identifies them; this change reconstructs them.

**The field is read whole, changed and written back**, which is why the original
stages it through the frame: the four bytes are loaded as a word into a stack
slot, the last is replaced there, and the first three are copied back one at a
time. That is CodeWarrior copying a four byte structure member by member.

**The last member is written from the value, not re-read from the copy.**
Writing the whole structure back as one assignment produces a `clrlwi` before
the final `stb` — the compiler narrows the member it just read — and leaves the
function at 92.5% with every other instruction already identical. Assigning the
first three members from the copy and the last from the value directly is what
removes it, because then the compiler has the value in a register and stores it
unchanged, which is what the original does.

These were found by clustering every stage01D function by instruction shape and
looking for clusters that mix reconstructed and still-assembly functions. Two
more functions share this exact shape but sit between unnamed neighbours on both
sides, so there is no evidence for what to call them and they are left out.

## Verification

- [x] `python tools/check_language_policy.py` — 231 managed sources, 0 pending
- [x] `python -m unittest tools.test_check_language_policy` — 36 tests OK
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid — `18 files OK`,
      confirmed independently against `config/G9SE8P/build.sha1`

`report.json` `matched_functions` goes from 4110 to 4131, and no previously
carved unit moved.

Objdiff before/after:

| unit | before | after |
|---|---|---|
| `rel/checkpoint_field` | not carved | 100.00% in 12 modules, 14/14 instructions |
| `rel/goal_ring_field` | not carved | 100.00% in 9 modules, 14/14 instructions |
