### PR TITLE
decomp: match two GCCI accessors and reconstruct its seek

### DIFF
--- a/src/game/cri/gcci.c
+++ b/src/game/cri/gcci.c
@@ -32,9 +32,13 @@
 typedef void (*GcciErrFunc)(void* obj, const char* msg, void* arg);
 
 typedef struct GcciObj {
-	/* 0x00 */ s8 pad00[0x10];
+	/* 0x00 */ s8 pad00[2];
+	/* 0x02 */ s8 unk02;
+	/* 0x03 */ s8 pad03[0xD];
 	/* 0x10 */ s32 unk10;
-	/* 0x14 */ s8 pad14[0xC];
+	/* 0x14 */ s32 pad14;
+	/* 0x18 */ s32 unk18;
+	/* 0x1C */ s32 unk1C;
 	/* 0x20 */ s32 unk20;
 } GcciObj;
 
@@ -75,4 +79,43 @@ void fn_8021F20C(GcciErrFunc func, void* obj)
 {
 	gcci_ErrFunc = func;
 	gcci_ErrObj  = obj;
+}
+
+s32 fn_8021E57C(GcciObj* p)
+{
+	if (p == NULL) {
+		gcci_Error(gcci_ErrHandl);
+		return 0;
+	}
+	return p->unk02;
+}
+
+s32 fn_8021EBA8(GcciObj* p)
+{
+	if (p == NULL) {
+		gcci_Error(gcci_ErrHandl);
+		return 0;
+	}
+	return p->unk1C;
+}
+
+s32 fn_8021EC08(GcciObj* p, s32 off, s32 whence)
+{
+	if (p == NULL) {
+		gcci_Error(gcci_ErrHandl);
+		return 0;
+	}
+	if (whence == 0) {
+		p->unk1C = off;
+	} else if (whence == 2) {
+		p->unk1C = p->unk18 + off;
+	} else if (whence == 1) {
+		p->unk1C = p->unk1C + off;
+	}
+	p->unk1C = p->unk1C < p->unk18 ? p->unk1C : p->unk18;
+	if (p->unk1C > 0) {
+	} else {
+		p->unk1C = 0;
+	}
+	return p->unk1C;
 }


### PR DESCRIPTION
Takes `game/cri/gcci.c` to five of fifteen functions byte-exact, 150 of 1038 instructions, up from 53.

`fn_8021E57C` and `fn_8021EBA8` close at 25/25 and 24/24. `fn_8021EC08` goes from assembly to 48/51.

## Evidence

The two accessors are the same inlined-reporter idiom as the three already in, differing only in the field they return — a signed byte at 0x02 and a word at 0x1C. Both matched on the first attempt.

`fn_8021EC08` is a seek, and it is **the same function as MFCI's `fn_80222F28`**: same three-way whence dispatch, same clamp to the length at 0x18, same lower clamp to zero. Writing it from that template got it to 48/51 immediately, which is what carrying the pattern between CRI units is for.

Struct offsets 0x02, 0x18 and 0x1C are now known.

## The one gap, and it is a known wall

Three instructions, and they are the lower clamp: the target emits `ble`/`b` where this build emits a single inverted branch. **This is the identical gap that has `fn_80222F28` stuck at 57/61 in MFCI**, where eight spellings were tried and none reproduced it. Two more were tried here — plain ternary and the inverted ternary — and both measure worse, at 46/51.

So it is one shape, appearing twice, resisting ten attempts across two units. Recording it as a wall rather than retrying it a third time.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] clang-format clean, language policy checks pass