### PR TITLE
decomp: carve variadic save-area function

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -147,6 +147,11 @@ game/Endian.cpp:
 	.text       start:0x8004BECC end:0x8004C160
 	.ctors      start:0x802398D0 end:0x802398D4
 
+game/fn_80057524.cpp:
+	extab       start:0x800065E4 end:0x800065EC
+	extabindex  start:0x8000CF94 end:0x8000CFA0
+	.text       start:0x80057524 end:0x80057574
+
 game/fn_8005776C.cpp:
 	.text       start:0x8005776C end:0x80057774
 

--- a/configure.py
+++ b/configure.py
@@ -611,6 +611,7 @@ config.libs = [
                 "game/Endian.cpp",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
+            Object(Matching, "game/fn_80057524.cpp", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/fn_8005776C.cpp"),
             Object(Matching, "game/fn_8005F794.cpp"),
             Object(

--- a/src/game/fn_80057524.cpp
+++ b/src/game/fn_80057524.cpp
@@ -1,0 +1,9 @@
+#include "types.h"
+
+// fn_80057524 has no callers or data references and consists solely of the
+// EABI register-save area emitted for a variadic function.  Like the adjacent
+// leaf-function carves, this records only its proven data-free range; it does
+// not assert a translation-unit boundary.
+extern "C" void fn_80057524(s32 first, ...)
+{
+}


### PR DESCRIPTION
## Summary\n- reconstruct the isolated variadic EABI save-area function at 0x80057524\n- map its matching .text, extab, and extabindex ranges\n\n## Validation\n- python3 -m unittest tools.test_check_language_policy\n- python3 tools/check_language_policy.py\n- ninja build/G9SE8P/report.json (100% code and data match)\n- ninja (build and link succeed; final project hash check remains blocked by existing NonMatching units)