### PR TITLE
decomp: carve the CRI GCCI translation unit

### DIFF
--- a/config/G9SE8P/language_policy.json
+++ b/config/G9SE8P/language_policy.json
@@ -20,6 +20,7 @@
     "autosaveD/prolog.c",
     "game/cri/adapter.c",
     "game/cri/axrna.c",
+    "game/cri/gcci.c",
     "game/cri/lsc.c",
     "game/cri/mfci.c",
     "movieD/cri/sfxahn.c",

--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -856,6 +856,12 @@ dolphin/exi/EXIBios.c:
 	.bss        start:0x8040EA90 end:0x8040EB50
 	.sbss       start:0x8042CF30 end:0x8042CF34
 
+game/cri/gcci.c:
+	.text       start:0x8021E3D8 end:0x8021F410
+	.rodata     start:0x8023FBC0 end:0x8023FDF8
+	.data       start:0x8029B7B8 end:0x8029B828
+	.bss        start:0x8041F6B8 end:0x80420770
+
 game/cri/lsc.c:
 	.text       start:0x8021F544 end:0x80220544
 	.rodata     start:0x8023FDF8 end:0x8023FF50

--- a/configure.py
+++ b/configure.py
@@ -541,6 +541,11 @@ config.libs = [
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
             Object(
+                NonMatching,
+                "game/cri/gcci.c",
+                extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
+            ),
+            Object(
                 Matching,
                 "game/cri/lsc.c",
                 extra_cflags=[

--- a/src/game/cri/gcci.c
+++ b/src/game/cri/gcci.c
@@ -1,0 +1,78 @@
+#include "types.h"
+
+// CRI GCCI for GameCube: the file layer the stream controller sits on, wrapping
+// the Dolphin DVD calls behind CRI's handle and error conventions.
+//
+// The unit runs from fn_8021E3D8 at 0x8021E3D8 to the end of fn_8021F404 at
+// 0x8021F410, fifteen functions, and owns .rodata 0x8023FBC0 to 0x8023FDF8,
+// .data 0x8029B7B8 to 0x8029B828 and .bss 0x8041F6B8 to 0x80420770. The disc
+// ships no map, so the bounds are argued. Four lines agree:
+//
+//   The .rodata opens with the module's own version banner, "\nGCCI Ver.1.09
+//   Build:May  9 2003 17:09:53\n", and every other string in the block is one
+//   of this module's messages. CRI writes the banner into the library's main
+//   source file.
+//
+//   Every .rodata, .data and .bss label the run touches has all of its users
+//   inside the run. That was checked one label at a time, eleven of them, and
+//   not one leaks: the error hook pair at 0x8041F6C4 and 0x8041F6C8 is reached
+//   by eight functions here and by nothing else in the binary.
+//
+//   All three data sections are contiguous and abut their neighbours exactly.
+//   The .rodata ends at 0x8023FDF8, which is where game/cri/lsc.c's begins.
+//
+//   The lower bound is the first cut where no data crosses; below it
+//   fn_8021E118 and fn_8021E3D8 share nothing. The upper bound is fn_8021F410,
+//   the shared error reporter that lsc.c also calls, so it belongs to neither.
+//
+// Nothing is named yet. The messages here carry no function names -- unlike
+// MFCI and LSC, whose "(mfCiOpen)" and "(LSC_Create)" suffixes gave the naming
+// away -- so every function keeps its dtk name until something anchors it.
+
+typedef void (*GcciErrFunc)(void* obj, const char* msg, void* arg);
+
+typedef struct GcciObj {
+	/* 0x00 */ s8 pad00[0x10];
+	/* 0x10 */ s32 unk10;
+	/* 0x14 */ s8 pad14[0xC];
+	/* 0x20 */ s32 unk20;
+} GcciObj;
+
+static GcciErrFunc gcci_ErrFunc;
+static void* gcci_ErrObj;
+
+extern const char gcci_ErrHandl[];
+extern const char gcci_ErrHandl2[];
+extern const char gcci_ErrSize[];
+extern const char gcci_ErrHandl3[];
+
+static void gcci_Error(const char* msg)
+{
+	if (gcci_ErrFunc != NULL) {
+		gcci_ErrFunc(gcci_ErrObj, msg, NULL);
+	}
+}
+
+s32 fn_8021E3D8(GcciObj* p)
+{
+	if (p == NULL) {
+		gcci_Error(gcci_ErrHandl);
+		return 0;
+	}
+	return p->unk20;
+}
+
+s32 fn_8021E51C(GcciObj* p)
+{
+	if (p == NULL) {
+		gcci_Error(gcci_ErrHandl3);
+		return 0;
+	}
+	return p->unk10;
+}
+
+void fn_8021F20C(GcciErrFunc func, void* obj)
+{
+	gcci_ErrFunc = func;
+	gcci_ErrObj  = obj;
+}


### PR DESCRIPTION
Carves a new unit: `game/cri/gcci.c`, the file layer the stream controller sits on, wrapping the Dolphin DVD calls behind CRI's handle and error conventions. Fifteen functions, three of them byte-exact already. NonMatching, so it is not linked and every artifact hash is unchanged (18/18).

    .text 0x8021E3D8-0x8021F410   .rodata 0x8023FBC0-0x8023FDF8
    .data 0x8029B7B8-0x8029B828   .bss    0x8041F6B8-0x80420770

## Evidence

- The .rodata opens with the module's own version banner, `\nGCCI Ver.1.09 Build:May  9 2003 17:09:53\n`, and every other string in the block is one of this module's messages.
- **Every label the run touches is confined to it.** Eleven were checked one at a time and not one leaks — the error hook pair at 0x8041F6C4 and 0x8041F6C8 is reached by eight functions here and by nothing else in the binary.
- All three data sections are contiguous and abut their neighbours exactly. The .rodata ends at 0x8023FDF8, which is where `game/cri/lsc.c`'s begins — the unit merged in #321.
- The lower bound is the first cut where no data crosses. The upper bound is `fn_8021F410`, the shared error reporter that `lsc.c` also calls, so it belongs to neither unit.

Nothing is named. Unlike MFCI and LSC, whose `(mfCiOpen)` and `(LSC_Create)` suffixes gave the naming away, GCCI's messages carry no function names, so every function keeps its dtk name until something anchors it.

`game/cri/gcci.c` joins `reviewed_c_boundary_sources` with the other CRI units.

## Already matching

`fn_8021E3D8`, `fn_8021E51C` and `fn_8021F20C` — the error-hook setter and two accessors, on the same inlined-reporter idiom MFCI uses. The pair differ only in which field they return, 0x20 against 0x10, which is how those two struct offsets are already known.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] clang-format clean, language policy checks pass