### PR TITLE
decomp: reconstrói fn_802242CC na unidade CRI AXRNA

### DIFF
--- a/src/game/cri/axrna.c
+++ b/src/game/cri/axrna.c
@@ -27,7 +27,9 @@
 typedef struct AxObj AxObj;
 
 typedef struct AxVtbl {
-	/* 0x00 */ u8 pad00[0x20];
+	/* 0x00 */ u8 pad00[0xc];
+	/* 0x0c */ void (*stop)(AxObj* obj);
+	/* 0x10 */ u8 pad10[0x10];
 	/* 0x20 */ void (*put)(AxObj* obj, s32 which, void* buf);
 	/* 0x24 */ s32 (*get)(AxObj* obj, s32 arg);
 } AxVtbl;
@@ -54,7 +56,8 @@ typedef struct AxRna {
 	/* 0x03 */ s8 idx;
 	/* 0x04 */ u8 pad04[4];
 	/* 0x08 */ AxObj* obj[2];
-	/* 0x10 */ u8 pad10[0x20];
+	/* 0x10 */ AxCb* cb[2];
+	/* 0x18 */ u8 pad18[0x18];
 	/* 0x30 */ AxObj* strmA[2];
 	/* 0x38 */ AxObj* strmB[2];
 	/* 0x40 */ u8 bufA[2][8];
@@ -260,6 +263,37 @@ s32 fn_80224CE8(void* p)
 		return 0;
 	}
 	return *(s32*)((s8*)p + 4);
+}
+
+extern void fn_80223F2C(AxRna* p, s32 v);
+extern void fn_802240CC(AxRna* p, s32 v);
+extern void fn_801E221C(AxObj* obj);
+extern void fn_80224D00(void* p);
+
+void fn_802242CC(AxRna* p)
+{
+	s32 i;
+
+	if (p == NULL) {
+		return;
+	}
+	fn_80223F2C(p, 0);
+	fn_802240CC(p, 0);
+	for (i = 0; i < p->nch; i++) {
+		if (p->strmB[i] != NULL) {
+			p->strmB[i]->vtbl->stop(p->strmB[i]);
+		}
+		if (p->cb[i] != NULL) {
+			fn_80224D00(p->cb[i]);
+		}
+		fn_802234B0();
+		if (p->obj[i] != NULL) {
+			fn_801E8984(p->obj[i]);
+			fn_801E221C(p->obj[i]);
+		}
+		fn_80223490();
+	}
+	memset(p, 0, sizeof(AxRna));
 }
 
 void fn_80224D00(void* p)


### PR DESCRIPTION
## What

Reconstrução byte-exata de `fn_802242CC` (0x802242CC) na unidade `game/cri/axrna.c` — a rotina de "shutdown"/liberação de canal de um `AxRna`: chama `fn_80223F2C`/`fn_802240CC`, percorre os `nch` canais parando o stream B via vtable, limpando o callback pendente (`cb[i]`), liberando o objeto de voz sob lock (`fn_802234B0`/`fn_80223490`) e por fim zera a struct inteira com `memset`.

Dois campos até então marcados como padding em structs já existentes foram nomeados a partir dessa evidência:
- `AxVtbl`: slot de vtable em 0x0c (`stop`), chamado só com `this`.
- `AxRna`: `cb[2]` (`AxCb*`) em 0x10, antes coberto por `pad10`.

A unidade `game/cri/axrna.c` segue `NonMatching` (ainda restam outras funções em assembly), mas essa função específica agora bate 100%.

## Evidence

- [x] Identifiquei a função via desmontagem do `.s` extraído (`fn_802242CC`), não por hipótese externa.
- [x] Não se aplica (não é fronteira C ABI nova).
- [x] Os dois campos renomeados vieram de leitura direta dos offsets acessados pela própria função (evidência GameCube), sem uso de metadado PS2.
- [x] Não se aplica.
- [x] Não mudei flags de compilação; só a ordem textual da função em relação a `fn_80224D00` foi ajustada (movida para antes da definição) para reproduzir a decisão de inlining do `-inline auto` do alvo — `fn_80224D00` só é referenciada como `extern` até esse ponto do arquivo, então a chamada permanece `bl` em vez de ser inlinada.
- [x] Nenhum binário, asset, assembly extraído ou fonte vazado foi adicionado.

Evidência e referências: leitura direta do `.s` desmontado do objeto original (`build/G9SE8P/asm/game/cri/axrna.s`); campos derivados por correlação com os offsets já nomeados em `AxRna`/`AxVtbl` no mesmo arquivo (`obj[2]`, `strmA[2]`, `strmB[2]`).

## Verification

- [x] `python tools/check_language_policy.py`
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `clang-format -i` nos arquivos alterados
- [x] resultado do objdiff registrado abaixo
- [x] `ninja` passa e o `build.sha1` continua 18/18 OK

Objdiff antes/depois: `fn_802242CC` 0% (assembly puro) → **100% (*** MATCH ***)**, 54/54 instruções.