### PR TITLE
feat: match fn_8005EC0C

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -141,6 +141,9 @@ game/Endian.cpp:
 	.text       start:0x8004BECC end:0x8004C160
 	.ctors      start:0x802398D0 end:0x802398D4
 
+game/fn_8005EC0C.cpp:
+	.text       start:0x8005EC0C end:0x8005EC14
+
 game/dAnim.cpp:
 	extab       start:0x80007B40 end:0x80007B70
 	extabindex  start:0x8000E1AC end:0x8000E1F4

--- a/configure.py
+++ b/configure.py
@@ -610,6 +610,11 @@ config.libs = [
             ),
             Object(
                 Matching,
+                "game/fn_8005EC0C.cpp",
+                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
+            ),
+            Object(
+                Matching,
                 "game/GetSpParam.cpp",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),

--- a/src/game/fn_8005EC0C.cpp
+++ b/src/game/fn_8005EC0C.cpp
@@ -1,0 +1,12 @@
+#include "types.h"
+
+// Reconstruction fragment for fn_8005EC0C. The function's eight-byte range is
+// exact, but it is only an island between the larger functions at 0x8005EA04
+// and 0x8005EC14, not evidence of an original translation-unit boundary.
+
+extern "C" void* lbl_8042C2A8;
+
+extern "C" void* fn_8005EC0C(void)
+{
+	return lbl_8042C2A8;
+}


### PR DESCRIPTION
## What

Describe the one logical unit changed by this pull request.

## Evidence

- [ ] I identified the source language and linkage from evidence, not from the
      current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a
      reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known
      library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and
      included only the minimum symbolic fact and independent GameCube
      correlation.
- [x] If I changed inline flags, I documented the source/emission order and
      compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or
      links to those materials.

Evidence and references:

<!-- Give symbol names, strings, vtable relationships, public references or
     compiler experiments. Do not attach proprietary artifacts. -->

## Verification

<!-- Full artifact CI for a fork runs only after a maintainer reviews the
     commits and tests them from a repository-owned integration branch. -->

- [x] `python tools/check_language_policy.py`
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:
