### PR TITLE
decomp: match fn_802237C4 and advance fn_80224B1C in CRI AXRNA

### DIFF
--- a/src/game/cri/axrna.c
+++ b/src/game/cri/axrna.c
@@ -251,15 +251,12 @@ void fn_802237B4(void* p, s8 v)
 
 void fn_802237C4(void)
 {
-	AxRna* p;
 	u32 i;
 
-	p = ax_Tbl;
 	for (i = 0; i < AX_RNA_MAX; i++) {
-		if (p->stat == 1) {
-			fn_80223820(p);
+		if (ax_Tbl[i].stat == 1) {
+			fn_80223820(&ax_Tbl[i]);
 		}
-		p++;
 	}
 }
 
@@ -754,18 +751,15 @@ void fn_80224A88(AxObj* obj)
 
 void fn_80224B1C(void)
 {
-	AxRna* p;
 	s32 i;
 
 	if (--ax_RefCnt != 0) {
 		return;
 	}
-	p = ax_Tbl;
 	for (i = 0; i < AX_RNA_MAX; i++) {
-		if (p->stat == 1) {
-			fn_802242CC(p);
+		if (ax_Tbl[i].stat == 1) {
+			fn_802242CC(&ax_Tbl[i]);
 		}
-		p++;
 	}
 	memset(ax_Tbl, 0, sizeof(ax_Tbl));
 	fn_80224E1C();


### PR DESCRIPTION
Takes `game/cri/axrna.c` to **fourteen of twenty-two functions byte-exact**, 1008 of 1541 instructions, up from 984.

`fn_802237C4` closes at 23/23. `fn_80224B1C` goes from 44/72 to 64/72.

## Evidence

Both were the same defect and both took the same one-line fix: the loop over the sixteen-entry handle table was written as a walking pointer, and the target indexes the array. The compiler does the strength reduction itself, and writing the pointer by hand costs an extra `addi`/`mr` to materialise the base plus a knock-on shift in every branch offset after it.

That is the third unit where this has come up — it closed `fn_802201E0` in LSC and `fn_802235B4` in this file earlier. Worth treating as the default: **index the array, do not walk a pointer.**

## What is left in fn_80224B1C

Eight instructions, and all eight are an r29/r30 swap between two compiler-generated pointers that walk together — one reading the record, one reading a byte two ahead of it. Local declaration order does not reach compiler temporaries, which is the same wall the other partial functions in this unit are against.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] objdiff: fn_802237C4 23/23, zero shape gaps
- [x] clang-format clean, language policy checks pass