### PR TITLE
decomp: build the resource dispatch unit with pooldata off and fix fn_8005ED88 frame

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -616,7 +616,11 @@ config.libs = [
             Object(
                 NonMatching,
                 "game/fn_8005E8EC.cpp",
-                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
+                extra_cflags=[
+                    "-Cpp_exceptions on",
+                    "-opt noschedule,nopeephole",
+                    "-pooldata off",
+                ],
             ),
             Object(
                 Matching,

--- a/src/game/fn_8005E8EC.cpp
+++ b/src/game/fn_8005E8EC.cpp
@@ -41,7 +41,33 @@
 //   point, misaligns the function badly (81 differing rows against 66), so it
 //   is not simply more of the same.
 //
-//   fn_8005ED88 is thirty-two bytes short and has not been looked at yet.
+//   fn_8005ED88 is the right length now and twenty-seven bytes differ, all of
+//   them one register swap: the target keeps the archive handle in r27 and the
+//   scratch buffer in r29, this build has them the other way round. Getting
+//   there took four things.
+//
+//   The big one is a build flag, not source: the unit needs -pooldata off. With
+//   pooling on, MWCC notices that every one of this unit's data labels lives in
+//   its own sections and folds them into one base register plus offsets --
+//   `addi r3, r25, 0x4400`, `addi r4, r31, 0x188` and so on -- where the target
+//   emits an independent lis/addi pair for each. That alone was thirty-six
+//   bytes. eff_tornado.cpp already carries the same flag.
+//
+//   The stack frame gave away the path buffer. The target opens with
+//   `stwu r1, -0x50(r1)` and saves r24 through r31, which leaves forty bytes
+//   between the linkage area and the register save area. A `char path[0x40]`
+//   cannot fit there; anything from 0x20 to 0x28 produces identical code, so
+//   the size is only bounded, not recovered, and 0x20 is what is written.
+//
+//   The clearing loop shares the array base with the walk that follows it, and
+//   the target materialises that base once into a callee-saved register. That
+//   needs `request` declared before the loop, used by it, and assigned again
+//   afterwards -- redundant as C, but it is what produces the single
+//   materialisation.
+//
+//   Last, materialData has to be declared and initialised before material, with
+//   material's call split out into its own statement, or the `li rN, 0` lands
+//   after the fn_80041FF4 call instead of before it.
 
 struct ResourceEntry {
 	char name[0x40];
@@ -319,15 +345,16 @@ extern "C" void fn_8005ED88(void)
 	fn_8015C710(lbl_803039E0, 1, 3, 10);
 	fn_8015C720(lbl_803039E0, 3);
 	if (lbl_8042C2A8 == NULL) {
-		char path[0x40];
+		char path[0x20];
 		sprintf(path, lbl_802435A0);
 		lbl_8042C2A8 = texLoadTexDictionaryFile__FPc(path);
 		if (lbl_8042C2A8 == NULL)
 			return;
 		fn_801A4778(lbl_8042C2A8, (void*)fn_8005E03C, 6);
 	}
-	void* material     = fn_80041FF4(lbl_802435BC);
+	void* material;
 	void* materialData = NULL;
+	material           = fn_80041FF4(lbl_802435BC);
 	if (material != NULL) {
 		if (fn_80192F38(material, 0x21, 0, 0) != 0)
 			materialData = fn_80146EA8(material);
@@ -340,11 +367,13 @@ extern "C" void fn_8005ED88(void)
 		fn_800BCC84(archive, lbl_802435C8, 0);
 	if (archive != NULL) {
 		fn_801A4C84(lbl_8042C2A8);
-		void* workspace = fn_80012994(0x25800);
-		for (u32 i = 0; i < 10; i++)
-			lbl_803039F8[i].data = NULL;
+		u32 i;
+		void* workspace          = fn_80012994(0x25800);
 		ResourceRequest* request = lbl_803039F8;
-		for (u32 i = 0; i < 0x100; i++) {
+		for (u32 i = 0; i < 10; i++)
+			request[i].data = NULL;
+		request = lbl_803039F8;
+		for (i = 0; i < 0x100; i++) {
 			char* source = (char*)fn_800BC694(archive, i);
 			if (source == NULL) {
 				memset(&lbl_802FF5E0[i], 0, 0x40);


### PR DESCRIPTION
`fn_8005ED88` goes from thirty-two bytes short to the exact length, with
twenty-seven bytes left, all of them one register swap. `build.sha1` 18 files OK;
the unit stays `NonMatching` at 2 of 5 byte-exact, and the other two functions
are untouched by any of this.

## The unit needs `-pooldata off`

This is a build flag, not source, and it was worth thirty-six bytes on its own.

With pooling on, MWCC notices that every data label this unit touches lives in
its own sections and folds them into one base register plus offsets:

```
addi r31, r3, ...data.0@l
addi r3, r25, 0x4400        <- lbl_803039E0
addi r4, r31, 0x188         <- lbl_802435A0
addi r25, r31, 0xa4         <- lbl_802434BC
```

The target emits an independent `lis`/`addi` pair per label. Turning pooling off
reproduces that. `eff_tornado.cpp` already carries the same flag, which is what
put me onto it.

Swept the alternatives to be sure the rest of the flags are right: no `-opt` at
all, `nopeephole` alone, `noschedule` alone, `level=4,nopeephole`. All are worse
and several lose `fn_8005EC14`, which currently matches.

## The stack frame gave away the path buffer

The target opens `stwu r1, -0x50(r1)` and saves r24 through r31, so between the
linkage area and the register save area there are forty bytes. `char path[0x40]`
does not fit. Anything from `0x20` to `0x28` produces byte-identical code, so
the size is bounded rather than recovered — `0x20` is what went in, and the
header says so.

## Two source shapes

- The clearing loop and the walk that follows share one array base, and the
  target materialises it once into a callee-saved register. That needs `request`
  declared before the loop, used by it, and assigned again after — redundant as
  C, but it is what produces the single materialisation.
- `materialData` has to be declared and initialised before `material`, with
  `material`'s call split into its own statement, or the `li rN, 0` lands after
  the `fn_80041FF4` call instead of before it.

Also hoisted the `for` loop's `i` to a plain declaration, which was worth
fourteen bytes.

## Where it stands

```
fn_8005E8EC   DIFF 35 bytes   (right length)
fn_8005EA04   508 vs 520
fn_8005EC0C   byte-exact
fn_8005EC14   byte-exact
fn_8005ED88   DIFF 27 bytes   (right length, was 32 short)
```

`fn_8005ED88`'s remaining twenty-seven bytes are the archive handle and the
scratch buffer trading r27 and r29. Six ways of declaring and assigning those
two were tried; the current arrangement is the best of them.
