### PR TITLE
fix(eff_tornado): claim the full .sdata2 range and the .sbss global it owns

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -183,7 +183,7 @@ game/eff_tornado.cpp:
 	.data       start:0x802532E8 end:0x80253648
 	.sdata      start:0x8042B350 end:0x8042B374
 	.sbss       start:0x8042C34C end:0x8042C380
-	.sdata2     start:0x8042DBD8 end:0x8042DBE0
+	.sdata2     start:0x8042DBD0 end:0x8042DBE0
 
 game/hAnim.cpp:
 	extab       start:0x80008300 end:0x80008348

--- a/src/game/eff_tornado.cpp
+++ b/src/game/eff_tornado.cpp
@@ -1,5 +1,47 @@
 #include "types.h"
 
+// The tornado, typhoon and tornado-spin effects: TObjEffTornado and the two
+// classes derived from it, plus the free functions that create and dispose of
+// them. The unit runs from InitEffTornado at 0x800AB77C to the end of
+// SetEffectTornadoSpin at 0x800ADC3C, and owns .data 0x802532E8..0x80253648,
+// .sdata 0x8042B350..0x8042B374, .sbss 0x8042C34C..0x8042C380 and .sdata2
+// 0x8042DBD0..0x8042DBE0.
+//
+// Every one of those data ranges now reproduces byte for byte, which took two
+// corrections worth recording:
+//
+//   The .sdata2 claim used to start at 0x8042DBD8 and so covered only one of
+//   the unit's two generated conversion constants. The one left outside,
+//   0x8042DBD0, is the unsigned int-to-double magic 2^52; the file worked
+//   around the gap by defining it as a variable of its own, which made the
+//   compiler emit a third constant and pushed every pool index along. Claiming
+//   0x8042DBD0 and deleting the hand-written definition leaves exactly the two
+//   the original had.
+//
+//   lbl_8042C34C is storage this unit owns but never touches -- easySelect.cpp
+//   is what reads and writes it. It has to be defined here, and defined first,
+//   because MWCC lays .sbss out in order of first reference and an object
+//   nothing in the file references keeps its declaration position. Without it
+//   every later .sbss object sat four bytes low.
+//
+// NOT MATCHING: twenty of the twenty-two functions are byte-exact.
+//
+//   TDisp__15TObjEffTornado2Fv differs only in register allocation -- the
+//   target keeps the handle in r31 and this build keeps it in r27, and r26,
+//   r28 and r30 rotate along with it. Size, mnemonics and relocations already
+//   agree.
+//
+//   TDisp__14TObjEffTornadoFv is one instruction long. The target materialises
+//   two of the loop's address constants straight into their callee-saved
+//   registers; this build routes them through r0 and copies, and saves one
+//   copy elsewhere, for a net gain of one. Ruled out: dropping or inverting the
+//   opt_common_subs pragma around it, which costs three more instructions, and
+//   declaring the three loops' pointers inside their blocks instead of sharing
+//   the outer declarations, which costs the same three.
+//
+// The remaining extab and extabindex bytes are the frame descriptors of those
+// two functions and will follow them.
+
 inline void* operator new(unsigned long, void* address)
 {
 	return address;
@@ -169,6 +211,11 @@ void fn_800189A4(void*, void*);
 
 extern TObject* lbl_8042C2A0;
 extern TObject* lbl_8042C110;
+// Storage owned by this unit but read and written from easySelect.cpp, which is
+// why nothing here touches it. It has to be declared first: MWCC lays .sbss out
+// in order of first reference, and an object nothing in the file references
+// keeps its declaration position.
+void* lbl_8042C34C;
 extern void* lbl_8042C350;
 extern void* lbl_8042C354;
 extern void* lbl_8042C358;
@@ -232,7 +279,6 @@ extern f32 lbl_8042DC18;
 extern f32 lbl_8042DC1C;
 extern f32 lbl_8042DC20;
 extern f32 lbl_8042DC24;
-extern const f64 lbl_8042DBD0 = 4503599627370496.0;
 
 extern u8 lbl_8029C310[];
 extern u8 lbl_802D5E80[];


### PR DESCRIPTION
Every data section of `game/eff_tornado` now reproduces byte for byte. The code
is unchanged at 20 of 22 functions byte-exact; this is about the data and two
real bugs behind it.

## `.sdata2` was claimed eight bytes short

The split started at `0x8042DBD8`, so it covered only one of the unit's two
generated conversion constants. The one left outside is `0x8042DBD0`, the
unsigned int-to-double magic `2^52`. Nothing else in `splits.txt` claimed that
address either — it was sitting in the unattributed blob.

The file worked around the gap by defining the constant itself:

```cpp
extern const f64 lbl_8042DBD0 = 4503599627370496.0;
```

which made MWCC emit a *third* constant (its own duplicate of `2^52`) and pushed
every constant-pool index along, so the references came out as `@158` and `@164`
where the target had `lbl_8042DBD0` and `@28`.

Claiming `0x8042DBD0..0x8042DBE0` and deleting that definition leaves exactly
the two constants the original object had, in the original order.

## The unit was missing a `.sbss` global it owns

`lbl_8042C34C` is the first object in the unit's `.sbss` range, which the split
already claimed correctly. Nothing in `eff_tornado.cpp` touches it —
`easySelect.cpp` is what reads and writes it — so it had simply never been
written down, and every later `.sbss` object sat four bytes low.

It has to be a definition and not an `extern` declaration, and it has to come
first: MWCC lays `.sbss` out in order of first reference, and an object nothing
in the file references keeps its declaration position.

## Before and after

| section | before | after |
|---|---|---|
| `.sdata2` | 24 bytes vs 16, three constants vs two | 16/16, byte-equal |
| `.sbss` | 48 bytes vs 52, everything four low | 52/52, byte-equal |
| `.sdata` | byte-equal | byte-equal |
| `.data` | byte-equal | byte-equal |

`extab` still differs in three bytes and `extabindex` in one; those are the frame
descriptors of the two functions that do not match yet and will follow them.

## Header comment

The file had none. Added one recording the unit's bounds, the two corrections
above, and what is left in `TDisp__15TObjEffTornado2Fv` (register allocation
only) and `TDisp__14TObjEffTornadoFv` (one instruction), including what has
already been ruled out on each — dropping or inverting the `opt_common_subs`
pragma costs three more instructions, and block-scoping the three loops'
pointers costs the same three.

## Verification

```
python3 configure.py                                   OK
python3 -m unittest tools.test_check_language_policy    36 tests, OK
python3 tools/check_language_policy.py                  exit 0
ninja                                                   build.sha1: 18 files OK
clang-format                                            clean
```

Byte comparison with relocation fields masked: `game/eff_tornado: 20/22
functions byte-exact`, unchanged, and all four data sections byte-equal.
