### PR TITLE
decomp: carve link node inserter

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -155,6 +155,11 @@ game/fn_80054230.cpp:
 	extabindex  start:0x8000CEBC end:0x8000CEC8
 	.text       start:0x80054230 end:0x8005428C
 
+game/fn_8005428C.cpp:
+	extab       start:0x8000652C end:0x80006534
+	extabindex  start:0x8000CEC8 end:0x8000CED4
+	.text       start:0x8005428C end:0x8005430C
+
 game/fn_80057524.cpp:
 	extab       start:0x800065E4 end:0x800065EC
 	extabindex  start:0x8000CF94 end:0x8000CFA0

--- a/configure.py
+++ b/configure.py
@@ -617,6 +617,11 @@ config.libs = [
                 "game/fn_80054230.cpp",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
+            Object(
+                Matching,
+                "game/fn_8005428C.cpp",
+                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
+            ),
             Object(Matching, "game/fn_80057524.cpp", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/fn_8005776C.cpp"),
             Object(Matching, "game/fn_8005F794.cpp"),

--- a/src/game/fn_8005428C.cpp
+++ b/src/game/fn_8005428C.cpp
@@ -1,0 +1,37 @@
+#include "types.h"
+
+// fn_8005428C allocates a three-word list node, links it immediately before
+// the supplied node when present, and assigns its 16-bit value.  The only data
+// reference is the pre-existing global allocator, so this is a recorded
+// function carve rather than a claimed source translation-unit boundary.
+struct Fn8005428CNode {
+    u16 value;
+    u16 padding;
+    Fn8005428CNode* previous;
+    Fn8005428CNode* next;
+};
+
+struct Fn8005428CAllocator {
+    u8 padding[0x134];
+    Fn8005428CNode* (*allocate)(u32 size);
+};
+
+extern "C" Fn8005428CAllocator* lbl_8042C9A4;
+
+extern "C" Fn8005428CNode* fn_8005428C(Fn8005428CNode* next, u16 value)
+{
+    Fn8005428CNode* node = lbl_8042C9A4->allocate(sizeof(Fn8005428CNode));
+    if (node == 0) {
+        return 0;
+    }
+
+    if (next != 0) {
+        node->next = next;
+        next->previous = node;
+    } else {
+        node->next = 0;
+    }
+    node->previous = 0;
+    node->value = value;
+    return node;
+}


### PR DESCRIPTION
## Summary\n- reconstruct the isolated list-node insertion helper at 0x8005428C\n- preserve allocator relocation and exception metadata\n\n## Validation\n- python3 -m unittest tools.test_check_language_policy\n- python3 tools/check_language_policy.py\n- ninja build/G9SE8P/report.json (100% code and data match)\n- ninja (18 files OK)