### PR TITLE
decomp: carve the CRI MFCI translation unit

### DIFF
--- a/config/G9SE8P/language_policy.json
+++ b/config/G9SE8P/language_policy.json
@@ -18,6 +18,7 @@
   "reviewed_c_boundary_sources": [
     "advertiseD/prolog.c",
     "autosaveD/prolog.c",
+    "game/cri/mfci.c",
     "movieD/cri/sfxahn.c",
     "movieD/cri/sfxcnv.c",
     "movieD/cri/sfxset.c",

--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -674,3 +674,9 @@ dolphin/exi/EXIBios.c:
 	.text       start:0x801FA418 end:0x801FBDF4
 	.bss        start:0x8040EA90 end:0x8040EB50
 	.sbss       start:0x8042CF30 end:0x8042CF34
+
+game/cri/mfci.c:
+	.text       start:0x80222A14 end:0x80223424
+	.rodata     start:0x80240168 end:0x80240400
+	.data       start:0x8029BA48 end:0x8029BAB0
+	.bss        start:0x80427F78 end:0x80428970

--- a/configure.py
+++ b/configure.py
@@ -502,6 +502,16 @@ config.libs = [
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
             Object(
+                NonMatching,
+                "game/cri/mfci.c",
+                extra_cflags=[
+                    "-sdata 0",
+                    "-sdata2 0",
+                    "-str reuse,readonly",
+                    "-use_lmw_stmw on",
+                ],
+            ),
+            Object(
                 Matching,
                 "game/skyfs_adx.c",
                 extra_cflags=[

--- a/src/game/cri/mfci.c
+++ b/src/game/cri/mfci.c
@@ -1,0 +1,422 @@
+#include "types.h"
+
+// CRI MFCI for GameCube: the file-entry layer that turns a "AAAAAAAA.SSSSSSS"
+// name into an address/size pair and hands out read handles over it.
+//
+// The unit runs from fn_80222A14 at 0x80222A14 to the end of fn_80223410 at
+// 0x80223424, and owns .rodata 0x80240168 to 0x80240400, .data 0x8029BA48 to
+// 0x8029BAB0 and .bss 0x80427F78 to 0x80428970. The disc ships no map, so the
+// bounds are argued rather than read. Five independent lines agree:
+//
+//   The .rodata block opens with the module's own version banner,
+//   "\nMFCI/GC Ver.1.05 Build:May  9 2003 17:10:33\n", and runs to 0x80240400,
+//   where AXRNA's banner starts. CRI puts that banner in the module's main
+//   source file, and every string in the block names something declared here:
+//   mfCiOpen, mfCiOpenEntry, mfCiReqRd and mfci_get_adr_size.
+//
+//   The .bss is private to the run. lbl_80427F78 and the block at lbl_80427F7C
+//   are touched by exactly the twelve functions from fn_80222A14 to
+//   fn_802233F0, and by nothing before or after.
+//
+//   Every .rodata label inside 0x80240168..0x80240400 is reached from this run
+//   and from nowhere else, including lbl_80240198, whose only reader is
+//   fn_80223410.
+//
+//   The .data at 0x8029BA48 is this module's interface table. Its thirteen
+//   non-null entries are exactly the functions of the run, in reverse source
+//   order, and fn_80223410 is the accessor that hands the table back.
+//
+//   The neighbours settle both ends. Nothing below 0x80222A14 touches any of
+//   the block; fn_80223424 and everything after it work on lbl_80428970, a
+//   disjoint private block that starts exactly where this .bss ends. The
+//   lock/unlock pair the file calls, fn_802229AC and fn_8022291C, sits just
+//   below the run but belongs elsewhere: fourteen functions spread from
+//   0x802127B0 to 0x8021B214 call it too, so it is shared CRI plumbing rather
+//   than a static of this file.
+//
+// Names come from the error strings, which CRI writes with the reporting
+// function in parentheses. Everything not named there keeps its dtk name.
+//
+// NOT MATCHING: 528 of 644 instructions. Seven of the fourteen functions are
+// byte-exact; mfCiReqRd and mfCiOpen carry most of what is left. See
+// notes/cri-mfci.md for the measurements, including what has already been
+// ruled out.
+//
+// The open problem is one shape. Those two functions reach five messages each
+// through a single base register (addi rN, r30, 388, with r30 pointing at the
+// banner), and read the module globals as displacements off a second one. That
+// only works when the literals share one object and the globals share another.
+// Both ways of asking for that -- "-str pool" and folding the globals into one
+// struct -- make MWCC 1.3.2 emit "lis; addi base; addi +offset" everywhere,
+// three instructions where the twelve small functions want two, and the total
+// falls (408 and 362 against 528). The original evidently folds the offset into
+// @l when it does not hoist, and this compiler never does.
+//
+// The .rodata also still carries the three "(mfCiOpenEntry)" messages although
+// no surviving function reads them. mfCiOpenEntry is reconstructed below as the
+// static it must have been. The reconstruction is a hypothesis about how those
+// strings survive, and an incomplete one: this compiler keeps the body, so the
+// object holds eighteen functions against the target's fourteen.
+
+typedef void (*MfciErrFunc)(void* obj, const char* msg, void* arg);
+typedef void (*MfciFunc)(void);
+
+typedef struct MfciObj {
+	/* 0x00 */ s8 stat;
+	/* 0x01 */ s8 busy;
+	/* 0x02 */ s8 pad[2];
+	/* 0x04 */ s32 sctsize;
+	/* 0x08 */ s32 size;
+	/* 0x0C */ s32 nsct;
+	/* 0x10 */ s32 pos;
+	/* 0x14 */ s32 total;
+	/* 0x18 */ s32 rdsct;
+	/* 0x1C */ char fname[20];
+	/* 0x30 */ s32 ofst;
+	/* 0x34 */ s32 nbyte;
+} MfciObj;
+
+#define MFCI_OBJ_MAX  40
+#define MFCI_SCT_SIZE 2048
+
+extern void fn_802229AC(void);
+extern void fn_8022291C(void);
+
+extern u32 strlen(const char* s);
+extern char* strcpy(char* dst, const char* src);
+extern void* memset(void* p, int c, u32 n);
+extern void* memcpy(void* d, const void* s, u32 n);
+extern u32 strtoul(const char* s, char** end, int base);
+extern int sprintf(char* buf, const char* fmt, ...);
+
+s32 fn_80222A14(MfciObj* hn);
+void fn_80222A74(MfciObj* hn, s32 sctsize);
+s32 fn_80222B0C(MfciObj* hn);
+s32 fn_80222B6C(MfciObj* hn);
+void fn_80222BD0(MfciObj* hn);
+s32 fn_80222C40(MfciObj* hn, s32 nsct, void* buf);
+s32 fn_80222EC8(MfciObj* hn);
+s32 fn_80222F28(MfciObj* hn, s32 off, s32 whence);
+void fn_8022301C(MfciObj* hn);
+MfciObj* fn_802230B4(const char* fname, s32 mode, s32 rw);
+u32 fn_802232E4(const char* fname);
+void fn_802233F0(MfciErrFunc func, void* obj);
+void fn_80223404(void);
+void* fn_80223410(void);
+
+const char mfci_ver[]                = "\nMFCI/GC Ver.1.05 Build:May  9 2003 17:10:33\n";
+static const char* const mfci_verptr = mfci_ver;
+
+static MfciErrFunc mfci_ErrFunc;
+static void* mfci_ErrObj;
+static char mfci_WorkStr[300];
+static MfciObj mfci_ObjTbl[MFCI_OBJ_MAX];
+
+MfciFunc mfci_IfTbl[26] = {
+	(MfciFunc)fn_80223404,
+	(MfciFunc)fn_802233F0,
+	(MfciFunc)fn_802232E4,
+	NULL,
+	(MfciFunc)fn_802230B4,
+	(MfciFunc)fn_8022301C,
+	(MfciFunc)fn_80222F28,
+	(MfciFunc)fn_80222EC8,
+	(MfciFunc)fn_80222C40,
+	NULL,
+	(MfciFunc)fn_80222BD0,
+	(MfciFunc)fn_80222B6C,
+	(MfciFunc)fn_80222B0C,
+	(MfciFunc)fn_80222A74,
+	(MfciFunc)fn_80222A14,
+};
+
+static void mfci_ErrorN(const char* msg)
+{
+	if (mfci_ErrFunc != NULL) {
+		mfci_ErrFunc(mfci_ErrObj, msg, NULL);
+	}
+}
+
+static void mfci_Error(const char* msg, void* arg)
+{
+	if (mfci_ErrFunc != NULL) {
+		mfci_ErrFunc(mfci_ErrObj, msg, arg);
+	}
+}
+
+// Never called. The hypothesis is that the original was a static the compiler
+// dropped, leaving only its three messages at the head of the pool.
+static MfciObj* mfCiOpenEntry(s32 no, s32 rw)
+{
+	MfciObj* hn;
+	s32 i;
+
+	if (no < 0 || no >= MFCI_OBJ_MAX) {
+		mfci_ErrorN("E1041001:invalid entry number.(mfCiOpenEntry)");
+		return NULL;
+	}
+	if (rw != 0) {
+		mfci_ErrorN("E1041002:rw is illigal.(mfCiOpenEntry)");
+		return NULL;
+	}
+	hn = NULL;
+	for (i = 0; i < MFCI_OBJ_MAX; i++) {
+		if (mfci_ObjTbl[i].stat == 0) {
+			hn = &mfci_ObjTbl[i];
+			break;
+		}
+	}
+	if (hn == NULL) {
+		mfci_ErrorN("E1041002:not enough handle resource.(mfCiOpenEntry)");
+		return NULL;
+	}
+	return hn;
+}
+
+static u32 mfci_get_adr_size(const char* fname, u32* size)
+{
+	char* p = (char*)fname;
+	u32 v;
+
+	if (strlen(fname) != 17) {
+		sprintf(
+		    mfci_WorkStr, "E01100308:length of '%s' is not 17 bytes.(mfci_get_adr_size)", fname);
+		mfci_ErrorN(mfci_WorkStr);
+	}
+	if (fname[8] != '.') {
+		sprintf(mfci_WorkStr, "E01100309:illegal file name format '%s'(mfci_get_adr_size)", fname);
+		mfci_ErrorN(mfci_WorkStr);
+	}
+	v = strtoul(p, &p, 16);
+	if (*p != '\0') {
+		p++;
+	}
+	if (size != NULL) {
+		*size = strtoul(p, &p, 16);
+	}
+	return v;
+}
+
+s32 fn_80222A14(MfciObj* hn)
+{
+	if (hn == NULL) {
+		mfci_ErrorN("E0092912:handl is null.");
+		return 0;
+	}
+	return hn->total;
+}
+
+void fn_80222A74(MfciObj* hn, s32 sctsize)
+{
+	s32 total;
+
+	if (hn == NULL) {
+		mfci_ErrorN("E0040302:handl is null.");
+		return;
+	}
+	total       = hn->pos * hn->sctsize;
+	hn->sctsize = sctsize;
+	hn->nsct    = (hn->sctsize + hn->size - 1) / hn->sctsize;
+	hn->pos     = total / hn->sctsize;
+	hn->total   = hn->rdsct * sctsize;
+}
+
+s32 fn_80222B0C(MfciObj* hn)
+{
+	if (hn == NULL) {
+		mfci_ErrorN("E0040301:handl is null.");
+		return 0;
+	}
+	return hn->sctsize;
+}
+
+s32 fn_80222B6C(MfciObj* hn)
+{
+	if (hn == NULL) {
+		mfci_ErrorN("E01100307:handl is null.");
+		return 0;
+	}
+	return hn->busy;
+}
+
+void fn_80222BD0(MfciObj* hn)
+{
+	if (hn == NULL) {
+		mfci_ErrorN("E0092912:handl is null.");
+		return;
+	}
+	fn_802229AC();
+	hn->busy = 0;
+	fn_8022291C();
+}
+
+s32 fn_80222C40(MfciObj* hn, s32 nsct, void* buf)
+{
+	s32 rest;
+	u32 adr;
+	u32 size;
+	s32 n;
+
+	if (hn == NULL) {
+		mfci_ErrorN("E01100307:handl is null.");
+		return 0;
+	}
+	if (nsct < 0) {
+		mfci_Error("E01100308:nsct < 0.(mfCiReqRd)", hn);
+		return 0;
+	}
+	if (buf == NULL) {
+		mfci_Error("E01100309:buf is null.(mfCiReqRd)", hn);
+		return 0;
+	}
+	if (nsct == 0) {
+		hn->busy = 1;
+		return 0;
+	}
+
+	fn_802229AC();
+	hn->total = 0;
+	rest      = hn->nsct - hn->pos;
+	hn->rdsct = nsct < rest ? nsct : rest;
+	{
+		s32 nbyte = hn->rdsct * hn->sctsize;
+		s32 ofst  = hn->pos * hn->sctsize;
+		if (nbyte == 0) {
+			hn->busy = 1;
+			fn_8022291C();
+			return 0;
+		}
+		hn->ofst  = ofst;
+		hn->nbyte = nbyte;
+	}
+	hn->busy = 2;
+	adr      = mfci_get_adr_size(hn->fname, &size);
+	n        = hn->nbyte <= (s32)(size - hn->ofst) ? hn->nbyte : (s32)(size - hn->ofst);
+	memcpy(buf, (void*)(adr + hn->ofst), hn->nbyte);
+	memset((s8*)buf + n, 0, hn->nbyte - n);
+	hn->total = hn->rdsct * hn->sctsize;
+	hn->pos   = hn->pos + hn->rdsct;
+	hn->busy  = 1;
+	fn_8022291C();
+	return hn->rdsct;
+}
+
+s32 fn_80222EC8(MfciObj* hn)
+{
+	if (hn == NULL) {
+		mfci_ErrorN("E01100306:handl is null.");
+		return 0;
+	}
+	return hn->pos;
+}
+
+s32 fn_80222F28(MfciObj* hn, s32 off, s32 whence)
+{
+	if (hn == NULL) {
+		mfci_ErrorN("E01100305:handl is null.");
+		return 0;
+	}
+	fn_802229AC();
+	if (whence == 0) {
+		hn->pos = off;
+	} else if (whence == 2) {
+		hn->pos = hn->nsct + off;
+	} else if (whence == 1) {
+		hn->pos = hn->pos + off;
+	}
+	hn->pos = hn->pos < hn->nsct ? hn->pos : hn->nsct;
+	if (hn->pos > 0) {
+	} else {
+		hn->pos = 0;
+	}
+	fn_8022291C();
+	return hn->pos;
+}
+
+void fn_8022301C(MfciObj* hn)
+{
+	if (hn == NULL) {
+		return;
+	}
+	if (hn == NULL) {
+		mfci_ErrorN("E0092912:handl is null.");
+	} else {
+		fn_802229AC();
+		hn->busy = 0;
+		fn_8022291C();
+	}
+	if (hn->stat == 1) {
+		hn->stat = 0;
+		memset(hn, 0, sizeof(MfciObj));
+	}
+}
+
+MfciObj* fn_802230B4(const char* fname, s32 mode, s32 rw)
+{
+	MfciObj* hn;
+	u32 size;
+	s32 i;
+
+	if (fname == NULL) {
+		mfci_ErrorN("E01100301:fname is null.(mfCiOpen)");
+		return NULL;
+	}
+	if (rw != 0) {
+		mfci_ErrorN("E01100302:rw is illigal.(mfCiOpen)");
+		return NULL;
+	}
+	hn = NULL;
+	for (i = 0; i < MFCI_OBJ_MAX; i++) {
+		if (mfci_ObjTbl[i].stat == 0) {
+			hn = &mfci_ObjTbl[i];
+			break;
+		}
+	}
+	if (hn == NULL) {
+		mfci_ErrorN("E01100303:not enough handle resource.(mfCiOpen)");
+		return NULL;
+	}
+	strcpy(hn->fname, fname);
+	hn->sctsize = MFCI_SCT_SIZE;
+	mfci_get_adr_size(hn->fname, &size);
+	hn->size = size;
+	{
+		s32 n;
+		n        = hn->sctsize + hn->size;
+		n        = n - 1;
+		hn->nsct = n / hn->sctsize;
+	}
+	hn->pos   = 0;
+	hn->rdsct = 0;
+	hn->total = 0;
+	hn->busy  = 0;
+	hn->stat  = 1;
+	return hn;
+}
+
+u32 fn_802232E4(const char* fname)
+{
+	u32 size;
+
+	mfci_get_adr_size(fname, &size);
+	return size;
+}
+
+void fn_802233F0(MfciErrFunc func, void* obj)
+{
+	mfci_ErrFunc = func;
+	mfci_ErrObj  = obj;
+}
+
+void fn_80223404(void)
+{
+	s32 i;
+
+	for (i = 0; i < MFCI_OBJ_MAX; i++) {
+	}
+}
+
+void* fn_80223410(void)
+{
+	return mfci_IfTbl;
+}


### PR DESCRIPTION
## What

Carves the CRI MFCI translation unit out of the automatic split and reconstructs
it. **Not matching yet:** 528 of 644 instructions, 7 of the 14 functions
byte-exact. The object stays `NonMatching`, so it is not linked and every
artifact hash is unchanged.

    .text   0x80222A14-0x80223424      .rodata 0x80240168-0x80240400
    .data   0x8029BA48-0x8029BAB0      .bss    0x80427F78-0x80428970

Exact: fn_80222A14, fn_80222B0C, fn_80222B6C, fn_80222BD0, fn_80222EC8,
fn_8022301C, fn_802233F0.
Partial: fn_802230B4 116/140, fn_80222C40 96/162, fn_80222F28 57/61,
fn_802232E4 54/67, fn_80222A74 34/38, fn_80223410 2/5, fn_80223404 1/3.

## Evidence

The boundary is argued from five independent lines, all recorded in the file
header:

1. `.rodata` opens with the module's own banner, `\nMFCI/GC Ver.1.05 Build:May
   9 2003 17:10:33\n`, and runs to `0x80240400` where AXRNA's banner begins.
   CRI puts that banner in the library's main source file.
2. The `.bss` block is touched by exactly the twelve functions from
   `fn_80222A14` to `fn_802233F0`, and by nothing before or after.
3. Every `.rodata` label inside the range is reached only from this run.
4. The `.data` object is the module's interface table; its thirteen non-null
   entries are exactly the functions of the run, in reverse source order, and
   `fn_80223410` is the accessor that returns it.
5. The neighbours settle both ends. The lock/unlock pair the file calls sits
   just below the range but is shared plumbing: fourteen functions between
   `0x802127B0` and `0x8021B214` call it too.

Names (`mfCiOpen`, `mfCiOpenEntry`, `mfCiReqRd`, `mfci_get_adr_size`) come from
the error strings, where CRI writes the reporting function in parentheses.
Nothing else is renamed.

`game/cri/mfci.c` is added to `reviewed_c_boundary_sources`, the same category
that already holds `movieD/cri/sud.c`, `sfxcnv.c`, `sfxset.c` and `sfxahn.c`.
That category records language uncertainty for a vendor/middleware boundary
rather than claiming positive C evidence, which is the honest classification
here: the symbols are unmangled and there is no C++ construct, but that is
linkage evidence, not proof of the original extension.

No PS2 metadata was used. No binaries, assets or disassembly are included.

### What is left, and what is already ruled out

One shape blocks the two large functions. They reach five messages each through
a single base register (`addi rN, r30, 388`, r30 at the banner) and read the
module globals as displacements off a second base. Both ways of asking MWCC
1.3.2 for that make it emit `lis; addi base; addi +offset` everywhere — three
instructions where the twelve small functions want two:

    -sdata 0 -sdata2 0 -str reuse,readonly -use_lmw_stmw on    528   <- current
    ... with -str pool                                          408
    ... globals folded into one struct                          362
    ... -str pool with -opt peephole                            419

Compiler version is settled: 1.2.5/1.2.5n collapse, 1.3 gives 522, and 1.3.2
through 2.7 are byte-identical at 528.

## Verification

- [x] `python -m unittest tools.test_check_language_policy`
- [x] `python tools/check_language_policy.py --staged`
- [x] `clang-format` clean on the changed source
- [x] `ninja` passes and `sha1sum -c config/G9SE8P/build.sha1` is 18/18
- [x] objdiff result recorded above

`python tools/check_language_policy.py` without `--staged` cannot run on
Windows: it matches `-c src/...` while Ninja emits `-c src\...`. That is
pre-existing and unrelated to this change; CI runs it on Linux.

## AI assistance

Written with Claude Code. Every figure above is measured, not estimated.
