### PR TITLE
decomp: carve list node builder

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -152,6 +152,11 @@ game/fn_80053FB8.cpp:
 	extabindex  start:0x8000CE98 end:0x8000CEA4
 	.text       start:0x80053FB8 end:0x80054048
 
+game/fn_80054048.cpp:
+	extab       start:0x80006514 end:0x8000651C
+	extabindex  start:0x8000CEA4 end:0x8000CEB0
+	.text       start:0x80054048 end:0x80054158
+
 game/fn_8005421C.cpp:
 	.text       start:0x8005421C end:0x80054230
 

--- a/configure.py
+++ b/configure.py
@@ -611,6 +611,7 @@ config.libs = [
                 "game/Endian.cpp",
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
+            Object(Matching, "game/fn_80054048.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"]),
             Object(
                 Matching,
                 "game/fn_80053FB8.cpp",

--- a/src/game/fn_80054048.cpp
+++ b/src/game/fn_80054048.cpp
@@ -1,0 +1,35 @@
+#include "types.h"
+
+struct Fn80054048Vec { f32 x; f32 y; f32 z; };
+struct Fn80054048Node {
+    u16 value;
+    s16 secondaryValue;
+    Fn80054048Vec first;
+    Fn80054048Vec second;
+    Fn80054048Vec third;
+    Fn80054048Node* previous;
+    Fn80054048Node* next;
+};
+struct Fn80054048List { s32 count; Fn80054048Node* first; Fn80054048Node* last; };
+struct Fn80054048Allocator { u8 padding[0x140]; Fn80054048Node* (*allocate)(u32, u32); };
+extern "C" Fn80054048Allocator* lbl_8042C9A4;
+
+extern "C" void fn_80054048(Fn80054048List* list, u16 value, const Fn80054048Vec* first,
+    const Fn80054048Vec* second, const Fn80054048Vec* third, const s16* secondaryValue)
+{
+    Fn80054048Node* node = lbl_8042C9A4->allocate(sizeof(Fn80054048Node), 1);
+    if (node != 0) {
+        if (list->first != 0) {
+            node->next = list->first;
+            list->first->previous = node;
+        }
+        node->value = value;
+        if (first != 0) node->first = *first;
+        if (second != 0) node->second = *second;
+        if (third != 0) node->third = *third;
+        if (secondaryValue != 0) node->secondaryValue = *secondaryValue;
+        list->first = node;
+        if (list->count == 0) list->last = node;
+        list->count++;
+    }
+}


### PR DESCRIPTION
## Summary\n- reconstruct the 272-byte list node builder at 0x80054048\n- preserve allocator calls, list linking, and exception metadata\n\n## Validation\n- python3 -m unittest tools.test_check_language_policy\n- python3 tools/check_language_policy.py\n- ninja build/G9SE8P/report.json (100% code and data match)\n- ninja (18 files OK)