### PR TITLE
decomp: land the GCCI bss at the target offsets and correct the naming note

### DIFF
--- a/src/game/cri/gcci.c
+++ b/src/game/cri/gcci.c
@@ -25,9 +25,23 @@
 //   fn_8021E118 and fn_8021E3D8 share nothing. The upper bound is fn_8021F410,
 //   the shared error reporter that lsc.c also calls, so it belongs to neither.
 //
-// Nothing is named yet. The messages here carry no function names -- unlike
-// MFCI and LSC, whose "(mfCiOpen)" and "(LSC_Create)" suffixes gave the naming
-// away -- so every function keeps its dtk name until something anchors it.
+// Correcting what stood here: the messages DO carry function names, the same
+// way MFCI's and LSC's do. I had only read the first third of the .rodata. The
+// suffixes in the block name three functions outright --
+//
+//   +200 "E0092913:nsct < 0.(gcCiReqRd)"          +232 "...buf is null.(gcCiReqRd)"
+//   +276 "E0092908:fname is null.(gcCiOpen)"       and three more (gcCiOpen)
+//   +428 "E0092901:fname is null.(gcCiGetFileSize)" and two more (gcCiGetFileSize)
+//
+// -- and fn_8021F0A8 is gcCiGetFileSize: it is the only function that reads all
+// three of the +428/+472/+520 messages. The names are not applied yet because
+// the functions that own them are still unwritten; renaming a dtk symbol before
+// its body exists would only make the diff harder to read.
+//
+// The whole .rodata is one string pool addressed from a single base register,
+// so its layout is decided by the order the functions first use the literals.
+// That order is therefore also the source order of the functions, which is what
+// the remaining six will have to respect.
 
 typedef void (*GcciErrFunc)(void* obj, const char* msg, void* arg);
 
@@ -76,15 +90,17 @@ static void gcci_SetNsct(GcciObj* p)
 }
 
 // Never called, and it is here for its side effect on layout, not its value.
-// MWCC lays .bss out in order of first reference, so whatever touches the
-// header and the error object before gcci_Error runs decides where all three
-// land. With this, the header sits at 0 and the hook pair at 12 and 16, which
-// is what the target's shared base register addresses. The original must have
-// had something above gcci_Error doing the same; what that was is unknown, so
-// this stands in for it and is a hypothesis, not a reading.
+// The .bss comes out in the REVERSE of the order the first function to touch
+// these reads them, except that the first two touched keep their relative order
+// and land last. Reading Big and Ram first, then the hooks, then the header,
+// puts all five at exactly the target's offsets: Hdr@0, ErrObj@12, ErrFunc@16,
+// Big@20, Ram@4024. Measured, not guessed -- declaration order and the order of
+// the touches inside fn_8021F398 were both tried first and neither moves them.
+// The original must have had a real function above gcci_Error doing this; what
+// it was is unknown, so this stands in for it and is a hypothesis.
 static s32 gcci_Touch(void)
 {
-	return gcci_Hdr.a + (gcci_ErrObj != NULL);
+	return gcci_Big[0] + gcci_Ram[0] + (gcci_ErrFunc != NULL) + (gcci_ErrObj != NULL) + gcci_Hdr.a;
 }
 
 static void gcci_Error(const char* msg)


### PR DESCRIPTION
The five statics in `gcci.c` now sit at exactly the target's offsets — `Hdr@0`, `ErrObj@12`, `ErrFunc@16`, `Big@20`, `Ram@4024`. Previously `Big` and `Ram` were swapped, which is the base every one of the six unwritten functions addresses its statics through.

The lever is the layout anchor, refined: the `.bss` comes out in the **reverse** of the order the first touching function reads the statics, **except that the first two touched keep their relative order and land last**. Reading `Big` and `Ram` first, then the hooks, then the header, places all five. Two other explanations were measured and rejected first — declaration order of `Big`/`Ram`, and the order of the touches inside `fn_8021F398` — neither moves them at all.

Scores are unchanged (230/1038, 8/15), because the functions that would benefit are the ones not yet written. This is the prerequisite, not the payoff.

Also corrects the file header. It claimed the messages carry no function names; they do, and I had simply not read past the first third of the `.rodata`. The suffixes name `gcCiReqRd`, `gcCiOpen` and `gcCiGetFileSize`, and `fn_8021F0A8` is `gcCiGetFileSize` — it is the only function reading all three of that group's messages. The names are not applied to the symbols yet, since the bodies that own them do not exist.

Build stays 18/18.