### PR TITLE
decomp: reconstruct spatial list search

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -170,6 +170,11 @@ game/fn_8005428C.cpp:
 	extabindex  start:0x8000CEC8 end:0x8000CED4
 	.text       start:0x8005428C end:0x8005430C
 
+game/fn_8005438C.cpp:
+	extab       start:0x8000653C end:0x80006544
+	extabindex  start:0x8000CEE0 end:0x8000CEEC
+	.text       start:0x8005438C end:0x8005446C
+
 game/fn_80057524.cpp:
 	extab       start:0x800065E4 end:0x800065EC
 	extabindex  start:0x8000CF94 end:0x8000CFA0

--- a/configure.py
+++ b/configure.py
@@ -622,6 +622,7 @@ config.libs = [
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
             Object(Matching, "game/fn_80054048.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"]),
+            Object(NonMatching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(
                 Matching,
                 "game/fn_80053FB8.cpp",

--- a/src/game/fn_8005438C.cpp
+++ b/src/game/fn_8005438C.cpp
@@ -1,0 +1,32 @@
+#include "types.h"
+
+// The control flow, data layout, arithmetic, exception metadata, and source
+// range are exact. GC/1.3.2 retains a register-allocation-only residual:
+// root/child use r7/r8 and the two live float values use f5/f4 in retail,
+// while the independently reconstructed source swaps each pair.
+
+struct Fn8005438CVec { f32 x; f32 y; f32 z; };
+struct Fn8005438CNode {
+    u8 padding[4]; u16 childIndex; u8 padding2[0xE]; u16 zIndex; u16 xIndex; u8 level; u8 padding3[7];
+};
+struct Fn8005438CGrid {
+    Fn8005438CNode* nodes; u8 padding[0x2C]; f32 baseZ; f32 padding2; f32 baseX; f32 scaleX;
+    f32 padding3; f32 scaleZ; u8 padding4[0xC]; f32 cellSizes[1];
+};
+
+extern "C" Fn8005438CNode* fn_8005438C(Fn8005438CGrid* grid, const Fn8005438CVec* point)
+{
+    Fn8005438CNode* nodes = grid->nodes;
+    if (nodes == 0) return 0;
+    Fn8005438CNode* node = nodes;
+    while (node->childIndex != 0) {
+        f32 cellSize = grid->cellSizes[node->level];
+        f32 scale = grid->scaleX * grid->scaleZ;
+        f32 maxZ = grid->baseZ + (f32)node->zIndex * scale + cellSize;
+        f32 maxX = grid->baseX + (f32)node->xIndex * scale + cellSize;
+        u32 child = (point->x >= maxX) ? 1 : 0;
+        if (point->z >= maxZ) child |= 2;
+        node = &nodes[node->childIndex + child];
+    }
+    return node;
+}


### PR DESCRIPTION
## Summary\n- reconstruct the 224-byte spatial list search at 0x8005438C\n- preserve its exact data layout, arithmetic, exception metadata, and control flow\n- record the remaining GC/1.3.2 register-allocation residual as NonMatching\n\n## Validation\n- python3 configure.py --non-matching\n- python3 -m unittest tools.test_check_language_policy\n- python3 tools/check_language_policy.py\n- ninja