### PR TITLE
decomp: carve link node destructor

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -150,6 +150,11 @@ game/Endian.cpp:
 game/fn_8005421C.cpp:
 	.text       start:0x8005421C end:0x80054230
 
+game/fn_80054230.cpp:
+	extab       start:0x80006524 end:0x8000652C
+	extabindex  start:0x8000CEBC end:0x8000CEC8
+	.text       start:0x80054230 end:0x8005428C
+
 game/fn_80057524.cpp:
 	extab       start:0x800065E4 end:0x800065EC
 	extabindex  start:0x8000CF94 end:0x8000CFA0

--- a/configure.py
+++ b/configure.py
@@ -612,6 +612,11 @@ config.libs = [
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
             Object(Matching, "game/fn_8005421C.cpp"),
+            Object(
+                Matching,
+                "game/fn_80054230.cpp",
+                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
+            ),
             Object(Matching, "game/fn_80057524.cpp", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/fn_8005776C.cpp"),
             Object(Matching, "game/fn_8005F794.cpp"),

--- a/src/game/fn_80054230.cpp
+++ b/src/game/fn_80054230.cpp
@@ -1,0 +1,31 @@
+#include "types.h"
+
+// fn_80054230 removes the node initialized by fn_8005421C from its doubly
+// linked list, then releases it through the global allocator.  Its only data
+// reference is that pre-existing allocator pointer; this records the proven
+// function range without claiming the surrounding translation-unit boundary.
+struct Fn80054230Node {
+    void* value;
+    Fn80054230Node* previous;
+    Fn80054230Node* next;
+};
+
+struct Fn80054230Allocator {
+    u8 padding[0x138];
+    void (*release)(Fn80054230Node*);
+};
+
+extern "C" Fn80054230Allocator* lbl_8042C9A4;
+
+extern "C" void fn_80054230(Fn80054230Node* node)
+{
+    if (node != 0) {
+        if (node->previous != 0) {
+            node->previous->next = node->next;
+        }
+        if (node->next != 0) {
+            node->next->previous = node->previous;
+        }
+        lbl_8042C9A4->release(node);
+    }
+}


### PR DESCRIPTION
## Summary\n- reconstruct the isolated link-node destructor at 0x80054230\n- preserve its allocator relocation and exception metadata\n\n## Validation\n- python3 -m unittest tools.test_check_language_policy\n- python3 tools/check_language_policy.py\n- ninja build/G9SE8P/report.json (100% code and data match)\n- ninja (18 files OK)