### PR TITLE
feat: match the Kamome, Wave and SHACHI object records

### DIFF
--- a/config/G9SE8P/stage01D/splits.txt
+++ b/config/G9SE8P/stage01D/splits.txt
@@ -416,6 +416,18 @@ rel/o_s01_iwamizu.cpp:
 	.data       start:0x0000A8F0 end:0x0000AA04
 	.bss        start:0x00001344 end:0x000013D0
 
+rel/kamome_register.cpp:
+	.text       start:0x00084518 end:0x000845C4
+	.ctors      start:0x000000DC end:0x000000E0
+
+rel/wave_register.cpp:
+	.text       start:0x00089438 end:0x000894E4
+	.ctors      start:0x000000E8 end:0x000000EC
+
+rel/shachi_register.cpp:
+	.text       start:0x0008A7A8 end:0x0008A854
+	.ctors      start:0x000000EC end:0x000000F0
+
 rel/o_s01_shachicolli.cpp:
 	.text       start:0x0008A85C end:0x0008AC30
 	.ctors      start:0x000000F0 end:0x000000F4

--- a/configure.py
+++ b/configure.py
@@ -1574,6 +1574,21 @@ config.libs = [
             ),
             Object(
                 Matching,
+                "rel/kamome_register.cpp",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
+                "rel/wave_register.cpp",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
+                "rel/shachi_register.cpp",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "rel/gokurakucho_register.cpp",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/rel/kamome_register.cpp
+++ b/src/rel/kamome_register.cpp
@@ -1,0 +1,73 @@
+#include "types.h"
+
+// The record that registers S01 Kamome with the editor.
+//
+// The claim is .text 0x84518 to 0x845C4 and the .ctors word at 0xDC that names
+// it. Only the record is taken: the three hooks it points at stay assembly and
+// are reached by the names each module's symbols.txt gives them.
+//
+// The object's name is the display string the record itself installs, which is
+// what names every symbol here.
+//
+// The .ctors slot follows from the order being monotonic in .text address:
+// rel/o_s01_iwamizu.cpp holds 0xD8 and rel/o_s01_shachicolli.cpp holds 0xF0,
+// and this record's run sits between them.
+//
+// Only stage01D carries this run, like the other stage-01 object records around
+// it.
+
+typedef struct ObjectEntry {
+	const char* name;        // 0x00
+	void (*load)(void);      // 0x04
+	void (*unload)(void);    // 0x08
+	void (*create)(void);    // 0x0C
+	void* unk10;             // 0x10
+	u32 flags;               // 0x14
+	u32 unk18;               // 0x18
+	s16 unk1C;               // 0x1C
+	s16 unk1E;               // 0x1E
+	u8 unk20;                // 0x20
+	u8 unk21;                // 0x21
+	u8 pad22[2];             // 0x22
+	const char* fieldTypes;  // 0x24
+	const char** fieldNames; // 0x28
+} ObjectEntry;               // 0x2C
+
+// Defined by the module, renamed to these names in its own symbols.txt.
+extern "C" void kamomeLoad(void);
+extern "C" void kamomeUnload(void);
+extern "C" void kamomeCreate(void);
+extern "C" ObjectEntry kamomeEntry;
+extern "C" char kamomeDisplayName[];
+extern "C" char kamomeFieldTypes[];
+extern "C" const char* kamomeFieldNames[];
+
+extern "C" void kamomeRegister(void)
+{
+	kamomeEntry.flags = 0;
+	kamomeEntry.unk18 = 0;
+
+	kamomeEntry.name   = kamomeDisplayName;
+	kamomeEntry.load   = kamomeLoad;
+	kamomeEntry.unload = kamomeUnload;
+	kamomeEntry.create = kamomeCreate;
+	kamomeEntry.unk10  = NULL;
+
+	kamomeEntry.flags = 0x21000;
+	kamomeEntry.unk18 = 0;
+	kamomeEntry.unk20 = 100;
+	kamomeEntry.unk1C = 387;
+	kamomeEntry.unk1E = 2;
+	kamomeEntry.unk21 = 0;
+
+	kamomeEntry.fieldTypes = kamomeFieldTypes;
+	kamomeEntry.fieldNames = kamomeFieldNames;
+
+	if (kamomeFieldTypes != NULL) {
+		kamomeEntry.flags |= 8;
+	} else {
+		kamomeEntry.flags &= ~8;
+	}
+}
+
+__declspec(section ".ctors") void (*const kamomeCtorEntry)(void) = kamomeRegister;

--- a/src/rel/shachi_register.cpp
+++ b/src/rel/shachi_register.cpp
@@ -1,0 +1,73 @@
+#include "types.h"
+
+// The record that registers S01 SHACHI with the editor.
+//
+// The claim is .text 0x8A7A8 to 0x8A854 and the .ctors word at 0xEC that names
+// it. Only the record is taken: the three hooks it points at stay assembly and
+// are reached by the names each module's symbols.txt gives them.
+//
+// The object's name is the display string the record itself installs, which is
+// what names every symbol here.
+//
+// The .ctors slot follows from the order being monotonic in .text address:
+// rel/o_s01_iwamizu.cpp holds 0xD8 and rel/o_s01_shachicolli.cpp holds 0xF0,
+// and this record's run sits between them.
+//
+// Only stage01D carries this run, like the other stage-01 object records around
+// it.
+
+typedef struct ObjectEntry {
+	const char* name;        // 0x00
+	void (*load)(void);      // 0x04
+	void (*unload)(void);    // 0x08
+	void (*create)(void);    // 0x0C
+	void* unk10;             // 0x10
+	u32 flags;               // 0x14
+	u32 unk18;               // 0x18
+	s16 unk1C;               // 0x1C
+	s16 unk1E;               // 0x1E
+	u8 unk20;                // 0x20
+	u8 unk21;                // 0x21
+	u8 pad22[2];             // 0x22
+	const char* fieldTypes;  // 0x24
+	const char** fieldNames; // 0x28
+} ObjectEntry;               // 0x2C
+
+// Defined by the module, renamed to these names in its own symbols.txt.
+extern "C" void shachiLoad(void);
+extern "C" void shachiUnload(void);
+extern "C" void shachiCreate(void);
+extern "C" ObjectEntry shachiEntry;
+extern "C" char shachiDisplayName[];
+extern "C" char shachiFieldTypes[];
+extern "C" const char* shachiFieldNames[];
+
+extern "C" void shachiRegister(void)
+{
+	shachiEntry.flags = 0;
+	shachiEntry.unk18 = 0;
+
+	shachiEntry.name   = shachiDisplayName;
+	shachiEntry.load   = shachiLoad;
+	shachiEntry.unload = shachiUnload;
+	shachiEntry.create = shachiCreate;
+	shachiEntry.unk10  = NULL;
+
+	shachiEntry.flags = 0x21000;
+	shachiEntry.unk18 = 0;
+	shachiEntry.unk20 = 50;
+	shachiEntry.unk1C = 386;
+	shachiEntry.unk1E = 2;
+	shachiEntry.unk21 = 0;
+
+	shachiEntry.fieldTypes = shachiFieldTypes;
+	shachiEntry.fieldNames = shachiFieldNames;
+
+	if (shachiFieldTypes != NULL) {
+		shachiEntry.flags |= 8;
+	} else {
+		shachiEntry.flags &= ~8;
+	}
+}
+
+__declspec(section ".ctors") void (*const shachiCtorEntry)(void) = shachiRegister;

--- a/src/rel/wave_register.cpp
+++ b/src/rel/wave_register.cpp
@@ -1,0 +1,73 @@
+#include "types.h"
+
+// The record that registers S01 Wave with the editor.
+//
+// The claim is .text 0x89438 to 0x894E4 and the .ctors word at 0xE8 that names
+// it. Only the record is taken: the three hooks it points at stay assembly and
+// are reached by the names each module's symbols.txt gives them.
+//
+// The object's name is the display string the record itself installs, which is
+// what names every symbol here.
+//
+// The .ctors slot follows from the order being monotonic in .text address:
+// rel/o_s01_iwamizu.cpp holds 0xD8 and rel/o_s01_shachicolli.cpp holds 0xF0,
+// and this record's run sits between them.
+//
+// Only stage01D carries this run, like the other stage-01 object records around
+// it.
+
+typedef struct ObjectEntry {
+	const char* name;        // 0x00
+	void (*load)(void);      // 0x04
+	void (*unload)(void);    // 0x08
+	void (*create)(void);    // 0x0C
+	void* unk10;             // 0x10
+	u32 flags;               // 0x14
+	u32 unk18;               // 0x18
+	s16 unk1C;               // 0x1C
+	s16 unk1E;               // 0x1E
+	u8 unk20;                // 0x20
+	u8 unk21;                // 0x21
+	u8 pad22[2];             // 0x22
+	const char* fieldTypes;  // 0x24
+	const char** fieldNames; // 0x28
+} ObjectEntry;               // 0x2C
+
+// Defined by the module, renamed to these names in its own symbols.txt.
+extern "C" void waveLoad(void);
+extern "C" void waveUnload(void);
+extern "C" void waveCreate(void);
+extern "C" ObjectEntry waveEntry;
+extern "C" char waveDisplayName[];
+extern "C" char waveFieldTypes[];
+extern "C" const char* waveFieldNames[];
+
+extern "C" void waveRegister(void)
+{
+	waveEntry.flags = 0;
+	waveEntry.unk18 = 0;
+
+	waveEntry.name   = waveDisplayName;
+	waveEntry.load   = waveLoad;
+	waveEntry.unload = waveUnload;
+	waveEntry.create = waveCreate;
+	waveEntry.unk10  = NULL;
+
+	waveEntry.flags = 0x21000;
+	waveEntry.unk18 = 0;
+	waveEntry.unk20 = 127;
+	waveEntry.unk1C = 391;
+	waveEntry.unk1E = 2;
+	waveEntry.unk21 = 0;
+
+	waveEntry.fieldTypes = waveFieldTypes;
+	waveEntry.fieldNames = waveFieldNames;
+
+	if (waveFieldTypes != NULL) {
+		waveEntry.flags |= 8;
+	} else {
+		waveEntry.flags &= ~8;
+	}
+}
+
+__declspec(section ".ctors") void (*const waveCtorEntry)(void) = waveRegister;


### PR DESCRIPTION
## What

Three more editor records in stage01D — `S01 Kamome`, `S01 Wave` and
`S01 SHACHI` — named in #207 and now carved. All three match byte for byte.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the
      current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a
      reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known
      library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and
      included only the minimum symbolic fact and independent GameCube
      correlation.
- [x] If I changed inline flags, I documented the source/emission order and
      compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or
      links to those materials.

Evidence and references:

No PS2 or external metadata was used. Every name is the display string the
record itself installs, as in #207.

**The `.ctors` order is monotonic in `.text` address.** Tabulating every carved
unit that claims a slot shows the two rise together without exception across all
47 claims. That turns slot assignment from a guess into an interpolation:
`rel/o_s01_iwamizu.cpp` holds `0xD8` and `rel/o_s01_shachicolli.cpp` holds
`0xF0`, so the five free slots between them belong, in order, to the five
uncarved units whose runs fall between those two addresses.

**dtk reports a wrong assignment as a cyclic dependency, not as a hash
mismatch.** The first attempt gave Kamome `0xE4`, and the split failed with
`Cyclic dependency encountered while resolving link order: rel/kamome_register
-> auto_00_000845C4_text -> auto_fn_3_85F54_text`. That names the two automatic
units sitting between Kamome's run and Wave's, which must therefore hold the two
slots between theirs — so Kamome takes `0xDC`, and Wave and SHACHI keep `0xE8`
and `0xEC`. The error is more useful than a failing hash: it says which units
are out of order rather than only that the bytes differ.

Only the records are carved. The nine hooks they point at stay assembly and are
reached by the names #207 gave them.

## Verification

- [x] `python tools/check_language_policy.py` — 235 managed sources, 0 pending
- [x] `python -m unittest tools.test_check_language_policy` — 36 tests OK
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid — `18 files OK`,
      confirmed independently against `config/G9SE8P/build.sha1`

`report.json` `matched_functions` goes from 4132 to 4135, and no previously
carved unit moved.

Objdiff before/after:

| unit | before | after |
|---|---|---|
| `stage01D/rel/kamome_register` | not carved | 100.00%, 43/43 instructions |
| `stage01D/rel/wave_register` | not carved | 100.00%, 43/43 |
| `stage01D/rel/shachi_register` | not carved | 100.00%, 43/43 |
