### PR TITLE
decomp: match fn_80223500 in the CRI AXRNA unit

### DIFF
--- a/src/game/cri/axrna.c
+++ b/src/game/cri/axrna.c
@@ -37,16 +37,48 @@ struct AxObj {
 
 typedef struct AxRna {
 	/* 0x00 */ s8 stat;
-	/* 0x01 */ s8 pad01[2];
+	/* 0x01 */ s8 pad01;
+	/* 0x02 */ s8 nch;
 	/* 0x03 */ s8 idx;
-	/* 0x04 */ u8 pad04[0x30];
-	/* 0x34 */ AxObj* slot[4];
-	/* 0x44 */ u8 pad44[0xA4];
+	/* 0x04 */ u8 pad04[4];
+	/* 0x08 */ AxObj* obj[11];
+	/* 0x34 */ AxObj* slot[21];
+	/* 0x88 */ s32 pan[11];
+	/* 0xB4 */ u8 padB4[0x34];
 } AxRna;
 
 #define AX_RNA_MAX 16
 
 extern void fn_8022347C(void* func, void* obj);
+extern void fn_80223490(void);
+extern void fn_802234B0(void);
+extern void fn_801E89CC(AxObj* obj, s32 v);
+
+extern s32 ax_PanTbl[31];
+
+void fn_80223500(AxRna* p, s32 ch, s32 v)
+{
+	s32 n;
+
+	if (p == NULL) {
+		return;
+	}
+	if (ch >= p->nch) {
+		return;
+	}
+	n = v >= 15 ? 15 : v;
+	n = n <= -15 ? -15 : n;
+	if (n == p->pan[ch]) {
+		return;
+	}
+	p->pan[ch] = n;
+	fn_802234B0();
+	if (p->obj[ch] != NULL) {
+		fn_801E89CC(p->obj[ch], ax_PanTbl[n + 15]);
+	}
+	fn_80223490();
+}
+
 extern void fn_80223820(AxRna* p);
 
 static AxRna ax_Tbl[AX_RNA_MAX];


### PR DESCRIPTION
Continues `game/cri/axrna.c`. Eight of the twenty-two functions are now byte-exact, up from seven. Still NonMatching, so the object is not linked and every artifact hash is unchanged (18/18).

## Evidence

`fn_80223500` is a per-channel pan setter. It clamps the value to [-15, 15], writes it into the handle's pan array at 0x88, and if the channel has a live object at 0x08 it pushes the value through a 31-entry table in .data at 0x8029BAB4, indexed by `n + 15`. The table's 124 bytes are exactly 31 words, which is what fixes the index bias.

That gave three more struct offsets — the channel count at 0x02 and the arrays at 0x08 and 0x88 — which the remaining functions will need.

The last instruction came down to operand order: the target emits `cmpw r31, r0`, so the source compares `n == p->pan[ch]`, not the other way round.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] objdiff: fn_80223500 45/45, 100% mnemonic and byte-exact
- [x] clang-format clean, language policy checks pass