### PR TITLE
decomp: carve list removal helper

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -147,6 +147,11 @@ game/Endian.cpp:
 	.text       start:0x8004BECC end:0x8004C160
 	.ctors      start:0x802398D0 end:0x802398D4
 
+game/fn_80053FB8.cpp:
+	extab       start:0x8000650C end:0x80006514
+	extabindex  start:0x8000CE98 end:0x8000CEA4
+	.text       start:0x80053FB8 end:0x80054048
+
 game/fn_8005421C.cpp:
 	.text       start:0x8005421C end:0x80054230
 

--- a/configure.py
+++ b/configure.py
@@ -611,6 +611,11 @@ config.libs = [
                 "game/Endian.cpp",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
+            Object(
+                Matching,
+                "game/fn_80053FB8.cpp",
+                extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
+            ),
             Object(Matching, "game/fn_8005421C.cpp"),
             Object(
                 Matching,

--- a/src/game/fn_80053FB8.cpp
+++ b/src/game/fn_80053FB8.cpp
@@ -1,0 +1,41 @@
+#include "types.h"
+
+// fn_80053FB8 unlinks an element from the list and releases it through the
+// existing global allocator.  It references no local data and records only
+// its independently provable function range.
+struct Fn80053FB8Node {
+    u8 padding[0x28];
+    Fn80053FB8Node* previous;
+    Fn80053FB8Node* next;
+};
+
+struct Fn80053FB8List {
+    u32 count;
+    Fn80053FB8Node* first;
+    Fn80053FB8Node* last;
+};
+
+struct Fn80053FB8Allocator {
+    u8 padding[0x138];
+    void (*release)(Fn80053FB8Node*);
+};
+
+extern "C" Fn80053FB8Allocator* lbl_8042C9A4;
+
+extern "C" void fn_80053FB8(Fn80053FB8List* list, Fn80053FB8Node* node)
+{
+    if (node != 0) {
+        if (node->previous != 0) {
+            node->previous->next = node->next;
+        } else {
+            list->first = node->next;
+        }
+        if (node->next != 0) {
+            node->next->previous = node->previous;
+        } else {
+            list->last = node->previous;
+        }
+        lbl_8042C9A4->release(node);
+        list->count--;
+    }
+}


### PR DESCRIPTION
## Summary\n- reconstruct the isolated list-removal helper at 0x80053FB8\n- preserve its allocator relocation and exception metadata\n\n## Validation\n- python3 -m unittest tools.test_check_language_policy\n- python3 tools/check_language_policy.py\n- ninja build/G9SE8P/report.json (100% code and data match)\n- ninja (18 files OK)