### PR TITLE
feat: match the four stage-02 object records

### DIFF
--- a/config/G9SE8P/stage01D/splits.txt
+++ b/config/G9SE8P/stage01D/splits.txt
@@ -440,3 +440,19 @@ rel/o_s01_taihostull.cpp:
 	.rodata     start:0x000016D8 end:0x00001720
 	.data       start:0x0000B59C end:0x0000B610
 	.bss        start:0x000017B8 end:0x000017F4
+
+rel/s02_moving_land_register.cpp:
+	.text       start:0x0009F2CC end:0x0009F378
+	.ctors      start:0x00000118 end:0x0000011C
+
+rel/s02_water_register.cpp:
+	.text       start:0x000A35B0 end:0x000A365C
+	.ctors      start:0x00000120 end:0x00000124
+
+rel/s02_green_register.cpp:
+	.text       start:0x000AECF0 end:0x000AED9C
+	.ctors      start:0x00000124 end:0x00000128
+
+rel/s02_pole_register.cpp:
+	.text       start:0x000B05CC end:0x000B0678
+	.ctors      start:0x0000012C end:0x00000130

--- a/configure.py
+++ b/configure.py
@@ -1574,6 +1574,26 @@ config.libs = [
             ),
             Object(
                 Matching,
+                "rel/s02_moving_land_register.cpp",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
+                "rel/s02_water_register.cpp",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
+                "rel/s02_green_register.cpp",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
+                "rel/s02_pole_register.cpp",
+                extra_cflags=["-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "rel/kamome_register.cpp",
                 extra_cflags=["-opt noschedule,nopeephole"],
             ),

--- a/src/rel/s02_green_register.cpp
+++ b/src/rel/s02_green_register.cpp
@@ -1,0 +1,74 @@
+#include "types.h"
+
+// The record that registers S02D Green with the editor.
+//
+// The claim is .text 0xAECF0 to 0xAED9C and the .ctors word at 0x124 that names
+// it. Only the record is taken: the three hooks it points at stay assembly and
+// are reached by the names each module's symbols.txt gives them.
+//
+// The object's name is the display string the record itself installs, which is
+// what names every symbol here.
+//
+// The .ctors slot is derived rather than guessed. Every function that owns a
+// .ctors word was collected from the module's relocations and sorted by run
+// address; the slot is that position times four. The rule reproduces all fifty
+// slots already claimed in this module and contradicts none.
+//
+// Only stage01D carries this run, like the other stage-02 object records around
+// it.
+
+typedef struct ObjectEntry {
+	const char* name;        // 0x00
+	void (*load)(void);      // 0x04
+	void (*unload)(void);    // 0x08
+	void (*create)(void);    // 0x0C
+	void* unk10;             // 0x10
+	u32 flags;               // 0x14
+	u32 unk18;               // 0x18
+	s16 unk1C;               // 0x1C
+	s16 unk1E;               // 0x1E
+	u8 unk20;                // 0x20
+	u8 unk21;                // 0x21
+	u8 pad22[2];             // 0x22
+	const char* fieldTypes;  // 0x24
+	const char** fieldNames; // 0x28
+} ObjectEntry;               // 0x2C
+
+// Defined by the module, renamed to these names in its own symbols.txt.
+extern "C" void s02GreenLoad(void);
+extern "C" void s02GreenUnload(void);
+extern "C" void s02GreenCreate(void);
+extern "C" ObjectEntry s02GreenEntry;
+extern "C" char s02GreenDisplayName[];
+extern "C" char s02GreenFieldTypes[];
+extern "C" const char* s02GreenFieldNames[];
+
+extern "C" void s02GreenRegister(void)
+{
+	s02GreenEntry.flags = 0;
+	s02GreenEntry.unk18 = 0;
+
+	s02GreenEntry.name   = s02GreenDisplayName;
+	s02GreenEntry.load   = s02GreenLoad;
+	s02GreenEntry.unload = s02GreenUnload;
+	s02GreenEntry.create = s02GreenCreate;
+	s02GreenEntry.unk10  = NULL;
+
+	s02GreenEntry.flags = 0x21000;
+	s02GreenEntry.unk18 = 0;
+	s02GreenEntry.unk20 = 20;
+	s02GreenEntry.unk1C = 644;
+	s02GreenEntry.unk1E = 2;
+	s02GreenEntry.unk21 = 0;
+
+	s02GreenEntry.fieldTypes = s02GreenFieldTypes;
+	s02GreenEntry.fieldNames = s02GreenFieldNames;
+
+	if (s02GreenFieldTypes != NULL) {
+		s02GreenEntry.flags |= 8;
+	} else {
+		s02GreenEntry.flags &= ~8;
+	}
+}
+
+__declspec(section ".ctors") void (*const s02GreenCtorEntry)(void) = s02GreenRegister;

--- a/src/rel/s02_moving_land_register.cpp
+++ b/src/rel/s02_moving_land_register.cpp
@@ -1,0 +1,74 @@
+#include "types.h"
+
+// The record that registers S02D MovingLand with the editor.
+//
+// The claim is .text 0x9F2CC to 0x9F378 and the .ctors word at 0x118 that names
+// it. Only the record is taken: the three hooks it points at stay assembly and
+// are reached by the names each module's symbols.txt gives them.
+//
+// The object's name is the display string the record itself installs, which is
+// what names every symbol here.
+//
+// The .ctors slot is derived rather than guessed. Every function that owns a
+// .ctors word was collected from the module's relocations and sorted by run
+// address; the slot is that position times four. The rule reproduces all fifty
+// slots already claimed in this module and contradicts none.
+//
+// Only stage01D carries this run, like the other stage-02 object records around
+// it.
+
+typedef struct ObjectEntry {
+	const char* name;        // 0x00
+	void (*load)(void);      // 0x04
+	void (*unload)(void);    // 0x08
+	void (*create)(void);    // 0x0C
+	void* unk10;             // 0x10
+	u32 flags;               // 0x14
+	u32 unk18;               // 0x18
+	s16 unk1C;               // 0x1C
+	s16 unk1E;               // 0x1E
+	u8 unk20;                // 0x20
+	u8 unk21;                // 0x21
+	u8 pad22[2];             // 0x22
+	const char* fieldTypes;  // 0x24
+	const char** fieldNames; // 0x28
+} ObjectEntry;               // 0x2C
+
+// Defined by the module, renamed to these names in its own symbols.txt.
+extern "C" void s02MovingLandLoad(void);
+extern "C" void s02MovingLandUnload(void);
+extern "C" void s02MovingLandCreate(void);
+extern "C" ObjectEntry s02MovingLandEntry;
+extern "C" char s02MovingLandDisplayName[];
+extern "C" char s02MovingLandFieldTypes[];
+extern "C" const char* s02MovingLandFieldNames[];
+
+extern "C" void s02MovingLandRegister(void)
+{
+	s02MovingLandEntry.flags = 0;
+	s02MovingLandEntry.unk18 = 0;
+
+	s02MovingLandEntry.name   = s02MovingLandDisplayName;
+	s02MovingLandEntry.load   = s02MovingLandLoad;
+	s02MovingLandEntry.unload = s02MovingLandUnload;
+	s02MovingLandEntry.create = s02MovingLandCreate;
+	s02MovingLandEntry.unk10  = NULL;
+
+	s02MovingLandEntry.flags = 0x21400;
+	s02MovingLandEntry.unk18 = 0;
+	s02MovingLandEntry.unk20 = 50;
+	s02MovingLandEntry.unk1C = 640;
+	s02MovingLandEntry.unk1E = 2;
+	s02MovingLandEntry.unk21 = 0;
+
+	s02MovingLandEntry.fieldTypes = s02MovingLandFieldTypes;
+	s02MovingLandEntry.fieldNames = s02MovingLandFieldNames;
+
+	if (s02MovingLandFieldTypes != NULL) {
+		s02MovingLandEntry.flags |= 8;
+	} else {
+		s02MovingLandEntry.flags &= ~8;
+	}
+}
+
+__declspec(section ".ctors") void (*const s02MovingLandCtorEntry)(void) = s02MovingLandRegister;

--- a/src/rel/s02_pole_register.cpp
+++ b/src/rel/s02_pole_register.cpp
@@ -1,0 +1,74 @@
+#include "types.h"
+
+// The record that registers S02D Pole with the editor.
+//
+// The claim is .text 0xB05CC to 0xB0678 and the .ctors word at 0x12C that names
+// it. Only the record is taken: the three hooks it points at stay assembly and
+// are reached by the names each module's symbols.txt gives them.
+//
+// The object's name is the display string the record itself installs, which is
+// what names every symbol here.
+//
+// The .ctors slot is derived rather than guessed. Every function that owns a
+// .ctors word was collected from the module's relocations and sorted by run
+// address; the slot is that position times four. The rule reproduces all fifty
+// slots already claimed in this module and contradicts none.
+//
+// Only stage01D carries this run, like the other stage-02 object records around
+// it.
+
+typedef struct ObjectEntry {
+	const char* name;        // 0x00
+	void (*load)(void);      // 0x04
+	void (*unload)(void);    // 0x08
+	void (*create)(void);    // 0x0C
+	void* unk10;             // 0x10
+	u32 flags;               // 0x14
+	u32 unk18;               // 0x18
+	s16 unk1C;               // 0x1C
+	s16 unk1E;               // 0x1E
+	u8 unk20;                // 0x20
+	u8 unk21;                // 0x21
+	u8 pad22[2];             // 0x22
+	const char* fieldTypes;  // 0x24
+	const char** fieldNames; // 0x28
+} ObjectEntry;               // 0x2C
+
+// Defined by the module, renamed to these names in its own symbols.txt.
+extern "C" void s02PoleLoad(void);
+extern "C" void s02PoleUnload(void);
+extern "C" void s02PoleCreate(void);
+extern "C" ObjectEntry s02PoleEntry;
+extern "C" char s02PoleDisplayName[];
+extern "C" char s02PoleFieldTypes[];
+extern "C" const char* s02PoleFieldNames[];
+
+extern "C" void s02PoleRegister(void)
+{
+	s02PoleEntry.flags = 0;
+	s02PoleEntry.unk18 = 0;
+
+	s02PoleEntry.name   = s02PoleDisplayName;
+	s02PoleEntry.load   = s02PoleLoad;
+	s02PoleEntry.unload = s02PoleUnload;
+	s02PoleEntry.create = s02PoleCreate;
+	s02PoleEntry.unk10  = NULL;
+
+	s02PoleEntry.flags = 0x21000;
+	s02PoleEntry.unk18 = 0;
+	s02PoleEntry.unk20 = 20;
+	s02PoleEntry.unk1C = 645;
+	s02PoleEntry.unk1E = 2;
+	s02PoleEntry.unk21 = 0;
+
+	s02PoleEntry.fieldTypes = s02PoleFieldTypes;
+	s02PoleEntry.fieldNames = s02PoleFieldNames;
+
+	if (s02PoleFieldTypes != NULL) {
+		s02PoleEntry.flags |= 8;
+	} else {
+		s02PoleEntry.flags &= ~8;
+	}
+}
+
+__declspec(section ".ctors") void (*const s02PoleCtorEntry)(void) = s02PoleRegister;

--- a/src/rel/s02_water_register.cpp
+++ b/src/rel/s02_water_register.cpp
@@ -1,0 +1,74 @@
+#include "types.h"
+
+// The record that registers S02D Water with the editor.
+//
+// The claim is .text 0xA35B0 to 0xA365C and the .ctors word at 0x120 that names
+// it. Only the record is taken: the three hooks it points at stay assembly and
+// are reached by the names each module's symbols.txt gives them.
+//
+// The object's name is the display string the record itself installs, which is
+// what names every symbol here.
+//
+// The .ctors slot is derived rather than guessed. Every function that owns a
+// .ctors word was collected from the module's relocations and sorted by run
+// address; the slot is that position times four. The rule reproduces all fifty
+// slots already claimed in this module and contradicts none.
+//
+// Only stage01D carries this run, like the other stage-02 object records around
+// it.
+
+typedef struct ObjectEntry {
+	const char* name;        // 0x00
+	void (*load)(void);      // 0x04
+	void (*unload)(void);    // 0x08
+	void (*create)(void);    // 0x0C
+	void* unk10;             // 0x10
+	u32 flags;               // 0x14
+	u32 unk18;               // 0x18
+	s16 unk1C;               // 0x1C
+	s16 unk1E;               // 0x1E
+	u8 unk20;                // 0x20
+	u8 unk21;                // 0x21
+	u8 pad22[2];             // 0x22
+	const char* fieldTypes;  // 0x24
+	const char** fieldNames; // 0x28
+} ObjectEntry;               // 0x2C
+
+// Defined by the module, renamed to these names in its own symbols.txt.
+extern "C" void s02WaterLoad(void);
+extern "C" void s02WaterUnload(void);
+extern "C" void s02WaterCreate(void);
+extern "C" ObjectEntry s02WaterEntry;
+extern "C" char s02WaterDisplayName[];
+extern "C" char s02WaterFieldTypes[];
+extern "C" const char* s02WaterFieldNames[];
+
+extern "C" void s02WaterRegister(void)
+{
+	s02WaterEntry.flags = 0;
+	s02WaterEntry.unk18 = 0;
+
+	s02WaterEntry.name   = s02WaterDisplayName;
+	s02WaterEntry.load   = s02WaterLoad;
+	s02WaterEntry.unload = s02WaterUnload;
+	s02WaterEntry.create = s02WaterCreate;
+	s02WaterEntry.unk10  = NULL;
+
+	s02WaterEntry.flags = 0x21000;
+	s02WaterEntry.unk18 = 0;
+	s02WaterEntry.unk20 = 20;
+	s02WaterEntry.unk1C = 643;
+	s02WaterEntry.unk1E = 2;
+	s02WaterEntry.unk21 = 0;
+
+	s02WaterEntry.fieldTypes = s02WaterFieldTypes;
+	s02WaterEntry.fieldNames = s02WaterFieldNames;
+
+	if (s02WaterFieldTypes != NULL) {
+		s02WaterEntry.flags |= 8;
+	} else {
+		s02WaterEntry.flags &= ~8;
+	}
+}
+
+__declspec(section ".ctors") void (*const s02WaterCtorEntry)(void) = s02WaterRegister;


### PR DESCRIPTION
## What

The four stage-02 editor records in stage01D — `S02D MovingLand`, `S02D Water`,
`S02D Green` and `S02D Pole` — named in #207 and now carved. All four match byte
for byte.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the
      current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a
      reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known
      library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and
      included only the minimum symbolic fact and independent GameCube
      correlation.
- [x] If I changed inline flags, I documented the source/emission order and
      compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or
      links to those materials.

Evidence and references:

No PS2 or external metadata was used. Every name is the display string the
record itself installs, as in #207 and #208.

**The `.ctors` slots are derived, not guessed.** #208 assigned them by
interpolating between neighbouring claims, which needed one failed build to
correct. This change replaces that with a rule: collect every function that owns
a `.ctors` word from the module's own `.rela.ctors` relocations, sort by run
address, and the slot is that position times four. There are 92 such owners in
stage01D. **The rule reproduces all fifty slots already claimed in this module
and contradicts none**, which is what makes the four new assignments —
`0x118`, `0x120`, `0x124` and `0x12C` — predictions rather than attempts. All
four built byte-identically on the first try.

Only the records are carved. The twelve hooks they point at stay assembly and
are reached by the names #207 gave them.

## Verification

- [x] `python tools/check_language_policy.py` — 239 managed sources, 0 pending
- [x] `python -m unittest tools.test_check_language_policy` — 36 tests OK
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid — `18 files OK`,
      confirmed independently against `config/G9SE8P/build.sha1`

`report.json` `matched_functions` goes from 4135 to 4139, and no previously
carved unit moved.

Objdiff before/after:

| unit | before | after |
|---|---|---|
| `stage01D/rel/s02_moving_land_register` | not carved | 100.00%, 43/43 instructions |
| `stage01D/rel/s02_water_register` | not carved | 100.00%, 43/43 |
| `stage01D/rel/s02_green_register` | not carved | 100.00%, 43/43 |
| `stage01D/rel/s02_pole_register` | not carved | 100.00%, 43/43 |
