### PR TITLE
decomp: match fn_80223D00 in the CRI AXRNA unit

### DIFF
--- a/src/game/cri/axrna.c
+++ b/src/game/cri/axrna.c
@@ -405,7 +405,7 @@ void fn_80223D00(AxRna* p)
 
 	req = p->loopReq;
 	if (p->obj[p->idx - 1] != NULL) {
-		n            = *(s32*)((u8*)p->obj[p->idx - 1] + 0x1B2) - p->loopStart[p->idx];
+		n            = *(s32*)((u8*)p->obj[p->idx - 1] + 0x1B2) - p->loopStart[p->idx - 1];
 		ax_Z[ax_Y++] = n;
 		if (ax_Y == 32) {
 			ax_Y = 0;


### PR DESCRIPTION
Closes `fn_80223D00`, taking `game/cri/axrna.c` to thirteen of twenty-two functions byte-exact. Still NonMatching, artifact hashes unchanged (18/18).

## Evidence

One instruction: the target reads `20(r5)` where this build read `24(r5)`, with `r5 = p + idx * 4`. The field itself was already at the right offset — the index was wrong. `loopStart` is indexed by `idx - 1`, matching the `obj[idx - 1]` on the same expression, not by `idx`.

Worth noting how it presented: 100% mnemonic alignment, zero shape gaps, one register difference. A wrong array index inside a correct struct looks exactly like a register permutation until you resolve the offset arithmetic, which is why the base and the index have to be checked separately.

## Not fixed

`fn_80224C3C` is still seven instructions short and all seven are the .bss layout: the target puts the refcount at 0 and the handle table at 4308, and this build puts the table first. Reversing the declaration order and giving the work buffer four-byte alignment so it joins the same group does not move it — measured, no change. That is now three separate approaches ruled out on this layout, so it stays parked until the remaining shape work in the unit is done.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] objdiff: fn_80223D00 94/94
- [x] clang-format clean, language policy checks pass