### PR TITLE
decomp: reconstruct list destructor

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -157,6 +157,11 @@ game/fn_80054048.cpp:
 	extabindex  start:0x8000CEA4 end:0x8000CEB0
 	.text       start:0x80054048 end:0x80054158
 
+game/fn_80054158.cpp:
+	extab       start:0x8000651C end:0x80006524
+	extabindex  start:0x8000CEB0 end:0x8000CEBC
+	.text       start:0x80054158 end:0x8005421C
+
 game/fn_8005421C.cpp:
 	.text       start:0x8005421C end:0x80054230
 

--- a/configure.py
+++ b/configure.py
@@ -627,6 +627,7 @@ config.libs = [
                 extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"],
             ),
             Object(Matching, "game/fn_80054048.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"]),
+            Object(Matching, "game/fn_80054158.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"]),
             Object(NonMatching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(
                 Matching,

--- a/src/game/fn_80054158.cpp
+++ b/src/game/fn_80054158.cpp
@@ -1,0 +1,29 @@
+#include "types.h"
+
+struct Fn80054158Node { u8 padding[0x28]; Fn80054158Node* previous; Fn80054158Node* next; };
+struct Fn80054158List { s32 count; Fn80054158Node* first; Fn80054158Node* last; };
+struct Fn80054158Allocator { u8 padding[0x138]; void (*release)(Fn80054158Node*); };
+extern "C" Fn80054158Allocator* lbl_8042C9A4;
+extern "C" void __dl(void*);
+
+extern "C" Fn80054158List* fn_80054158(Fn80054158List* list, s16 destroy)
+{
+    if (list != 0) {
+        if (list->count != 0) {
+            Fn80054158Node* previous = 0;
+            do {
+                Fn80054158Node* next = 0;
+                if (list->first->next != 0) {
+                    list->first->next->previous = previous;
+                    next = list->first->next;
+                }
+                lbl_8042C9A4->release(list->first);
+                list->first = next;
+            } while (list->first != 0);
+            list->last = 0;
+            list->count = 0;
+        }
+        if (destroy > 0) __dl(list);
+    }
+    return list;
+}


### PR DESCRIPTION
## Summary\n- reconstruct the 196-byte list destructor at 0x80054158\n- preserve allocator and deletion calls plus exception metadata\n\n## Validation\n- python3 -m unittest tools.test_check_language_policy\n- python3 tools/check_language_policy.py\n- ninja build/G9SE8P/report.json (100% code and data match)\n- ninja (18 files OK)