### PR TITLE
decomp: carve four data-free leaf functions out of the game asm

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -137,9 +137,21 @@ game/vibration.cpp:
 	.data       start:0x80241308 end:0x80241358
 	.sdata2     start:0x8042D038 end:0x8042D048
 
+game/fn_8003F300.cpp:
+	.text       start:0x8003F300 end:0x8003F308
+
+game/fn_80042864.cpp:
+	.text       start:0x80042864 end:0x8004286C
+
 game/Endian.cpp:
 	.text       start:0x8004BECC end:0x8004C160
 	.ctors      start:0x802398D0 end:0x802398D4
+
+game/fn_8005776C.cpp:
+	.text       start:0x8005776C end:0x80057774
+
+game/fn_8005F794.cpp:
+	.text       start:0x8005F794 end:0x8005F79C
 
 game/dAnim.cpp:
 	extab       start:0x80007B40 end:0x80007B70

--- a/configure.py
+++ b/configure.py
@@ -488,6 +488,8 @@ config.libs = [
         "progress_category": "game",
         "objects": [
             Object(Matching, "game/object_defaults.cpp"),
+            Object(Matching, "game/fn_8003F300.cpp"),
+            Object(Matching, "game/fn_80042864.cpp"),
             Object(
                 Matching,
                 "game/skeleton.cpp",
@@ -609,6 +611,8 @@ config.libs = [
                 "game/Endian.cpp",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
+            Object(Matching, "game/fn_8005776C.cpp"),
+            Object(Matching, "game/fn_8005F794.cpp"),
             Object(
                 Matching,
                 "game/GetSpParam.cpp",

--- a/src/game/fn_8003F300.cpp
+++ b/src/game/fn_8003F300.cpp
@@ -1,0 +1,20 @@
+#include "types.h"
+
+// fn_8003F300 is two instructions -- `li r3, 0` followed by `blr` -- at 0x8003F300.
+//
+// The bounds are the function's own range and nothing more. dtk already gives
+// this function an object of its own, because every one of its neighbours in
+// this stretch is its own auto object too, so that split carries no
+// translation-unit information. What can be said is narrower and is the reason
+// the carve is safe: the function references no data at all -- no .rodata, no
+// .sdata, no .bss, no .sbss -- so pulling it into its own unit cannot separate
+// a static from its users the way it would for a function that owns state.
+// Nothing here argues that the original file started or ended at this address.
+//
+// So this stays a recorded range, not a claimed boundary. When the surrounding
+// translation unit is identified, fold this back into it and delete the unit.
+
+extern "C" s32 fn_8003F300(void)
+{
+	return 0;
+}

--- a/src/game/fn_80042864.cpp
+++ b/src/game/fn_80042864.cpp
@@ -1,0 +1,20 @@
+#include "types.h"
+
+// fn_80042864 is two instructions -- `li r3, 1` followed by `blr` -- at 0x80042864.
+//
+// The bounds are the function's own range and nothing more. dtk already gives
+// this function an object of its own, because every one of its neighbours in
+// this stretch is its own auto object too, so that split carries no
+// translation-unit information. What can be said is narrower and is the reason
+// the carve is safe: the function references no data at all -- no .rodata, no
+// .sdata, no .bss, no .sbss -- so pulling it into its own unit cannot separate
+// a static from its users the way it would for a function that owns state.
+// Nothing here argues that the original file started or ended at this address.
+//
+// So this stays a recorded range, not a claimed boundary. When the surrounding
+// translation unit is identified, fold this back into it and delete the unit.
+
+extern "C" s32 fn_80042864(void)
+{
+	return 1;
+}

--- a/src/game/fn_8005776C.cpp
+++ b/src/game/fn_8005776C.cpp
@@ -1,0 +1,20 @@
+#include "types.h"
+
+// fn_8005776C is two instructions -- `li r3, 0` followed by `blr` -- at 0x8005776C.
+//
+// The bounds are the function's own range and nothing more. dtk already gives
+// this function an object of its own, because every one of its neighbours in
+// this stretch is its own auto object too, so that split carries no
+// translation-unit information. What can be said is narrower and is the reason
+// the carve is safe: the function references no data at all -- no .rodata, no
+// .sdata, no .bss, no .sbss -- so pulling it into its own unit cannot separate
+// a static from its users the way it would for a function that owns state.
+// Nothing here argues that the original file started or ended at this address.
+//
+// So this stays a recorded range, not a claimed boundary. When the surrounding
+// translation unit is identified, fold this back into it and delete the unit.
+
+extern "C" s32 fn_8005776C(void)
+{
+	return 0;
+}

--- a/src/game/fn_8005F794.cpp
+++ b/src/game/fn_8005F794.cpp
@@ -1,0 +1,20 @@
+#include "types.h"
+
+// fn_8005F794 is two instructions -- `li r3, 0x20` followed by `blr` -- at 0x8005F794.
+//
+// The bounds are the function's own range and nothing more. dtk already gives
+// this function an object of its own, because every one of its neighbours in
+// this stretch is its own auto object too, so that split carries no
+// translation-unit information. What can be said is narrower and is the reason
+// the carve is safe: the function references no data at all -- no .rodata, no
+// .sdata, no .bss, no .sbss -- so pulling it into its own unit cannot separate
+// a static from its users the way it would for a function that owns state.
+// Nothing here argues that the original file started or ended at this address.
+//
+// So this stays a recorded range, not a claimed boundary. When the surrounding
+// translation unit is identified, fold this back into it and delete the unit.
+
+extern "C" s32 fn_8005F794(void)
+{
+	return 0x20;
+}


### PR DESCRIPTION
Assume o trabalho de #290, #291, #292 e #293 (@Vitorxd12) numa PR só, com a
evidência que faltava e sem os problemas apontados lá. **#289 fica de fora de
propósito** — o motivo está no comentário daquela PR e resumido no fim.

`fn_8003F300`, `fn_80042864`, `fn_8005776C` e `fn_8005F794`, quatro folhas de
duas instruções cada.

## Por que estas quatro podem ser carvadas

O objeto que o dtk já dá a cada uma não diz nada: nessa faixa inteira **toda**
função vira um `auto_*` próprio, então esse corte não carrega informação de
unidade de tradução. O argumento é outro e mais estreito.

Varri as referências a dados de cada função no assembly gerado. As quatro não
referenciam **nada** — nem `.rodata`, nem `.sdata`, nem `.bss`, nem `.sbss`:

```
fn_8003F300  references: (none)
fn_80042864  references: (none)
fn_8005776C  references: (none)
fn_8005F794  references: (none)
```

Uma função sem estado não pode ser separada dos seus estáticos, porque não tem
nenhum. Então o carve não parte nada, que é o risco real. Isso não é o mesmo que
provar que o arquivo original começava ou terminava ali, e o cabeçalho de cada
arquivo diz isso com todas as letras: é um range registrado, não uma fronteira
reivindicada, e some quando a TU de verdade aparecer.

## Diferenças em relação às PRs originais

- **Uma PR só.** As quatro originais partiam de `1fdeb07` e inseriam nos mesmos
  dois pontos de `splits.txt` e `configure.py`; aceitar uma faria as outras
  conflitarem.
- **`extra_cflags` removidas.** As originais copiavam
  `["-Cpp_exceptions on", "-opt noschedule,nopeephole"]` do objeto vizinho.
  Testei sem: as quatro continuam byte-exatas e `build.sha1` continua verde, então
  as flags eram ruído. Entram como `Object(Matching, "game/fn_XXXXXXXX.cpp")`.
- **Cabeçalhos com a evidência**, em vez do texto genérico.

## Verificação

```
python3 configure.py                                   OK
python3 -m unittest tools.test_check_language_policy    36 testes, OK
python3 tools/check_language_policy.py                  exit 0, 538 managed sources
ninja                                                   build.sha1: 18 files OK
clang-format                                            limpo
```

Comparação por bytes com os campos de relocation mascarados, por objeto:

```
game/fn_8003F300: 1/1 functions byte-exact
game/fn_80042864: 1/1 functions byte-exact
game/fn_8005776C: 1/1 functions byte-exact
game/fn_8005F794: 1/1 functions byte-exact
```

## Sobre a #289

`fn_8005EC0C` não entra porque a mesma varredura mostra o contrário dela:

```
fn_8005EC0C  references: ['lbl_8042C2A8']
    lbl_8042C2A8 used by 3 fn(s): ['8005EC0C', '8005EC14', '8005ED88']
```

`lbl_8042C2A8` é um `.sbss` de 4 bytes tocado só por essas três funções, e as
três são vizinhas. Isso é um estático privado de uma unidade — o mesmo tipo de
argumento que delimita `src/game/cri/mfci.c`. Carvar `fn_8005EC0C` sozinha
separaria esse estático dos seus dois outros usuários. A unidade real ali começa
em 0x8005EC0C e vai pelo menos até o fim de `fn_8005ED88`, 1416 bytes, e é esse
o carve que vale fazer.
