### PR TITLE
decomp: fix the GCCI bss order with a layout anchor

### DIFF
--- a/src/game/cri/gcci.c
+++ b/src/game/cri/gcci.c
@@ -75,6 +75,18 @@ static void gcci_SetNsct(GcciObj* p)
 	p->nsct = n / p->sctsize;
 }
 
+// Never called, and it is here for its side effect on layout, not its value.
+// MWCC lays .bss out in order of first reference, so whatever touches the
+// header and the error object before gcci_Error runs decides where all three
+// land. With this, the header sits at 0 and the hook pair at 12 and 16, which
+// is what the target's shared base register addresses. The original must have
+// had something above gcci_Error doing the same; what that was is unknown, so
+// this stands in for it and is a hypothesis, not a reading.
+static s32 gcci_Touch(void)
+{
+	return gcci_Hdr.a + (gcci_ErrObj != NULL);
+}
+
 static void gcci_Error(const char* msg)
 {
 	if (gcci_ErrFunc != NULL) {


### PR DESCRIPTION
The .bss wall in `game/cri/gcci.c` is partly down. Three of the five statics now land exactly where the target has them, and `fn_8021F398` goes 14/27 to 17/27.

## What changed my mind

I had recorded this as a real wall — five approaches measured across AXRNA and GCCI, none moving it. The MFCI header merged in #325 says why they all failed: **.bss is laid out in order of first reference, and the lever is what a function above the first user touches**, not declaration order or alignment or the flag. Cypress used exactly that to steer MFCI's layout.

Applying it here: a static that touches the header and the error object before `gcci_Error` runs puts the header at 0 and the hook pair at 12 and 16 — which is precisely what the target's shared base register addresses, and what every large function in this unit needs before it can match.

    now     Hdr@0  ErrObj@12  ErrFunc@16  Ram@20    Big@276
    target  Hdr@0  ErrObj@12  ErrFunc@16  Big@20    Ram@4024

The anchor is a hypothesis and is labelled as one in the file. The original must have had something above `gcci_Error` touching those two; what it was is unknown.

## What is still out

`Ram` and `Big` are swapped. Three placements of the reference were measured — touching `Big` in the anchor moves it to the front (14/27), touching it between the hook pair and `Ram` gives 16/27, leaving it to `fn_8021F398` gives 17/27, which is the best of the three. Emission order inside that function does not decide it: the target materialises `Ram`'s address first too and still places `Big` at 20.

## Why this matters beyond one function

Every remaining function in this unit — all six, 798 instructions — reaches the error hook through that same base. They were blocked on this, not on their own shape.

## Verification

- [x] `ninja` passes, `sha1sum -c config/G9SE8P/build.sha1` 18/18
- [x] no regression: the eight functions already matching still do
- [x] clang-format clean, language policy checks pass