### PR TITLE
decomp: align tornado data layout

### DIFF
--- a/src/game/eff_tornado.cpp
+++ b/src/game/eff_tornado.cpp
@@ -232,7 +232,6 @@ extern f32 lbl_8042DC18;
 extern f32 lbl_8042DC1C;
 extern f32 lbl_8042DC20;
 extern f32 lbl_8042DC24;
-extern const f64 lbl_8042DBD0 = 4503599627370496.0;
 
 extern u8 lbl_8029C310[];
 extern u8 lbl_802D5E80[];

--- a/src/game/eff_tornado.cpp
+++ b/src/game/eff_tornado.cpp
@@ -1478,6 +1478,7 @@ extern "C" void SetEffectTornado__FP7TObjectiP5RwV3dP6sAngle(
 	new TObjEffTornado(parent, kind, position, rotation);
 }
 
+void* lbl_8042C34C;
 void* lbl_8042C350;
 void* lbl_8042C354;
 void* lbl_8042C358;


### PR DESCRIPTION
Aligns the remaining small-data layout of the tornado effect unit.

The unit remains NonMatching: all initialized and small-data sections now match, while the two residual TDisp functions differ only in CodeWarrior register allocation and exception metadata.

Validated with:
- python3 -m unittest tools.test_check_language_policy
- python3 tools/check_language_policy.py
- python3 configure.py && ninja
- python3 configure.py --non-matching && ninja