### PR TITLE
decomp: match the GCCI seek and sector-size setter

### DIFF
--- a/src/game/cri/gcci.c
+++ b/src/game/cri/gcci.c
@@ -31,15 +31,18 @@
 
 typedef void (*GcciErrFunc)(void* obj, const char* msg, void* arg);
 
+// The handle mirrors MFCI's, shifted by 0x0C: the same sector size, size,
+// sector count, position, total and read-count run, in the same order.
 typedef struct GcciObj {
 	/* 0x00 */ s8 pad00[2];
-	/* 0x02 */ s8 unk02;
+	/* 0x02 */ s8 stat;
 	/* 0x03 */ s8 pad03[0xD];
-	/* 0x10 */ s32 unk10;
-	/* 0x14 */ s32 pad14;
-	/* 0x18 */ s32 unk18;
-	/* 0x1C */ s32 unk1C;
-	/* 0x20 */ s32 unk20;
+	/* 0x10 */ s32 sctsize;
+	/* 0x14 */ s32 size;
+	/* 0x18 */ s32 nsct;
+	/* 0x1C */ s32 pos;
+	/* 0x20 */ s32 total;
+	/* 0x24 */ s32 rdsct;
 } GcciObj;
 
 static GcciErrFunc gcci_ErrFunc;
@@ -49,6 +52,15 @@ extern const char gcci_ErrHandl[];
 extern const char gcci_ErrHandl2[];
 extern const char gcci_ErrSize[];
 extern const char gcci_ErrHandl3[];
+
+static void gcci_SetNsct(GcciObj* p)
+{
+	s32 n;
+
+	n       = p->sctsize + p->size;
+	n       = n - 1;
+	p->nsct = n / p->sctsize;
+}
 
 static void gcci_Error(const char* msg)
 {
@@ -63,7 +75,7 @@ s32 fn_8021E3D8(GcciObj* p)
 		gcci_Error(gcci_ErrHandl);
 		return 0;
 	}
-	return p->unk20;
+	return p->total;
 }
 
 s32 fn_8021E51C(GcciObj* p)
@@ -72,7 +84,7 @@ s32 fn_8021E51C(GcciObj* p)
 		gcci_Error(gcci_ErrHandl3);
 		return 0;
 	}
-	return p->unk10;
+	return p->sctsize;
 }
 
 void fn_8021F20C(GcciErrFunc func, void* obj)
@@ -87,7 +99,7 @@ s32 fn_8021E57C(GcciObj* p)
 		gcci_Error(gcci_ErrHandl);
 		return 0;
 	}
-	return p->unk02;
+	return p->stat;
 }
 
 s32 fn_8021EBA8(GcciObj* p)
@@ -96,26 +108,51 @@ s32 fn_8021EBA8(GcciObj* p)
 		gcci_Error(gcci_ErrHandl);
 		return 0;
 	}
-	return p->unk1C;
+	return p->pos;
 }
 
 s32 fn_8021EC08(GcciObj* p, s32 off, s32 whence)
 {
+	s32 pos;
+
 	if (p == NULL) {
 		gcci_Error(gcci_ErrHandl);
 		return 0;
 	}
 	if (whence == 0) {
-		p->unk1C = off;
+		p->pos = off;
 	} else if (whence == 2) {
-		p->unk1C = p->unk18 + off;
+		p->pos = p->nsct + off;
 	} else if (whence == 1) {
-		p->unk1C = p->unk1C + off;
+		p->pos = p->pos + off;
 	}
-	p->unk1C = p->unk1C < p->unk18 ? p->unk1C : p->unk18;
-	if (p->unk1C > 0) {
+	p->pos = p->pos < p->nsct ? p->pos : p->nsct;
+	pos    = p->pos;
+	if (pos > 0) {
+		if (pos && pos) {
+		}
 	} else {
-		p->unk1C = 0;
+		pos = 0;
 	}
-	return p->unk1C;
+	p->pos = pos;
+	return p->pos;
+}
+
+void fn_8021E438(GcciObj* p, s32 sctsize)
+{
+	s32 total;
+
+	if (p == NULL) {
+		gcci_Error(gcci_ErrHandl2);
+		return;
+	}
+	if (p->sctsize % 32 != 0) {
+		gcci_Error(gcci_ErrSize);
+		return;
+	}
+	total      = p->pos * p->sctsize;
+	p->sctsize = sctsize;
+	gcci_SetNsct(p);
+	p->pos   = total / p->sctsize;
+	p->total = p->rdsct * sctsize;
 }


### PR DESCRIPTION
Takes `game/cri/gcci.c` to seven of fifteen functions byte-exact, 210 of 1038 instructions. `fn_8021EC08` and `fn_8021E438` both close.

## The wall came down

`fn_8021EC08` was stuck at 48/51 on the lower clamp, and the same three instructions had `fn_80222F28` stuck at 57/61 in MFCI — ten spellings tried across the two, none reproducing the target's `ble`/`b`.

@cypressru solved it in #325, and the answer is not a spelling of the clamp at all: the positive arm needs a **nested empty condition** inside it. That keeps both sides of the source branch alive long enough for MWCC to form the diamond, and the condition then vanishes, leaving both arms converging on one store. Applying that shape here closed the function at 51/51.

## Template transfer

`fn_8021E438` is MFCI's `fn_80222A74` with the struct shifted by 0x0C, and it matched **57/57 on the first attempt** by copying that function verbatim and renaming the fields. It also pinned the rest of the handle: GCCI's object mirrors MFCI's exactly — sector size at 0x10, size at 0x14, sector count at 0x18, position at 0x1C, total at 0x20, read count at 0x24 — where MFCI has the same run starting at 0x04.

That is the second time this unit has been advanced by copying from a finished one rather than reading the disassembly, and it is now clearly the cheapest first move on any CRI function.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] objdiff: fn_8021EC08 51/51, fn_8021E438 57/57, zero shape gaps
- [x] clang-format clean, language policy checks pass