### PR TITLE
docs(mfci): record what has been ruled out on the three remaining functions

### DIFF
--- a/src/game/cri/mfci.c
+++ b/src/game/cri/mfci.c
@@ -52,16 +52,36 @@
 //
 //   fn_80222C40 differs only in register allocation: the target ranks the
 //   handle above the buffer (r29/r28), this build ranks the buffer above the
-//   handle. Every instruction, every relocation and the function size already
-//   agree. Local declaration order, local types, helper extraction and the
-//   shape of the clamp all leave the ranking untouched.
+//   handle, and the two callee-saved registers the string and .bss bases free
+//   up afterwards follow that swap. Every instruction, every relocation and the
+//   function size already agree; 48 bytes differ and all of them are register
+//   fields. Ruled out: local declaration order, local types (`u32` vs a pointer
+//   for the address, signedness of the clamp), aliasing the buffer through a
+//   local `s8*`, extracting the min, the request setup or the memset tail into
+//   a static helper, and reshaping mfci_get_adr_size, which is inlined here.
+//   The mfCiOpenEntry lever described below is binary and already saturated:
+//   its two states give handle-above-buffer with the .rodata base sunk too far,
+//   or the base order right with the handle and buffer swapped. Neither is the
+//   target, so the remaining nudge has to come from somewhere else again.
 //
 //   fn_80222F28 is one instruction short. The target lowers the final clamp
 //   branchily -- `ble` into the block, `b` past the `li` into the shared store,
-//   which is a select with the value in r0. Every `?:` spelling of that clamp
-//   makes this compiler emit the branchless `neg/andc/srawi/and` sequence
-//   instead, and every `if`/`else` spelling makes it invert the test and drop
-//   the `b`.
+//   so both arms converge on one `stw` with the value in r0. That the compiler
+//   is willing to branch for a select is not in doubt: the preceding clamp
+//   against nsct is emitted exactly that way. It is the zero that is the
+//   problem. Every `?:` spelling whose false arm reaches zero -- literal,
+//   returned from a static helper, `off - off`, `whence & 0`, a local assigned
+//   0 -- constant-propagates before the idiom recogniser runs, and the clamp
+//   comes out as branchless `neg/andc/srawi/and`. Every plain `if`/`else`
+//   spelling has an empty then-arm, which the compiler answers by inverting
+//   the test and dropping the `b`.
+//
+//   The closest miss is worth keeping. Route both arms through a same-TU
+//   static setter -- `if (hn->pos > 0) { mfci_SetPos(hn, hn->pos); } else {
+//   mfci_SetPos(hn, 0); }` -- and the branch layout comes out exactly right,
+//   `ble` into the block and `b` skipping the `li`. What is left over is the
+//   then-arm's own redundant `stw`, which this compiler does not tail-merge
+//   with the else-arm's, so the function lands at 248 against the target's 244.
 //
 //   fn_80223404 is three instructions in the target -- `li r0, 0`,
 //   `cmpwi r0, 0x28`, `blr` -- the dead remains of a loop the optimiser
@@ -69,8 +89,13 @@
 //   the object table calling mfCiExecHndl, which is empty there (eight bytes,
 //   `jr ra`). Inlining that empty callee here removes the loop outright, so
 //   this build emits only `blr`; keeping the counter alive instead yields a
-//   `mtctr`/`bdnz` spin, and `volatile` yields a full stack frame. None of the
-//   three is the target.
+//   `mtctr`/`bdnz` spin, and `volatile` yields a full stack frame. Those three
+//   are attractors, not a spectrum -- index and pointer walks, `while`, `do`,
+//   `goto`, a `break`, an empty inner loop, `-inline deferred` and empty
+//   callees nested two and three deep all land on one of them. The target sits
+//   between the first two: the loop was deleted late enough that its guard had
+//   already been emitted, and its trip count never became a `ctr` loop, which
+//   here happens only while the body still holds a call.
 //
 // The register allocation of mfCiOpen and mfCiReqRd turned out to be steered
 // from outside those functions. Whether mfCiOpenEntry touches a third .bss


### PR DESCRIPTION
Só comentário. Nenhuma mudança de código, `build.sha1` continua com 18 files OK
e as onze funções byte-exatas de `mfci.c` continuam byte-exatas.

Registra o que foi descartado nas três que faltam, para a próxima rodada não
repetir o mesmo caminho.

**`fn_80222C40` (`mfCiReqRd`)** — 48 bytes diferem e todos são campos de
registrador. Descartados: ordem e tipos dos locais, alias do buffer por um
`s8*` local, extração do mínimo / do setup do request / da cauda do `memset`
para helper estático, e remodelagem de `mfci_get_adr_size` (que é inlined ali).
A alavanca do `mfCiOpenEntry` é binária e já está saturada: um estado dá
handle acima de buffer com a base de `.rodata` afundada demais, o outro dá a
ordem das bases certa com handle e buffer trocados.

**`fn_80222F28` (`mfCiSeek`)** — o compilador aceita gerar select com desvio: o
clamp anterior contra `nsct` sai exatamente assim. O problema é o zero. Toda
grafia com `?:` cujo ramo falso chega a zero — literal, retorno de helper,
`off - off`, `whence & 0`, local atribuído 0 — propaga a constante antes do
reconhecedor de idioma e vira `neg/andc/srawi/and`. Toda grafia com `if`/`else`
tem o ramo verdadeiro vazio e o compilador responde invertendo o teste.

O quase-acerto ficou registrado: roteando os dois ramos por um setter estático
do mesmo TU, o layout de desvios sai exatamente certo (`ble` para dentro do
bloco, `b` pulando o `li`). Sobra o `stw` redundante do ramo verdadeiro, que
este compilador não faz tail-merge com o do ramo falso — 248 contra 244.

**`fn_80223404` (`mfCiExecServer`)** — as três saídas conhecidas (`blr`, spin
com `mtctr`/`bdnz`, frame completo com `volatile`) são atratores, não um
espectro. Caminhada por índice e por ponteiro, `while`, `do`, `goto`, `break`,
laço interno vazio, `-inline deferred` e callees vazias aninhadas em dois e três
níveis caem todas em um dos três. O alvo fica entre os dois primeiros: o laço
foi apagado tarde o bastante para a guarda já ter sido emitida, e a contagem
nunca virou laço de `ctr` — o que aqui só acontece enquanto o corpo ainda tem
uma chamada.
