### PR TITLE
decomp: take CRI MFCI from 528 to 587 of 644 instructions

### DIFF
--- a/src/game/cri/mfci.c
+++ b/src/game/cri/mfci.c
@@ -37,20 +37,22 @@
 // Names come from the error strings, which CRI writes with the reporting
 // function in parentheses. Everything not named there keeps its dtk name.
 //
-// NOT MATCHING: 528 of 644 instructions. Seven of the fourteen functions are
-// byte-exact; mfCiReqRd and mfCiOpen carry most of what is left. See
-// notes/cri-mfci.md for the measurements, including what has already been
-// ruled out.
+// NOT MATCHING: 584 of 644 instructions. Eight of the fourteen functions are
+// byte-exact. See notes/cri-mfci.md for the measurements, including what has
+// already been ruled out.
 //
-// The open problem is one shape. Those two functions reach five messages each
-// through a single base register (addi rN, r30, 388, with r30 pointing at the
-// banner), and read the module globals as displacements off a second one. That
-// only works when the literals share one object and the globals share another.
-// Both ways of asking for that -- "-str pool" and folding the globals into one
-// struct -- make MWCC 1.3.2 emit "lis; addi base; addi +offset" everywhere,
-// three instructions where the twelve small functions want two, and the total
-// falls (408 and 362 against 528). The original evidently folds the offset into
-// @l when it does not hoist, and this compiler never does.
+// .rodata and .bss both match the original layout byte for byte. The .bss order
+// is load-bearing and not obvious: MWCC lays those statics out in order of
+// first reference, not order of declaration, so mfci_WorkStr only lands at
+// offset 8 because nothing touches mfci_ObjTbl before mfci_get_adr_size runs.
+// That is why mfCiOpenEntry below does not scan the table.
+//
+// What is left in mfCiReqRd and mfCiOpen is a two-register permutation, not a
+// shape difference: both are over 98% aligned on mnemonics, and the diff is
+// that the target puts the .bss base in r30 and the .rodata base in r29 while
+// this build swaps them. The prologues are otherwise instruction for
+// instruction identical. Local declaration order does not steer it -- all six
+// permutations in mfCiOpen measure the same.
 //
 // The .rodata also still carries the three "(mfCiOpenEntry)" messages although
 // no surviving function reads them. mfCiOpenEntry is reconstructed below as the
@@ -149,7 +151,6 @@ static void mfci_Error(const char* msg, void* arg)
 static MfciObj* mfCiOpenEntry(s32 no, s32 rw)
 {
 	MfciObj* hn;
-	s32 i;
 
 	if (no < 0 || no >= MFCI_OBJ_MAX) {
 		mfci_ErrorN("E1041001:invalid entry number.(mfCiOpenEntry)");
@@ -160,12 +161,6 @@ static MfciObj* mfCiOpenEntry(s32 no, s32 rw)
 		return NULL;
 	}
 	hn = NULL;
-	for (i = 0; i < MFCI_OBJ_MAX; i++) {
-		if (mfci_ObjTbl[i].stat == 0) {
-			hn = &mfci_ObjTbl[i];
-			break;
-		}
-	}
 	if (hn == NULL) {
 		mfci_ErrorN("E1041002:not enough handle resource.(mfCiOpenEntry)");
 		return NULL;
@@ -175,7 +170,7 @@ static MfciObj* mfCiOpenEntry(s32 no, s32 rw)
 
 static u32 mfci_get_adr_size(const char* fname, u32* size)
 {
-	char* p = (char*)fname;
+	char* p;
 	u32 v;
 
 	if (strlen(fname) != 17) {
@@ -187,6 +182,7 @@ static u32 mfci_get_adr_size(const char* fname, u32* size)
 		sprintf(mfci_WorkStr, "E01100309:illegal file name format '%s'(mfci_get_adr_size)", fname);
 		mfci_ErrorN(mfci_WorkStr);
 	}
+	p = (char*)fname;
 	v = strtoul(p, &p, 16);
 	if (*p != '\0') {
 		p++;
@@ -291,7 +287,10 @@ s32 fn_80222C40(MfciObj* hn, s32 nsct, void* buf)
 	}
 	hn->busy = 2;
 	adr      = mfci_get_adr_size(hn->fname, &size);
-	n        = hn->nbyte <= (s32)(size - hn->ofst) ? hn->nbyte : (s32)(size - hn->ofst);
+	n        = hn->nbyte;
+	if (n > (s32)(size - hn->ofst)) {
+		n = (s32)(size - hn->ofst);
+	}
 	memcpy(buf, (void*)(adr + hn->ofst), hn->nbyte);
 	memset((s8*)buf + n, 0, hn->nbyte - n);
 	hn->total = hn->rdsct * hn->sctsize;

--- a/src/game/cri/mfci.c
+++ b/src/game/cri/mfci.c
@@ -37,9 +37,16 @@
 // Names come from the error strings, which CRI writes with the reporting
 // function in parentheses. Everything not named there keeps its dtk name.
 //
-// NOT MATCHING: 584 of 644 instructions. Eight of the fourteen functions are
-// byte-exact. See notes/cri-mfci.md for the measurements, including what has
-// already been ruled out.
+// NOT MATCHING: 587 of 644 instructions. Ten of the fourteen functions are
+// byte-exact; mfCiReqRd, mfCiOpen, fn_80222A74 and fn_80222F28 are what is
+// left. See notes/cri-mfci.md for the measurements, including what has already
+// been ruled out.
+//
+// Two of the four closed on `volatile`, which is worth remembering. The target
+// keeps a load whose value is discarded (fn_80223410) and a loop whose body is
+// empty (fn_80223404); at -O4 nothing else makes MWCC keep either. Neither the
+// qualifier nor the read alone is enough -- the variable has to be volatile and
+// the read has to be written out.
 //
 // .rodata and .bss both match the original layout byte for byte. The .bss order
 // is load-bearing and not obvious: MWCC lays those statics out in order of
@@ -106,8 +113,8 @@ void fn_802233F0(MfciErrFunc func, void* obj);
 void fn_80223404(void);
 void* fn_80223410(void);
 
-const char mfci_ver[]                = "\nMFCI/GC Ver.1.05 Build:May  9 2003 17:10:33\n";
-static const char* const mfci_verptr = mfci_ver;
+const char mfci_ver[]                         = "\nMFCI/GC Ver.1.05 Build:May  9 2003 17:10:33\n";
+static const char* const volatile mfci_verptr = mfci_ver;
 
 static MfciErrFunc mfci_ErrFunc;
 static void* mfci_ErrObj;
@@ -212,9 +219,14 @@ void fn_80222A74(MfciObj* hn, s32 sctsize)
 	}
 	total       = hn->pos * hn->sctsize;
 	hn->sctsize = sctsize;
-	hn->nsct    = (hn->sctsize + hn->size - 1) / hn->sctsize;
-	hn->pos     = total / hn->sctsize;
-	hn->total   = hn->rdsct * sctsize;
+	{
+		s32 n;
+		n        = hn->sctsize + hn->size;
+		n        = n - 1;
+		hn->nsct = n / hn->sctsize;
+	}
+	hn->pos   = total / hn->sctsize;
+	hn->total = hn->rdsct * sctsize;
 }
 
 s32 fn_80222B0C(MfciObj* hn)
@@ -409,7 +421,7 @@ void fn_802233F0(MfciErrFunc func, void* obj)
 
 void fn_80223404(void)
 {
-	s32 i;
+	volatile s32 i;
 
 	for (i = 0; i < MFCI_OBJ_MAX; i++) {
 	}
@@ -417,5 +429,6 @@ void fn_80223404(void)
 
 void* fn_80223410(void)
 {
+	(void)mfci_verptr;
 	return mfci_IfTbl;
 }


### PR DESCRIPTION
## What

Continues `game/cri/mfci.c`. **Still NonMatching**, but ten of the fourteen
functions are now byte-exact, up from seven, and the object's .rodata and .bss
layouts match the original exactly.

    528 -> 587 of 644 instructions
    newly exact: fn_802232E4, fn_80223404, fn_80223410

Artifact hashes are unchanged (the object is not linked); `sha1sum -c` is 18/18.

## Evidence

Three findings did the work, all measured:

1. **MWCC orders .bss by first reference, not by declaration.** `mfci_WorkStr`
   only lands at offset 8 because nothing touches `mfci_ObjTbl` before
   `mfci_get_adr_size` runs; that is why the reconstructed `mfCiOpenEntry`
   does not scan the table. Worth +16 on its own and closed fn_802232E4.
2. **`mfci_get_adr_size` returns the address rather than writing it through an
   out-parameter.** That is what explains the first `strtoul` result being
   discarded in mfCiOpen but kept in mfCiReqRd, and why only the `size` guard
   survives inlining.
3. **Two functions needed `volatile`.** The target keeps a load whose value is
   discarded and a loop whose body is empty; at -O4 nothing else preserves
   either. Neither the qualifier nor the read alone is enough -- all sixteen
   combinations were tried and only volatile-plus-written-read works.

No PS2 metadata, no binaries, no disassembly.

### What is left

A two-register permutation in mfCiReqRd and mfCiOpen: both are over 98% aligned
on mnemonics and the prologues are instruction for instruction identical, but
the target puts the .bss base in r30 and the .rodata base in r29 while this
build swaps them. Ruled out: all six local declaration orders, seven -opt
sub-options, three error-helper shapes, static linkage on the globals, section
declaration order, and a padding static. fn_80222F28 is one branch short and
fn_80222A74 is a register permutation at 100% mnemonic alignment.

Details in notes/cri-mfci.md.

## Verification

- [x] `python -m unittest tools.test_check_language_policy`
- [x] `python tools/check_language_policy.py --staged`
- [x] clang-format clean
- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18

## AI assistance

Written with Claude Code. Every figure is measured.