### PR TITLE
feat: carve resource dispatch unit

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -150,6 +150,15 @@ game/Endian.cpp:
 game/fn_8005776C.cpp:
 	.text       start:0x8005776C end:0x80057774
 
+game/fn_8005E8EC.cpp:
+	extab       start:0x800069A4 end:0x800069D4
+	extabindex  start:0x8000D3F0 end:0x8000D420
+	.text       start:0x8005E8EC end:0x8005F194
+	.data       start:0x80243418 end:0x802435D8
+	.bss        start:0x802FF5E0 end:0x80303D18
+	.sdata      start:0x8042B228 end:0x8042B234
+	.sbss       start:0x8042C2A8 end:0x8042C2AC
+
 game/fn_8005F794.cpp:
 	.text       start:0x8005F794 end:0x8005F79C
 

--- a/configure.py
+++ b/configure.py
@@ -614,6 +614,11 @@ config.libs = [
             Object(Matching, "game/fn_8005776C.cpp"),
             Object(Matching, "game/fn_8005F794.cpp"),
             Object(
+                NonMatching,
+                "game/fn_8005E8EC.cpp",
+                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
+            ),
+            Object(
                 Matching,
                 "game/GetSpParam.cpp",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],

--- a/src/game/fn_8005E8EC.cpp
+++ b/src/game/fn_8005E8EC.cpp
@@ -1,0 +1,371 @@
+#include "types.h"
+
+// The original translation-unit name and private type names are unknown. This
+// neutral filename follows the first function address; descriptive private
+// identifiers below are reconstruction aids rather than recovered names.
+
+struct ResourceEntry {
+	char name[0x40];
+	void* object;
+};
+
+struct ResourceRequest {
+	char name[0x40];
+	void* data;
+	u32 size;
+	u32 slot;
+	void* dictionary;
+};
+
+extern "C" {
+char* strchr(const char*, s32);
+s32 strncmp(const char*, const char*, u32);
+char* strcpy(char*, const char*);
+void* memset(void*, s32, u32);
+s32 sprintf(char*, const char*, ...);
+void Exec__22TObjSetDamageCollisionFv(void);
+void EndEffTornado__Fv(void);
+void InitEffTornado__Fv(void);
+void startObjSetDamageCollision__Fv(void);
+s32 fn_801C3C04(const char*, const char*);
+void fn_80150958(void*);
+void fn_8020C2D8(void*);
+void fn_8011B7CC(void*);
+void* fn_80012994(u32);
+void fn_800126C8(void*);
+void fn_800D0624(void*, void*, u32);
+void* Expand2__FPvPv(void*, void*);
+void fn_801A4C84(void*);
+void* fn_80198000(s32, s32, void*);
+s32 fn_80192F38(void*, s32, s32, s32);
+void* fn_80150B88(void*);
+void fn_80197ED8(void*, s32);
+void fn_8014FFBC(void*, void*, s32);
+void fn_800D075C(void*);
+void* fn_801471DC(void);
+void fn_801471C8(void*);
+void fn_8014705C(void*);
+void fn_801A46D0(void*);
+void* texLoadTexDictionaryFile__FPc(char*);
+void fn_801A4778(void*, void*, s32);
+void* fn_80041FF4(char*);
+void* fn_80146EA8(void*);
+void* fn_80057644(u32);
+void fn_800BCC84(void*, char*, s32);
+void* fn_800BC694(void*, u32);
+void fn_80112718(void);
+void* fn_800BC370(void*, u32, void*, void*);
+void* fn_800BC46C(void*, u32, void*);
+void* fn_800BBF20(void*, u32, void*);
+void* fn_800BBE0C(void*, u32, void*);
+void fn_800BCBD4(void*, s32);
+void fn_8005D498(void);
+void fn_8005BEC4(void);
+void fn_8005E03C(void);
+void fn_8015C728(void*);
+void fn_8015C6F8(void*, s32, s32);
+void fn_8015C704(void*, s32, s32);
+void fn_8015C710(void*, s32, s32, s32);
+void fn_8015C720(void*, s32);
+
+void fn_8010F3CC(void);
+void fn_8010CA00(void);
+void fn_8010C0C0(void);
+void fn_8010AD10(void);
+void fn_801043EC(void);
+void fn_80100130(void);
+void fn_800FAB00(void);
+void fn_800F6FDC(void);
+void fn_800F45A8(void);
+void fn_800D0310(void);
+void fn_800C968C(void);
+void fn_800BDD5C(void);
+void fn_800BDDA0(void);
+void fn_800C9894(void);
+void fn_800D0360(void);
+void fn_800F45C8(void);
+void fn_800F7038(void);
+void fn_800FAB54(void);
+void fn_80100144(void);
+void fn_80104410(void);
+void fn_8010AD48(void);
+void fn_8010C108(void);
+void fn_8010CA14(void);
+void fn_8010F3F4(void);
+
+#pragma force_active on
+char lbl_80243418[]                     = "OBJ_BOBSLEIGH.DFF";
+char lbl_8024342C[]                     = "OBJ_BBS_LAUNCHER.DFF";
+char lbl_80243444[]                     = "OBJ_BOBSTOP.DFF";
+char lbl_80243454[]                     = "OBJ_ROLLDOOR.DFF";
+char lbl_80243468[]                     = "OBJ_SWB.DFF";
+char lbl_80243474[]                     = "OBJ_TARGET.DFF";
+char lbl_80243484[]                     = "OBJ_WEIGHT.DFF";
+char lbl_80243494[]                     = "OBJ_WEIGHT_BROKEN.DFF";
+char lbl_802434AC[]                     = "EF_RDOOR.DFF";
+__declspec(export) char* lbl_802434BC[] = { lbl_80243418, lbl_8024342C, lbl_80243444, lbl_80243454,
+	lbl_80243468, lbl_80243474, lbl_80243484, lbl_80243494, lbl_802434AC };
+char lbl_802434E0[]                     = "OBJ_DSHR.DFF";
+char lbl_802434F0[]                     = "OBJ_DUSHP.DFF";
+char lbl_80243500[]                     = "EFF_BOB_ON.DFF";
+char lbl_80243510[]                     = "EF_FIBALL.DFF";
+char lbl_80243520[]                     = "EF_FCHG_BEAM.DFF";
+char lbl_80243534[]                     = "EF_FLOWARP.DFF";
+char lbl_80243544[]                     = "OBJ_JBOARD.DFF";
+__declspec(export) char* lbl_80243554[] = { lbl_802434E0, lbl_802434F0, lbl_80243500, lbl_80243510,
+	lbl_80243520, lbl_80243534, lbl_80243544 };
+f32 lbl_80243570[] = { 8.5f, 9.0f, 6.4f, 9.0f, 19.0f, 8.5f, 9.0f, 25.0f, 6.3f, 8.5f, 22.0f, 6.2f };
+__declspec(export) char lbl_802435A0[] = "./textures/obj_common.txd";
+__declspec(export) char lbl_802435BC[] = "mte_gcn.mtd";
+__declspec(export) char lbl_802435C8[] = "comobj.one";
+
+char lbl_8042B228[] = "DFF";
+char lbl_8042B22C[] = "ANM";
+char lbl_8042B230[] = "UVB";
+
+ResourceEntry lbl_802FF5E0[0x100];
+u8 lbl_803039E0[0x18];
+ResourceRequest lbl_803039F8[10];
+void* lbl_8042C2A8;
+#pragma force_active reset
+}
+
+extern "C" void fn_8005E8EC(void)
+{
+	s32 i                = 0;
+	ResourceEntry* entry = lbl_802FF5E0;
+	do {
+		u32 found                = 0;
+		ResourceRequest* request = lbl_803039F8;
+		while (TRUE) {
+			if (fn_801C3C04(request->name, entry->name) != 0) {
+				request++;
+				found++;
+				if (found < 10)
+					continue;
+				found = -1;
+			} else {
+				break;
+			}
+			break;
+		}
+		if (found != -1) {
+			char* extension = strchr(entry->name, '.');
+			if (extension != NULL) {
+				if (strncmp(extension + 1, lbl_8042B228, 3) == 0)
+					fn_80150958(entry->object);
+				else if (strncmp(extension + 1, lbl_8042B22C, 3) == 0)
+					fn_8020C2D8(entry->object);
+				else if (strncmp(extension + 1, lbl_8042B230, 3) == 0)
+					fn_8011B7CC(entry->object);
+				entry->object  = NULL;
+				entry->name[0] = 0;
+			}
+		}
+		entry++;
+		i++;
+	} while (i < 0x100);
+}
+
+extern "C" void* fn_8005EA04(char* name)
+{
+	void* result         = NULL;
+	s32 i                = 0;
+	ResourceEntry* entry = lbl_802FF5E0;
+	while (TRUE) {
+		if (fn_801C3C04(entry->name, name) != 0) {
+			entry++;
+			i++;
+			if (i < 0x100)
+				continue;
+			i = -1;
+		}
+		break;
+	}
+	if (i != -1) {
+		result = entry->object;
+		goto done;
+	}
+
+	i                        = 0;
+	ResourceRequest* request = lbl_803039F8;
+	while (TRUE) {
+		if (fn_801C3C04(request->name, name) != 0) {
+			request++;
+			i++;
+			if ((u32)i < 10)
+				continue;
+			i = -1;
+		}
+		break;
+	}
+	if (i != -1) {
+		if (lbl_802FF5E0[request->slot].object != NULL)
+			return lbl_802FF5E0[request->slot].object;
+		if (request->data != NULL) {
+			void* expanded = fn_80012994(0x19000);
+			void* input    = fn_80012994(request->size);
+			fn_800D0624(input, request->data, request->size);
+			void* end           = Expand2__FPvPv(input, expanded);
+			void* streamArgs[2] = { expanded, end };
+			fn_801A4C84(request->dictionary);
+			void* stream = fn_80198000(3, 1, streamArgs);
+			if (fn_80192F38(stream, 0x10, 0, 0) != 0)
+				lbl_802FF5E0[request->slot].object = fn_80150B88(stream);
+			fn_80197ED8(stream, 0);
+			fn_800126C8(input);
+			fn_800126C8(expanded);
+			strcpy(lbl_802FF5E0[request->slot].name, request->name);
+			if (lbl_802FF5E0[request->slot].object != NULL)
+				fn_8014FFBC(lbl_802FF5E0[request->slot].object, (void*)fn_8005D498, 0);
+			result = lbl_802FF5E0[request->slot].object;
+		}
+	}
+done:
+	return result;
+}
+
+extern "C" void* fn_8005EC0C(void)
+{
+	return lbl_8042C2A8;
+}
+
+extern "C" void fn_8005EC14(void)
+{
+	Exec__22TObjSetDamageCollisionFv();
+	fn_8010F3CC();
+	fn_8010CA00();
+	fn_8010C0C0();
+	fn_8010AD10();
+	fn_801043EC();
+	fn_80100130();
+	fn_800FAB00();
+	fn_800F6FDC();
+	fn_800F45A8();
+	fn_800D0310();
+	fn_800C968C();
+	fn_800BDD5C();
+	EndEffTornado__Fv();
+	for (s32 i = 0; i < 0x100; i++) {
+		char* extension = strchr(lbl_802FF5E0[i].name, '.');
+		if (extension != NULL) {
+			if (strncmp(extension + 1, lbl_8042B228, 3) == 0)
+				fn_80150958(lbl_802FF5E0[i].object);
+			else if (strncmp(extension + 1, lbl_8042B22C, 3) == 0)
+				fn_8020C2D8(lbl_802FF5E0[i].object);
+			else if (strncmp(extension + 1, lbl_8042B230, 3) == 0)
+				fn_8011B7CC(lbl_802FF5E0[i].object);
+			lbl_802FF5E0[i].object = NULL;
+		}
+	}
+	for (u32 i = 0; i < 10; i++)
+		if (lbl_803039F8[i].data != NULL)
+			fn_800D075C(lbl_803039F8[i].data);
+	void* object = fn_801471DC();
+	if (object != NULL) {
+		fn_801471C8(NULL);
+		fn_8014705C(object);
+	}
+	if (lbl_8042C2A8 != NULL) {
+		fn_801A46D0(lbl_8042C2A8);
+		lbl_8042C2A8 = NULL;
+	}
+}
+
+extern "C" void fn_8005ED88(void)
+{
+	fn_8015C728(lbl_803039E0);
+	fn_8015C6F8(lbl_803039E0, 3, 6);
+	fn_8015C704(lbl_803039E0, 1, 0);
+	fn_8015C710(lbl_803039E0, 1, 3, 10);
+	fn_8015C720(lbl_803039E0, 3);
+	if (lbl_8042C2A8 == NULL) {
+		char path[0x40];
+		sprintf(path, lbl_802435A0);
+		lbl_8042C2A8 = texLoadTexDictionaryFile__FPc(path);
+		if (lbl_8042C2A8 == NULL)
+			return;
+		fn_801A4778(lbl_8042C2A8, (void*)fn_8005E03C, 6);
+	}
+	void* material     = fn_80041FF4(lbl_802435BC);
+	void* materialData = NULL;
+	if (material != NULL) {
+		if (fn_80192F38(material, 0x21, 0, 0) != 0)
+			materialData = fn_80146EA8(material);
+		fn_80197ED8(material, 0);
+	}
+	if (materialData != NULL)
+		fn_801471C8(materialData);
+	void* archive = fn_80057644(0x58);
+	if (archive != NULL)
+		fn_800BCC84(archive, lbl_802435C8, 0);
+	if (archive != NULL) {
+		fn_801A4C84(lbl_8042C2A8);
+		void* workspace = fn_80012994(0x25800);
+		for (u32 i = 0; i < 10; i++)
+			lbl_803039F8[i].data = NULL;
+		ResourceRequest* request = lbl_803039F8;
+		for (u32 i = 0; i < 0x100; i++) {
+			char* source = (char*)fn_800BC694(archive, i);
+			if (source == NULL) {
+				memset(&lbl_802FF5E0[i], 0, 0x40);
+				lbl_802FF5E0[i].object = NULL;
+				continue;
+			}
+			strcpy(lbl_802FF5E0[i].name, source);
+			char* extension = strchr(lbl_802FF5E0[i].name, '.');
+			if (extension == NULL)
+				continue;
+			fn_80112718();
+			if (strncmp(extension + 1, lbl_8042B228, 3) == 0) {
+				s32 special = FALSE;
+				for (u32 j = 0; j < 9; j++)
+					if (fn_801C3C04(lbl_802FF5E0[i].name, lbl_802434BC[j]) == 0) {
+						special = TRUE;
+						break;
+					}
+				if (special) {
+					lbl_802FF5E0[i].object = NULL;
+					request->data          = fn_800BC370(archive, i, workspace, &request->size);
+					request->slot          = i;
+					strcpy(request->name, lbl_802FF5E0[i].name);
+					lbl_802FF5E0[i].name[0] = 0;
+					request->dictionary     = lbl_8042C2A8;
+					request++;
+				} else {
+					lbl_802FF5E0[i].object = fn_800BC46C(archive, i, workspace);
+					for (u32 j = 0; j < 7; j++)
+						if (fn_801C3C04(lbl_802FF5E0[i].name, lbl_80243554[j]) == 0) {
+							fn_8014FFBC(lbl_802FF5E0[i].object, (void*)fn_8005BEC4, 0);
+							break;
+						}
+				}
+				if (lbl_802FF5E0[i].object != NULL)
+					fn_8014FFBC(lbl_802FF5E0[i].object, (void*)fn_8005D498, 0);
+			} else if (strncmp(extension + 1, lbl_8042B22C, 3) == 0)
+				lbl_802FF5E0[i].object = fn_800BBF20(archive, i, workspace);
+			else if (strncmp(extension + 1, lbl_8042B230, 3) == 0)
+				lbl_802FF5E0[i].object = fn_800BBE0C(archive, i, workspace);
+			else
+				lbl_802FF5E0[i].object = NULL;
+		}
+		if (workspace != NULL)
+			fn_800126C8(workspace);
+		fn_800BCBD4(archive, 1);
+	} else
+		memset(lbl_802FF5E0, 0, 0x4400);
+	InitEffTornado__Fv();
+	fn_800BDDA0();
+	fn_800C9894();
+	fn_800D0360();
+	fn_800F45C8();
+	fn_800F7038();
+	fn_800FAB54();
+	fn_80100144();
+	fn_80104410();
+	fn_8010AD48();
+	fn_8010C108();
+	fn_8010CA14();
+	fn_8010F3F4();
+	startObjSetDamageCollision__Fv();
+}


### PR DESCRIPTION
## What

Describe the one logical unit changed by this pull request.

## Evidence

- [ ] I identified the source language and linkage from evidence, not from the
      current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a
      reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known
      library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and
      included only the minimum symbolic fact and independent GameCube
      correlation.
- [x] If I changed inline flags, I documented the source/emission order and
      compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or
      links to those materials.

Evidence and references:

<!-- Give symbol names, strings, vtable relationships, public references or
     compiler experiments. Do not attach proprietary artifacts. -->

## Verification

<!-- Full artifact CI for a fork runs only after a maintainer reviews the
     commits and tests them from a repository-owned integration branch. -->

- [x] `python tools/check_language_policy.py`
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:
