### PR TITLE
decomp: carve link node initializer

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -147,6 +147,9 @@ game/Endian.cpp:
 	.text       start:0x8004BECC end:0x8004C160
 	.ctors      start:0x802398D0 end:0x802398D4
 
+game/fn_8005421C.cpp:
+	.text       start:0x8005421C end:0x80054230
+
 game/fn_80057524.cpp:
 	extab       start:0x800065E4 end:0x800065EC
 	extabindex  start:0x8000CF94 end:0x8000CFA0

--- a/configure.py
+++ b/configure.py
@@ -611,6 +611,7 @@ config.libs = [
                 "game/Endian.cpp",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
+            Object(Matching, "game/fn_8005421C.cpp"),
             Object(Matching, "game/fn_80057524.cpp", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/fn_8005776C.cpp"),
             Object(Matching, "game/fn_8005F794.cpp"),

--- a/src/game/fn_8005421C.cpp
+++ b/src/game/fn_8005421C.cpp
@@ -1,0 +1,18 @@
+#include "types.h"
+
+// fn_8005421C initializes the three-word node returned by the 12-byte
+// allocator at each of its call sites.  The range has no data references, so
+// this is a safe recorded leaf-function carve rather than a claimed source
+// translation-unit boundary.
+struct Fn8005421CNode {
+    void* value;
+    Fn8005421CNode* previous;
+    Fn8005421CNode* next;
+};
+
+extern "C" void fn_8005421C(Fn8005421CNode* node)
+{
+    node->value = 0;
+    node->next = 0;
+    node->previous = 0;
+}


### PR DESCRIPTION
## Summary\n- reconstruct the isolated three-pointer link-node initializer at 0x8005421C\n- map its matching 20-byte text range\n\n## Validation\n- python3 -m unittest tools.test_check_language_policy\n- python3 tools/check_language_policy.py\n- ninja build/G9SE8P/report.json (100% function match)\n- ninja (18 files OK)