### PR TITLE
decomp: complete the CRI MFCI translation unit

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -566,7 +566,7 @@ config.libs = [
                 extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
             ),
             Object(
-                NonMatching,
+                Matching,
                 "game/cri/mfci.c",
                 extra_cflags=[
                     "-sdata 0",

--- a/src/game/cri/mfci.c
+++ b/src/game/cri/mfci.c
@@ -46,16 +46,12 @@
 // mfCiExecServer and mfCiGetInterface. The statics it also names are
 // mfci_alloc, mfci_reset_hn, mfci_get_adr_size and mfci_call_errfn.
 //
-// NOT MATCHING: thirteen of the fourteen functions are byte-exact. What is
-// left is fn_80222C40 (mfCiReqRd).
+// MATCHING: all fourteen functions are byte-exact.
 //
-//   fn_80222C40 differs only in six register fields. Treating its public handle
-//   as opaque, then naming the private `MfciObj*` locally, gives the target's
-//   entry allocation exactly: handle r29, buffer r28, .rodata r30 and .bss r31.
-//   Once the inlined address lookup frees the two section bases, the remaining
-//   miss is one swapped pair: the target keeps the returned address in r31 and
-//   the clamped byte count in r30, while this build chooses r30/r31. Every
-//   instruction, relocation and the 648-byte function size otherwise agree.
+//   fn_80222C40 needs its public handle typed opaquely and converted to the
+//   private `MfciObj*` locally. After the inlined address lookup, a named `max`
+//   and `n > max ? max : n` give the retail address/count register pair and
+//   branch direction.
 //
 //   fn_80222F28 is exact. Its final clamp needs a local result and a nested
 //   empty condition in the positive arm. The latter keeps both sides of the
@@ -306,11 +302,13 @@ void fn_80222BD0(MfciObj* hn)
 
 s32 fn_80222C40(void* obj, s32 nsct, void* buf)
 {
-	MfciObj* hn = obj;
 	s32 rest;
+	MfciObj* hn;
 	u32 adr;
 	u32 size;
 	s32 n;
+
+	hn = obj;
 
 	if (hn == NULL) {
 		mfci_ErrorN("E01100307:handl is null.");
@@ -346,9 +344,10 @@ s32 fn_80222C40(void* obj, s32 nsct, void* buf)
 	}
 	hn->busy = 2;
 	adr      = mfci_get_adr_size(hn->fname, &size);
-	n        = hn->nbyte;
-	if (n > (s32)(size - hn->ofst)) {
-		n = (s32)(size - hn->ofst);
+	{
+		s32 max = (s32)(size - hn->ofst);
+		n       = hn->nbyte;
+		n       = n > max ? max : n;
 	}
 	memcpy(buf, (void*)(adr + hn->ofst), hn->nbyte);
 	memset((s8*)buf + n, 0, hn->nbyte - n);

--- a/src/game/cri/mfci.c
+++ b/src/game/cri/mfci.c
@@ -46,8 +46,8 @@
 // mfCiExecServer and mfCiGetInterface. The statics it also names are
 // mfci_alloc, mfci_reset_hn, mfci_get_adr_size and mfci_call_errfn.
 //
-// NOT MATCHING: twelve of the fourteen functions are byte-exact. What is left
-// is fn_80222C40 (mfCiReqRd) and fn_80222F28 (mfCiSeek).
+// NOT MATCHING: thirteen of the fourteen functions are byte-exact. What is
+// left is fn_80222C40 (mfCiReqRd).
 //
 //   fn_80222C40 differs only in register allocation: the target ranks the
 //   handle above the buffer (r29/r28), this build ranks the buffer above the
@@ -63,24 +63,10 @@
 //   or the base order right with the handle and buffer swapped. Neither is the
 //   target, so the remaining nudge has to come from somewhere else again.
 //
-//   fn_80222F28 is one instruction short. The target lowers the final clamp
-//   branchily -- `ble` into the block, `b` past the `li` into the shared store,
-//   so both arms converge on one `stw` with the value in r0. That the compiler
-//   is willing to branch for a select is not in doubt: the preceding clamp
-//   against nsct is emitted exactly that way. It is the zero that is the
-//   problem. Every `?:` spelling whose false arm reaches zero -- literal,
-//   returned from a static helper, `off - off`, `whence & 0`, a local assigned
-//   0 -- constant-propagates before the idiom recogniser runs, and the clamp
-//   comes out as branchless `neg/andc/srawi/and`. Every plain `if`/`else`
-//   spelling has an empty then-arm, which the compiler answers by inverting
-//   the test and dropping the `b`.
-//
-//   The closest miss is worth keeping. Route both arms through a same-TU
-//   static setter -- `if (hn->pos > 0) { mfci_SetPos(hn, hn->pos); } else {
-//   mfci_SetPos(hn, 0); }` -- and the branch layout comes out exactly right,
-//   `ble` into the block and `b` skipping the `li`. What is left over is the
-//   then-arm's own redundant `stw`, which this compiler does not tail-merge
-//   with the else-arm's, so the function lands at 248 against the target's 244.
+//   fn_80222F28 is exact. Its final clamp needs a local result and a nested
+//   empty condition in the positive arm. The latter keeps both sides of the
+//   source branch alive until after MWCC forms the retail `ble`/`b` diamond;
+//   it then disappears, leaving both arms converging on one shared store.
 //
 //   fn_80223404 is exact. Its three instructions -- `li r0, 0`, `cmpwi r0,
 //   0x28`, `blr` -- are the dead remains of the PS2 body: a forty-entry walk
@@ -389,6 +375,8 @@ s32 fn_80222EC8(MfciObj* hn)
 
 s32 fn_80222F28(MfciObj* hn, s32 off, s32 whence)
 {
+	s32 pos;
+
 	if (hn == NULL) {
 		mfci_ErrorN("E01100305:handl is null.");
 		return 0;
@@ -402,10 +390,14 @@ s32 fn_80222F28(MfciObj* hn, s32 off, s32 whence)
 		hn->pos = hn->pos + off;
 	}
 	hn->pos = hn->pos < hn->nsct ? hn->pos : hn->nsct;
-	if (hn->pos > 0) {
+	pos     = hn->pos;
+	if (pos > 0) {
+		if (pos && pos) {
+		}
 	} else {
-		hn->pos = 0;
+		pos = 0;
 	}
+	hn->pos = pos;
 	fn_8022291C();
 	return hn->pos;
 }

--- a/src/game/cri/mfci.c
+++ b/src/game/cri/mfci.c
@@ -46,9 +46,8 @@
 // mfCiExecServer and mfCiGetInterface. The statics it also names are
 // mfci_alloc, mfci_reset_hn, mfci_get_adr_size and mfci_call_errfn.
 //
-// NOT MATCHING: eleven of the fourteen functions are byte-exact. What is left
-// is fn_80222C40 (mfCiReqRd), fn_80222F28 (mfCiSeek) and fn_80223404
-// (mfCiExecServer).
+// NOT MATCHING: twelve of the fourteen functions are byte-exact. What is left
+// is fn_80222C40 (mfCiReqRd) and fn_80222F28 (mfCiSeek).
 //
 //   fn_80222C40 differs only in register allocation: the target ranks the
 //   handle above the buffer (r29/r28), this build ranks the buffer above the
@@ -83,22 +82,11 @@
 //   then-arm's own redundant `stw`, which this compiler does not tail-merge
 //   with the else-arm's, so the function lands at 248 against the target's 244.
 //
-//   fn_80223404 is three instructions in the target -- `li r0, 0`,
-//   `cmpwi r0, 0x28`, `blr` -- the dead remains of a loop the optimiser
-//   deleted after emitting its guard. The PS2 build shows the body: a walk over
-//   the object table calling mfCiExecHndl, which is empty there (eight bytes,
-//   `jr ra`), guarded at the call site by the same stat test. Reproducing that
-//   split exactly -- empty callee, test in the caller -- lets this compiler
-//   delete the loop outright and emit a bare `blr`. Moving the test into the
-//   callee instead keeps the loop, as a `mtctr`/`bdnz` spin; that is what is
-//   written below, because it is the closest of the three shapes this compiler
-//   will produce. The third is `volatile`, which yields a full stack frame.
-//   They are attractors, not a spectrum: index and pointer walks, `while`,
-//   `do`, `goto`, a `break`, an empty inner loop, `-inline deferred` and empty
-//   callees nested two and three deep all land on one of them. The target sits
-//   between the first two -- the loop was deleted late enough that its guard
-//   had already been emitted, and its trip count never became a `ctr` loop,
-//   which here happens only while the body still holds a call.
+//   fn_80223404 is exact. Its three instructions -- `li r0, 0`, `cmpwi r0,
+//   0x28`, `blr` -- are the dead remains of the PS2 body: a forty-entry walk
+//   calling the empty mfCiExecHndl. Keeping the empty walk and placing the dead
+//   handler call after it makes MWCC remove the work late enough to retain the
+//   loop's initial guard, exactly as retail does.
 //
 // The register allocation of mfCiOpen and mfCiReqRd turned out to be steered
 // from outside those functions. Whether mfCiOpenEntry touches a third .bss
@@ -485,9 +473,9 @@ void fn_802233F0(MfciErrFunc func, void* obj)
 	mfci_ErrObj  = obj;
 }
 
-// Empty on the PS2 build too (eight bytes, `jr ra`), where the caller guards
-// the call with the same stat test. Folding the test into the callee is the
-// one shape that keeps the loop alive here; see the header.
+// Empty on the PS2 build too (eight bytes, `jr ra`). The apparently useful
+// test gives the inliner something to discard after the caller's loop shape
+// has already been formed; see the header.
 static void mfCiExecHndl(MfciObj* hn)
 {
 	if (hn->stat == 0) {
@@ -497,11 +485,12 @@ static void mfCiExecHndl(MfciObj* hn)
 
 void fn_80223404(void)
 {
-	s32 i;
+	MfciObj* hn;
+	long i;
 
 	for (i = 0; i < MFCI_OBJ_MAX; i++) {
-		mfCiExecHndl(&mfci_ObjTbl[i]);
 	}
+	mfCiExecHndl(hn = &mfci_ObjTbl[i]);
 }
 
 void* fn_80223410(void)

--- a/src/game/cri/mfci.c
+++ b/src/game/cri/mfci.c
@@ -49,19 +49,13 @@
 // NOT MATCHING: thirteen of the fourteen functions are byte-exact. What is
 // left is fn_80222C40 (mfCiReqRd).
 //
-//   fn_80222C40 differs only in register allocation: the target ranks the
-//   handle above the buffer (r29/r28), this build ranks the buffer above the
-//   handle, and the two callee-saved registers the string and .bss bases free
-//   up afterwards follow that swap. Every instruction, every relocation and the
-//   function size already agree; 48 bytes differ and all of them are register
-//   fields. Ruled out: local declaration order, local types (`u32` vs a pointer
-//   for the address, signedness of the clamp), aliasing the buffer through a
-//   local `s8*`, extracting the min, the request setup or the memset tail into
-//   a static helper, and reshaping mfci_get_adr_size, which is inlined here.
-//   The mfCiOpenEntry lever described below is binary and already saturated:
-//   its two states give handle-above-buffer with the .rodata base sunk too far,
-//   or the base order right with the handle and buffer swapped. Neither is the
-//   target, so the remaining nudge has to come from somewhere else again.
+//   fn_80222C40 differs only in six register fields. Treating its public handle
+//   as opaque, then naming the private `MfciObj*` locally, gives the target's
+//   entry allocation exactly: handle r29, buffer r28, .rodata r30 and .bss r31.
+//   Once the inlined address lookup frees the two section bases, the remaining
+//   miss is one swapped pair: the target keeps the returned address in r31 and
+//   the clamped byte count in r30, while this build chooses r30/r31. Every
+//   instruction, relocation and the 648-byte function size otherwise agree.
 //
 //   fn_80222F28 is exact. Its final clamp needs a local result and a nested
 //   empty condition in the positive arm. The latter keeps both sides of the
@@ -134,7 +128,7 @@ void fn_80222A74(MfciObj* hn, s32 sctsize);
 s32 fn_80222B0C(MfciObj* hn);
 s32 fn_80222B6C(MfciObj* hn);
 void fn_80222BD0(MfciObj* hn);
-s32 fn_80222C40(MfciObj* hn, s32 nsct, void* buf);
+s32 fn_80222C40(void* obj, s32 nsct, void* buf);
 s32 fn_80222EC8(MfciObj* hn);
 s32 fn_80222F28(MfciObj* hn, s32 off, s32 whence);
 void fn_8022301C(MfciObj* hn);
@@ -310,8 +304,9 @@ void fn_80222BD0(MfciObj* hn)
 	fn_8022291C();
 }
 
-s32 fn_80222C40(MfciObj* hn, s32 nsct, void* buf)
+s32 fn_80222C40(void* obj, s32 nsct, void* buf)
 {
+	MfciObj* hn = obj;
 	s32 rest;
 	u32 adr;
 	u32 size;

--- a/src/game/cri/mfci.c
+++ b/src/game/cri/mfci.c
@@ -365,8 +365,8 @@ s32 fn_80222C40(MfciObj* hn, s32 nsct, void* buf)
 	rest      = hn->nsct - hn->pos;
 	hn->rdsct = nsct < rest ? nsct : rest;
 	{
-		s32 nbyte = hn->rdsct * hn->sctsize;
 		s32 ofst  = hn->pos * hn->sctsize;
+		s32 nbyte = hn->rdsct * hn->sctsize;
 		if (nbyte == 0) {
 			hn->busy = 1;
 			fn_8022291C();


### PR DESCRIPTION
## What

Complete the C reconstruction of the CRI MFCI translation unit and promote `game/cri/mfci.c` from `NonMatching` to `Matching`.

This matches the three functions that remained on main:

- `fn_80222C40` (`mfCiReqRd`)
- `fn_80222F28` (`mfCiSeek`)
- `fn_80223404` (`mfCiExecServer`)

The complete unit now has all 14 functions and all linked sections supplied by C source.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and included only the minimum symbolic fact and independent GameCube correlation.
- [x] If I changed inline flags, I documented the source/emission order and compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or links to those materials.

Evidence and references:

- The GameCube `.rodata` block begins with the MFCI/GC version banner, and every string in the owned block refers to this module's interface or error paths.
- The owned `.data` block is the 26-entry MFCI interface table; its 13 non-null entries map exactly to the 14-function run through the interface accessor.
- The owned `.bss` objects are referenced only by this run, with neighboring functions switching to a disjoint block at the boundary.
- Names for the public interface and private helpers are corroborated by the PS2 build's symbol table. Only symbolic names and the empty `mfCiExecHndl`/server-loop structure were used; no donor binary or extracted assembly is included.
- `mfCiReqRd`'s opaque public handle plus private local object pointer reproduces the retail saved-register allocation. A named clamp maximum and `n > max ? max : n` reproduce the final retail branch diamond.
- `mfCiSeek` requires a local clamp result and a nested empty condition so MWCC retains the retail branch diamond until late optimization.
- `mfCiExecServer` preserves the dead loop guard left by MWCC after eliminating the empty handler walk.
- No inline compiler flags were changed.

## Verification

- [x] `python tools/check_language_policy.py`
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:

- Before: 11/14 functions byte-exact; the TU was incomplete.
- After: 14/14 functions byte-exact, 2576/2576 code bytes, 3320/3320 linked data bytes, `complete_units: 1`.
- `fn_80222C40`: 100.0% (648 bytes).
- `fn_80222F28`: 100.0% (244 bytes).
- `fn_80223404`: 100.0% (12 bytes).
- `ninja build/G9SE8P/ok`: `18 files OK`.
