### PR TITLE
decomp: match the GCCI argument setter and start its reset

### DIFF
--- a/src/game/cri/gcci.c
+++ b/src/game/cri/gcci.c
@@ -45,8 +45,21 @@ typedef struct GcciObj {
 	/* 0x24 */ s32 rdsct;
 } GcciObj;
 
-static GcciErrFunc gcci_ErrFunc;
+static struct {
+	s32 a;
+	s32 b;
+	s32 c;
+} gcci_Hdr;
+
 static void* gcci_ErrObj;
+static GcciErrFunc gcci_ErrFunc;
+
+extern void* gcci_IfTbl;
+extern void* gcci_Arg;
+extern void* memset(void* p, int c, u32 n);
+
+static u8 gcci_Big[0xFA4];
+static u8 gcci_Ram[256];
 
 extern const char gcci_ErrHandl[];
 extern const char gcci_ErrHandl2[];
@@ -155,4 +168,19 @@ void fn_8021E438(GcciObj* p, s32 sctsize)
 	gcci_SetNsct(p);
 	p->pos   = total / p->sctsize;
 	p->total = p->rdsct * sctsize;
+}
+
+void fn_8021F404(s32 a, s32 b, s32 c, void* d)
+{
+	gcci_Arg = d;
+}
+
+void* fn_8021F398(void)
+{
+	gcci_Big[0xFA0] = gcci_Big[0xFA0];
+	memset(gcci_Ram, 0, sizeof(gcci_Ram));
+	gcci_ErrFunc = NULL;
+	gcci_ErrObj  = NULL;
+	memset(&gcci_Hdr, 0, sizeof(gcci_Hdr));
+	return gcci_IfTbl;
 }


### PR DESCRIPTION
Takes `game/cri/gcci.c` to eight of fifteen functions byte-exact, 227 of 1038 instructions. `fn_8021F404` closes at 3/3; `fn_8021F398` goes from assembly to 14/27.

## Evidence

`fn_8021F398` is the module reset: it clears a 256-byte buffer, drops the error hook pair, wipes a twelve-byte header and returns the interface table. It also opens with a self-assignment of the last word of the module's large buffer, which the compiler keeps — the same shape MFCI's dead reads have.

The .bss beyond the two error-hook words is now partly mapped: a twelve-byte header at 0x8041F6B8, the hook pair behind it, a 0xFA4 block, and a 256-byte buffer at 0x80420670.

## What is left in it, and it is the known one

Thirteen instructions, and they are all the .bss layout. The target reaches the header, the error object and the error function from **one base register**, at +0, +12 and +16; this build gives them separate bases because MWCC orders those statics its own way. Declaring the header first, so the source order matches the target's addresses, measures identical — no change at all.

That is the same wall already recorded against `fn_80224C3C` in AXRNA, where five approaches were ruled out. Not spending more on it here; the remaining seven functions in this unit are shape work and worth more.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] no regression: the seven functions already matching still do
- [x] clang-format clean, language policy checks pass