### PR TITLE
decomp: reconstruct lsc_ExecHndl

### DIFF
--- a/src/game/cri/lsc.c
+++ b/src/game/cri/lsc.c
@@ -79,7 +79,10 @@ struct LscSj {
 typedef struct LscStm {
 	/* 0x00 */ s32 id;
 	/* 0x04 */ const char* fname;
-	/* 0x08 */ s8 pad08[0x10];
+	/* 0x08 */ s32 pad08;
+	/* 0x0C */ s32 ofst;
+	/* 0x10 */ s32 arg4;
+	/* 0x14 */ s32 nbyte;
 	/* 0x18 */ s32 stat;
 	/* 0x1C */ s32 rdsct;
 } LscStm;
@@ -89,7 +92,8 @@ typedef struct LscObj {
 	/* 0x01 */ s8 stat;
 	/* 0x02 */ s8 busy;
 	/* 0x03 */ s8 lpflg;
-	/* 0x04 */ s32 pad04;
+	/* 0x04 */ s8 halt;
+	/* 0x05 */ s8 pad05[3];
 	/* 0x08 */ struct LscSj* sj;
 	/* 0x0C */ s8 pad0C[8];
 	/* 0x14 */ s32 flowlimit;
@@ -120,6 +124,16 @@ extern void* memset(void* p, int c, u32 n);
 
 extern const char lsc_ErrParam[];
 extern const char lsc_ErrSj[];
+extern const char lsc_ErrFp[];
+extern s32 fn_8021722C(void* hndl);
+extern s32 fn_802171C0(void* hndl);
+extern void fn_80217044(void* hndl);
+extern void fn_80217434(void* hndl);
+extern void fn_80217584(void* hndl, const char* fname, s32 ofst, s32 arg4, s32 nbyte);
+extern void fn_80216EC4(void* hndl, s32 nbyte);
+extern void fn_80216810(void* hndl, s32 min, s32 nsct);
+extern void fn_802171DC(void* hndl, s32 a);
+extern void fn_8021713C(void* hndl);
 extern const char lsc_ErrMin[];
 extern const char lsc_ErrNo[];
 extern const char lsc_ErrId[];
@@ -161,12 +175,16 @@ void LSC_SetLpFlg(LscObj* lsc, s8 flag)
 	lsc->lpflg = flag;
 }
 
+// Kept out of line: the server calls it rather than inlining it, and at this
+// size the compiler would inline it by default.
+#pragma dont_inline on
 void LSC_CallStatFunc(void)
 {
 	if (lsc_StatEntry.func != NULL) {
 		lsc_StatEntry.func(lsc_StatEntry.obj, lsc_StatEntry.stat);
 	}
 }
+#pragma dont_inline off
 
 s32 LSC_GetFlowLimit(LscObj* lsc)
 {
@@ -472,4 +490,90 @@ LscObj* LSC_Create(LscSj* sj)
 	}
 	fn_8021F504(crs);
 	return lsc;
+}
+
+// lsc_ExecHndl: one pass of the server over a single handle. Three stages run
+// in sequence on the record at the head of the ring -- poll a read in flight,
+// retire one that finished, then start the next -- so a record can move two
+// states in a single pass.
+void fn_802202FC(LscObj* lsc)
+{
+	LscStm* stm;
+	s32 ret;
+	const char* fname;
+	s32 ofst;
+	s32 arg4;
+	s32 nbyte;
+
+	if (lsc->halt == 1) {
+		return;
+	}
+	if (lsc->stat != 2) {
+		return;
+	}
+	if (lsc->numstm <= 0) {
+		return;
+	}
+
+	if (lsc->stm[lsc->head].stat == 1) {
+		if (lsc->stmhndl == NULL) {
+			fn_8021F410(lsc_ErrFp);
+		} else {
+			stm = &lsc->stm[lsc->head];
+			ret = fn_8021722C(lsc->stmhndl);
+			if (ret == 4) {
+				lsc->stat = 3;
+			} else if (ret == 2) {
+				stm->rdsct = fn_802171C0(lsc->stmhndl);
+			} else if (ret == 3) {
+				stm->rdsct = lsc->f2C;
+				stm->stat  = 2;
+			}
+		}
+	}
+
+	if (lsc->stm[lsc->head].stat == 2) {
+		nbyte = 0;
+		arg4  = 0;
+		ofst  = 0;
+		fname = NULL;
+		if (lsc->stmhndl != NULL) {
+			if (lsc->lpflg == 1) {
+				stm   = &lsc->stm[lsc->head];
+				fname = stm->fname;
+				ofst  = stm->ofst;
+				arg4  = stm->arg4;
+				nbyte = stm->nbyte;
+			}
+			lsc->numstm--;
+			lsc->head = (lsc->head + 1) % LSC_STM_MAX;
+			if (lsc->numstm <= 0) {
+				LSC_CallStatFunc();
+				lsc->stat = 1;
+			}
+			if (lsc->lpflg == 1) {
+				fn_8021FD04(lsc, fname, ofst, arg4, nbyte);
+			}
+		}
+	}
+
+	if (lsc->stm[lsc->head].stat == 0) {
+		stm = &lsc->stm[lsc->head];
+		if (lsc->numstm > 0) {
+			fn_80217044(lsc->stmhndl);
+			fn_80217434(lsc->stmhndl);
+			fn_80217584(lsc->stmhndl, stm->fname, stm->ofst, stm->arg4, stm->nbyte);
+			fn_80216EC4(lsc->stmhndl, stm->nbyte);
+			lsc->f2C   = stm->nbyte;
+			stm->rdsct = 0;
+			lsc->busy  = 0;
+			if (lsc->busy == 0) {
+				fn_80216810(lsc->stmhndl, lsc->flowlimit, lsc->nsct);
+				fn_802171DC(lsc->stmhndl, 0);
+				fn_8021713C(lsc->stmhndl);
+				lsc->busy = 1;
+			}
+			stm->stat = 1;
+		}
+	}
 }


### PR DESCRIPTION
Continues `game/cri/lsc.c`: 828 of 1024 instructions, up from 693. `fn_802202FC` goes from assembly to 135/146.

## Evidence

`fn_802202FC` is `lsc_ExecHndl`, the body of the server loop. It runs three stages in sequence against the record at the head of the sixteen-entry ring, so one record can move two states in a single pass: poll a read in flight, retire one that finished and advance the head modulo sixteen, then start the next.

Retiring a read is what calls `LSC_CallStatFunc` and drops the object back to state 1 when the queue empties. The ring advance is a signed `% 16` — the `slwi`/`srwi`/`rotlwi` sequence — which confirms `head` is signed.

Four struct fields fell out of the request the last stage replays: `LscStm` carries the file name at 0x04 and three parameters at 0x0C, 0x10 and 0x14, and `LscObj` has a byte at 0x04 that halts the handle.

## One finding worth keeping

**`LSC_CallStatFunc` has to be kept out of line.** At fifteen instructions the compiler inlines it by default, which made this function eight instructions too long and cost nineteen more in knock-on register pressure; `#pragma dont_inline` around the definition restores the call and was worth +19 on its own. Nothing else in the unit regressed, so the pragma is scoped to that one function.

This is the second time in this unit that a call the target keeps was silently inlined — the first was `fn_8021FF7C`. Both showed up as a function that was *longer* than the target while staying near 100% mnemonic alignment, which is the signature to look for.

## What is left

Four instructions of shape in the zero-init of the replay parameters — the target chains `mr` from one register where this build emits separate `li` — plus a nine-register permutation. `fn_8021FD04` and the rest of `LSC_Create` are still open.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] clang-format clean, language policy checks pass