### PR TITLE
docs(eff_tornado): rule out a translation-unit lever for both TDisp gaps

### DIFF
--- a/src/game/eff_tornado.cpp
+++ b/src/game/eff_tornado.cpp
@@ -36,7 +36,18 @@
 //   or rotating the four material stores and the three else-branch colour
 //   computations, all of which are worse; rewriting the function as the free
 //   `extern "C" void TDisp__15TObjEffTornado2Fv(TObjEffTornado2*)` that every
-//   other TDisp in this file already is; and aliasing `this` into a local.
+//   other TDisp in this file already is; and aliasing `this` into a local. Also
+//   ruled out: every type the six locals can plausibly take (blue as u8, s8 or
+//   s32, all four colours as u8 or s32, frame as u32 -- which shortens the
+//   function by an instruction instead), eight more declaration orders, and
+//   twelve optimiser pragmas scoped tightly around this function alone.
+//
+//   And one negative that matters more than the rest: there is no
+//   translation-unit lever here. Adding an unused static function, an unused
+//   file-scope pointer or another `static inline` elsewhere in the file leaves
+//   both functions bit for bit unchanged. That is what cracked mfCiOpen and
+//   mfCiReqRd when nothing inside those functions responded, so its absence
+//   says the answer for these two has to be in their own shape.
 //
 //   TDisp__14TObjEffTornadoFv is one instruction long. The target materialises
 //   two of the loop's address constants straight into their callee-saved


### PR DESCRIPTION
Comment only. `build.sha1` 18 files OK, still 20 of 22 byte-exact.

Third and last round on these two before moving to #297. The result that matters
is a negative one.

## There is no translation-unit lever here

Adding an unused `static` function, an unused file-scope pointer, or another
`static inline` elsewhere in `eff_tornado.cpp` leaves **both** functions bit for
bit unchanged.

That is worth writing down because it is exactly the lever that cracked
`mfCiOpen` and `mfCiReqRd` in `src/game/cri/mfci.c`, where whether an unrelated
static touched a third `.bss` object decided, for the whole unit, how the
section bases ranked against the parameters. Here the allocation is purely
local, so the answer for these two has to be in their own shape — and their own
shape is now fairly well explored.

## Also ruled out this round

On `TDisp__15TObjEffTornado2Fv`:

- Every plausible type for the six locals: `blue` as `u8`, `s8` or `s32`; all
  four colours as `u8` or `s32`; `frame` as `u32`, which shortens the function
  by an instruction instead of fixing the swap.
- Eight more declaration orders, including `blue` last and each of the colours
  first. Base stays the best at 40 differing bytes; the rest land between 48 and
  58.
- Twelve optimiser pragmas scoped tightly around this function alone —
  `opt_common_subs` both ways, `opt_lifetimes`, `opt_propagation`,
  `opt_strength_reduction`, `opt_dead_assignments`, `opt_loop_invariants`,
  `optimize_for_size`, `scheduling`, `peephole`, `global_optimizer`,
  `opt_unroll_loops`. None improves on base; several make it worse.

## Where this leaves them

`TDisp__15TObjEffTornado2Fv` is one register swap — the handle and `blue` trade
r31 and r27, and all 40 differing bytes follow from that.
`TDisp__14TObjEffTornadoFv` is one instruction, from two address constants the
allocator could not coalesce into their callee-saved registers.

Both are the same class of wall as `mfCiReqRd`: the compiler simply chose
differently, with the same register set and the same instruction shape. Parking
them here and picking up #297, which is 2216 bytes of real decompilation with a
boundary already argued.
