### PR TITLE
decomp: match both AXRNA stream callbacks

### DIFF
--- a/src/game/cri/axrna.c
+++ b/src/game/cri/axrna.c
@@ -27,13 +27,25 @@
 typedef struct AxObj AxObj;
 
 typedef struct AxVtbl {
-	/* 0x00 */ u8 pad00[0x24];
+	/* 0x00 */ u8 pad00[0x20];
+	/* 0x20 */ void (*put)(AxObj* obj, s32 which, void* buf);
 	/* 0x24 */ s32 (*get)(AxObj* obj, s32 arg);
 } AxVtbl;
+
+typedef struct AxCb {
+	/* 0x00 */ s32 pad00;
+	/* 0x04 */ s32 id;
+} AxCb;
 
 struct AxObj {
 	/* 0x00 */ AxVtbl* vtbl;
 };
+
+typedef struct AxStream {
+	/* 0x00 */ s32 flag[2];
+	/* 0x08 */ s32 acc;
+	/* 0x0C */ s32 total;
+} AxStream;
 
 typedef struct AxRna {
 	/* 0x00 */ s8 stat;
@@ -41,11 +53,17 @@ typedef struct AxRna {
 	/* 0x02 */ s8 nch;
 	/* 0x03 */ s8 idx;
 	/* 0x04 */ u8 pad04[4];
-	/* 0x08 */ AxObj* obj[11];
-	/* 0x34 */ AxObj* slot[20];
+	/* 0x08 */ AxObj* obj[2];
+	/* 0x10 */ u8 pad10[0x20];
+	/* 0x30 */ AxObj* strmA[2];
+	/* 0x38 */ AxObj* strmB[2];
+	/* 0x40 */ u8 bufA[2][8];
+	/* 0x50 */ u8 bufB[2][8];
+	/* 0x60 */ AxStream st[2];
+	/* 0x80 */ s32 pad80;
 	/* 0x84 */ s32 vol;
-	/* 0x88 */ s32 pan[11];
-	/* 0xB4 */ u8 padB4[0x34];
+	/* 0x88 */ s32 pan[2];
+	/* 0x90 */ u8 pad90[0x58];
 } AxRna;
 
 #define AX_RNA_MAX 16
@@ -135,7 +153,7 @@ s32 fn_80223E78(AxRna* p)
 	if (p == NULL) {
 		return -1;
 	}
-	return (s32)((u32)p->slot[p->idx]->vtbl->get(p->slot[p->idx], 0) >> 1);
+	return (s32)((u32)p->strmA[p->idx + 1]->vtbl->get(p->strmA[p->idx + 1], 0) >> 1);
 }
 
 s32 fn_80223ED0(AxRna* p)
@@ -143,7 +161,44 @@ s32 fn_80223ED0(AxRna* p)
 	if (p == NULL) {
 		return -1;
 	}
-	return 4096 - (s32)((u32)p->slot[p->idx]->vtbl->get(p->slot[p->idx], 0) >> 1);
+	return 4096 - (s32)((u32)p->strmA[p->idx + 1]->vtbl->get(p->strmA[p->idx + 1], 0) >> 1);
+}
+
+void fn_80223B58(AxCb* cb)
+{
+	s32 x;
+	AxRna* p;
+	s32 ch;
+
+	x  = cb->id & 0x7FFFFFFF;
+	p  = &ax_Tbl[x / 2];
+	ch = x % 2;
+	if (p->st[1].flag[ch] == 1) {
+		p->strmB[ch]->vtbl->put(p->strmB[ch], 1, &p->bufB[ch]);
+		p->st[1].flag[ch] = 0;
+		if (ch == p->idx - 1) {
+			p->st[1].total += p->st[1].acc;
+		}
+	}
+}
+
+void fn_80223C24(AxCb* cb)
+{
+	s32 x;
+	AxRna* p;
+	s32 ch;
+
+	x  = cb->id & 0x7FFFFFFF;
+	p  = &ax_Tbl[x / 2];
+	ch = x % 2;
+	if (p->st[0].flag[ch] == 1) {
+		p->strmA[ch]->vtbl->put(p->strmA[ch], 0, &p->bufA[ch]);
+		p->strmB[ch]->vtbl->put(p->strmB[ch], 1, &p->bufB[ch]);
+		p->st[0].flag[ch] = 0;
+		if (ch == p->idx - 1) {
+			p->st[0].total += p->st[0].acc;
+		}
+	}
 }
 
 extern void fn_801E8984(AxObj* obj);


### PR DESCRIPTION
Continues `game/cri/axrna.c`: **eleven of twenty-two functions byte-exact**, up from nine. Still NonMatching, artifact hashes unchanged (18/18).

## Evidence

The two DSP callbacks, `fn_80223B58` and `fn_80223C24`, decode their handle from a packed id: `x = cb->id & 0x7FFFFFFF` selects the table entry with `x / 2` and the channel with `x % 2`. The compiler's signed div/mod-by-two sequence is what makes the masking visible — the sign correction is emitted even though the mask guarantees it is a no-op.

They also pinned the handle layout. `AxRna` now has **two parallel streams** with identical shape at 0x60 and 0x70 (`flag[2]`, `acc`, `total`), a pointer pair at 0x30 and 0x38, and matching eight-byte buffers at 0x40 and 0x50. Modelling those as one four-element array does not work: the target folds the second stream's index into the constant offset (`56(r3)`, `80(r4)`), which only happens with separate arrays. Splitting them also closed `fn_80223E78` and `fn_80223ED0`, which had been passing for the wrong reason.

**Declaration order was the last lever**, and this is worth recording: both callbacks sat at 100% mnemonic alignment with zero shape gaps and a pure r30/r31 swap, and declaring the handle pointer before the channel index closed both at once. The same trick does *not* work on `fn_802235B4` and `fn_802237C4`, where the conflicting register is a compiler-generated loop pointer rather than a source variable — those stay at 35/43 and 19/23, both already 100% mnemonic.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] objdiff: fn_80223B58 51/51, fn_80223C24 55/55, fn_80223E78 22/22, fn_80223ED0 23/23
- [x] clang-format clean, language policy checks pass