### PR TITLE
fix: remove duplicate tornado sbss definition

### DIFF
--- a/src/game/eff_tornado.cpp
+++ b/src/game/eff_tornado.cpp
@@ -1525,7 +1525,6 @@ extern "C" void SetEffectTornado__FP7TObjectiP5RwV3dP6sAngle(
 	new TObjEffTornado(parent, kind, position, rotation);
 }
 
-void* lbl_8042C34C;
 void* lbl_8042C350;
 void* lbl_8042C354;
 void* lbl_8042C358;


### PR DESCRIPTION
Removes the duplicate `lbl_8042C34C` definition introduced by overlapping small-data changes.

Validated with:
- python3 -m unittest tools.test_check_language_policy
- python3 tools/check_language_policy.py
- python3 configure.py && ninja