### PR TITLE
decomp: reconstruct mfCiExecServer from the PS2 body

### DIFF
--- a/src/game/cri/mfci.c
+++ b/src/game/cri/mfci.c
@@ -87,15 +87,18 @@
 //   `cmpwi r0, 0x28`, `blr` -- the dead remains of a loop the optimiser
 //   deleted after emitting its guard. The PS2 build shows the body: a walk over
 //   the object table calling mfCiExecHndl, which is empty there (eight bytes,
-//   `jr ra`). Inlining that empty callee here removes the loop outright, so
-//   this build emits only `blr`; keeping the counter alive instead yields a
-//   `mtctr`/`bdnz` spin, and `volatile` yields a full stack frame. Those three
-//   are attractors, not a spectrum -- index and pointer walks, `while`, `do`,
-//   `goto`, a `break`, an empty inner loop, `-inline deferred` and empty
+//   `jr ra`), guarded at the call site by the same stat test. Reproducing that
+//   split exactly -- empty callee, test in the caller -- lets this compiler
+//   delete the loop outright and emit a bare `blr`. Moving the test into the
+//   callee instead keeps the loop, as a `mtctr`/`bdnz` spin; that is what is
+//   written below, because it is the closest of the three shapes this compiler
+//   will produce. The third is `volatile`, which yields a full stack frame.
+//   They are attractors, not a spectrum: index and pointer walks, `while`,
+//   `do`, `goto`, a `break`, an empty inner loop, `-inline deferred` and empty
 //   callees nested two and three deep all land on one of them. The target sits
-//   between the first two: the loop was deleted late enough that its guard had
-//   already been emitted, and its trip count never became a `ctr` loop, which
-//   here happens only while the body still holds a call.
+//   between the first two -- the loop was deleted late enough that its guard
+//   had already been emitted, and its trip count never became a `ctr` loop,
+//   which here happens only while the body still holds a call.
 //
 // The register allocation of mfCiOpen and mfCiReqRd turned out to be steered
 // from outside those functions. Whether mfCiOpenEntry touches a third .bss
@@ -482,11 +485,22 @@ void fn_802233F0(MfciErrFunc func, void* obj)
 	mfci_ErrObj  = obj;
 }
 
+// Empty on the PS2 build too (eight bytes, `jr ra`), where the caller guards
+// the call with the same stat test. Folding the test into the callee is the
+// one shape that keeps the loop alive here; see the header.
+static void mfCiExecHndl(MfciObj* hn)
+{
+	if (hn->stat == 0) {
+		return;
+	}
+}
+
 void fn_80223404(void)
 {
 	s32 i;
 
 	for (i = 0; i < MFCI_OBJ_MAX; i++) {
+		mfCiExecHndl(&mfci_ObjTbl[i]);
 	}
 }
 


### PR DESCRIPTION
Non-match deliberado. `fn_80223404` (`mfCiExecServer`) sai de 33,33% para 46,33%
no objdiff, de 4 para 16 bytes contra os 12 do alvo. As onze funções byte-exatas
de `mfci.c` continuam byte-exatas e `build.sha1` segue com 18 files OK.

O corpo vem do build PS2, que tem símbolos: `mfCiExecServer` varre a tabela de
objetos e chama `mfCiExecHndl`, que lá é vazia (oito bytes, `jr ra`), guardada
no chamador pelo teste de `stat`.

Reproduzir essa divisão exatamente — callee vazia, teste no chamador — faz este
compilador apagar o laço inteiro e emitir só `blr`. Movendo o teste para dentro
da callee o laço sobrevive, como spin `mtctr`/`bdnz`. É a mais próxima das três
formas que este compilador produz, então é a que fica escrita. A terceira é
`volatile`, que gera frame completo.

O alvo fica entre as duas primeiras: o laço foi apagado tarde o bastante para a
guarda já ter sido emitida, e a contagem nunca virou laço de `ctr` — o que aqui
só acontece enquanto o corpo ainda tem uma chamada. O cabeçalho do arquivo
registra isso e o que já foi descartado.
