### PR TITLE
decomp: reconstruct the AXRNA init path

### DIFF
--- a/src/game/cri/axrna.c
+++ b/src/game/cri/axrna.c
@@ -76,6 +76,9 @@ extern void fn_801E89CC(AxObj* obj, s32 v);
 
 extern s32 ax_PanTbl[31];
 
+const char ax_ver[]                         = "\nAXRNA Ver.1.02 Build:May  9 2003 17:10:58\n";
+static const char* const volatile ax_verptr = ax_ver;
+
 void fn_80223500(AxRna* p, s32 ch, s32 v)
 {
 	s32 n;
@@ -124,6 +127,12 @@ void fn_802235B4(AxRna* p, s32 v)
 
 extern void fn_80223820(AxRna* p);
 
+static s32 ax_RefCnt;
+static void* ax_AlignedBuf;
+static s32 ax_X[2];
+static s32 ax_Y;
+static s32 ax_Z[32];
+static u8 ax_Buf[4160];
 static AxRna ax_Tbl[AX_RNA_MAX];
 
 void fn_802237B4(void* p, s8 v)
@@ -202,6 +211,19 @@ void fn_80223C24(AxCb* cb)
 }
 
 extern void fn_801E8984(AxObj* obj);
+extern void fn_80224F88(void);
+extern void* memset(void* p, int c, u32 n);
+
+void fn_80224C3C(void)
+{
+	(void)ax_verptr;
+	if (ax_RefCnt == 0) {
+		fn_80224F88();
+		memset(ax_Tbl, 0, sizeof(ax_Tbl));
+		ax_AlignedBuf = (void*)(((u32)ax_Buf + 31) & ~31);
+	}
+	ax_RefCnt++;
+}
 
 void fn_80224A88(AxObj* obj)
 {


### PR DESCRIPTION
Continues `game/cri/axrna.c`. Eleven of twenty-two functions still byte-exact; this adds the module's version banner, its .bss working set, and `fn_80224C3C` at 22/29.

## Evidence

The **.rodata now matches the original exactly**: the AXRNA banner at offset 0 and a pointer to it at 0x2C, the same banner-plus-pointer shape MFCI has. `fn_80224C3C` reads that pointer and throws the value away, which needs the `volatile`-plus-written-read combination — the same one that closed two MFCI functions.

`fn_80224C3C` is the refcounted init: on the first call it runs the module init, zeroes the sixteen-entry handle table, and stores a 32-byte-aligned pointer into the working buffer. That fixes four .bss offsets — refcount at 0, aligned pointer at 4, buffer at 148, table at 4308 — and `.bss` is now 0x1F54 against the target's 0x1F58, four bytes short of exact.

## The open problem, measured

The .bss ordering does not come out right, and it is not what I assumed. Probing declaration permutations shows **declaration order barely matters**: MWCC emits referenced statics first, grouped by alignment descending then size descending, and unreferenced ones last in reverse declaration order. That is why the 3712-byte table lands at offset 0 and the 4160-byte buffer at the end.

The target's order is plain declaration order, which none of those rules produce. Ruled out: `-common off`, every declaration permutation, and folding the statics into one struct — the struct is actively worse, it broke three functions that already matched, exactly as it did in MFCI.

The open hypothesis is that the layout resolves itself once `fn_80223D00` and `fn_8022439C` are written, because they reference three statics that are currently unreferenced and therefore sorted to the end. Worth testing before spending more on flags. Recorded in notes/cri-metodo.md, along with a correction: my earlier note claimed .bss follows first-reference order, and that was generalising from one case.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] .rodata byte-exact against the target
- [x] clang-format clean, language policy checks pass