### PR TITLE
decomp: match MSL fwide

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -381,6 +381,9 @@ MSL_C/uart_console_io.c:
 	.text       start:0x801C5900 end:0x801C59CC
 	.sbss       start:0x8042CAC0 end:0x8042CAC4
 
+MSL_C/wchar_io.c:
+	.text       start:0x801C59CC end:0x801C5A54
+
 dolphin/trk/nubevent.c:
 	.text       start:0x801C9418 end:0x801C9738
 	.bss        start:0x803EE0C8 end:0x803EE0F0

--- a/configure.py
+++ b/configure.py
@@ -328,6 +328,7 @@ config.libs = [
             ),
             Object(Matching, "MSL_C/strtoul.c"),
             Object(Matching, "MSL_C/uart_console_io.c"),
+            Object(Matching, "MSL_C/wchar_io.c"),
         ],
     },
     {

--- a/src/MSL_C/wchar_io.c
+++ b/src/MSL_C/wchar_io.c
@@ -1,0 +1,39 @@
+#include "MSL_C/file_io.h"
+
+enum {
+	__closed_file,
+};
+
+enum {
+	__unoriented,
+	__char_oriented,
+	__wide_oriented,
+};
+
+s32 fwide(FILE* file, s32 mode)
+{
+	s32 orientation;
+	s32 result;
+
+	if (file == 0 || file->mode.file_kind == __closed_file)
+		return 0;
+
+	orientation = file->mode.file_orientation;
+	switch (orientation) {
+		case __unoriented:
+			if (mode > 0)
+				file->mode.file_orientation = __wide_oriented;
+			else if (mode < 0)
+				file->mode.file_orientation = __char_oriented;
+			result = mode;
+			break;
+		case __wide_oriented:
+			result = 1;
+			break;
+		case __char_oriented:
+			result = -1;
+			break;
+	}
+
+	return result;
+}


### PR DESCRIPTION
## What

Reconstructs the MSL C `wchar_io.c` translation unit containing `fwide`.

The function is byte-exact and the object is marked `Matching` in `configure.py`.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and included only the minimum symbolic fact and independent GameCube correlation.
- [x] If I changed inline flags, I documented the source/emission order and compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or links to those materials.

Evidence and references:

- `fwide` is an MSL standard-library function adjacent to the existing MSL objects in the GameCube binary.
- The retained symbol, function boundary, packed `FILE` fields, branches, and orientation values are independently constrained by the GameCube object and existing `MSL_C/file_io.h`.
- The source is compiled as C by the existing MSL library configuration using Metrowerks GC/1.3.
- No PS2 metadata was used.

## Verification

- [x] `python3 tools/check_language_policy.py`
- [x] `python3 -m unittest tools.test_check_language_policy`
- [x] `clang-format -i src/MSL_C/wchar_io.c`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:

- Before: autogenerated assembly with no reconstructed source function.
- After: `fwide` is 100% byte-exact (136/136 code bytes).
- Full `ninja` completes and `CHECK config/G9SE8P/build.sha1` reports `18 files OK`.

## AI assistance

Developed with AI assistance. Match percentage, size, and verification results above were measured locally.