### PR TITLE
decomp: make spatial list search a fully matching TU

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -636,7 +636,7 @@ config.libs = [
             Object(Matching, "game/fn_800556A0.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"]),
             Object(Matching, "game/fn_80055874.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800546F4.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
-            Object(NonMatching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
+            Object(Matching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D75CC.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7920.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7A54.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
@@ -3461,6 +3461,11 @@ objdump_path = binutils_dir / (
 
 config.custom_build_rules = [
     {
+        "name": "fix_fn_8005438C_object",
+        "command": "$python tools/fix_fn_8005438C_object.py $in $out",
+        "description": "FIX fn_8005438C shared conversion bias",
+    },
+    {
         "name": "fix_wide_format_core_object",
         "command": "$python tools/fix_wide_format_core_object.py $in $out",
         "description": "FIX wide_format_core.cpp compiler-only codegen",
@@ -3722,6 +3727,12 @@ config.custom_build_rules = [
 ]
 config.custom_build_steps = {
     "post-compile": [
+        {
+            "outputs": "build/G9SE8P/fn-8005438C-object.stamp",
+            "rule": "fix_fn_8005438C_object",
+            "inputs": "build/G9SE8P/src/game/fn_8005438C.o",
+            "implicit": ["tools/fix_fn_8005438C_object.py"],
+        },
         {
             "outputs": "build/G9SE8P/wide-format-core-object.stamp",
             "rule": "fix_wide_format_core_object",

--- a/src/game/fn_8005438C.cpp
+++ b/src/game/fn_8005438C.cpp
@@ -1,32 +1,56 @@
 #include "types.h"
 
-// The control flow, data layout, arithmetic, exception metadata, and source
-// range are exact. GC/1.3.2 retains a register-allocation-only residual:
-// root/child use r7/r8 and the two live float values use f5/f4 in retail,
-// while the independently reconstructed source swaps each pair.
+// Spatial-list traversal split from the original game translation unit.
 
-struct Fn8005438CVec { f32 x; f32 y; f32 z; };
+struct Fn8005438CVec {
+	f32 x;
+	f32 y;
+	f32 z;
+};
 struct Fn8005438CNode {
-    u8 padding[4]; u16 childIndex; u8 padding2[0xE]; u16 zIndex; u16 xIndex; u8 level; u8 padding3[7];
+	u8 padding[4];
+	u16 childIndex;
+	u8 padding2[0xE];
+	u16 xIndex;
+	u16 zIndex;
+	u8 level;
+	u8 padding3[7];
 };
 struct Fn8005438CGrid {
-    Fn8005438CNode* nodes; u8 padding[0x2C]; f32 baseZ; f32 padding2; f32 baseX; f32 scaleX;
-    f32 padding3; f32 scaleZ; u8 padding4[0xC]; f32 cellSizes[1];
+	Fn8005438CNode* nodes;
+	u8 padding[0x2C];
+	f32 baseX;
+	f32 padding2;
+	f32 baseZ;
+	f32 scaleX;
+	f32 padding3;
+	f32 scaleZ;
+	u8 padding4[0xC];
+	f32 cellSizes[1];
 };
+
+extern "C" const f64 lbl_8042D3A0;
+// Retained only until the post-compile step retargets MWCC's private conversion
+// bias atom to the shared symbol used by the original translation unit.
+extern "C" const f64* fn_8005438C_bias_anchor = &lbl_8042D3A0;
 
 extern "C" Fn8005438CNode* fn_8005438C(Fn8005438CGrid* grid, const Fn8005438CVec* point)
 {
-    Fn8005438CNode* nodes = grid->nodes;
-    if (nodes == 0) return 0;
-    Fn8005438CNode* node = nodes;
-    while (node->childIndex != 0) {
-        f32 cellSize = grid->cellSizes[node->level];
-        f32 scale = grid->scaleX * grid->scaleZ;
-        f32 maxZ = grid->baseZ + (f32)node->zIndex * scale + cellSize;
-        f32 maxX = grid->baseX + (f32)node->xIndex * scale + cellSize;
-        u32 child = (point->x >= maxX) ? 1 : 0;
-        if (point->z >= maxZ) child |= 2;
-        node = &nodes[node->childIndex + child];
-    }
-    return node;
+	Fn8005438CNode* nodes = grid->nodes;
+	if (nodes == 0)
+		return 0;
+	u16 childIndex;
+	Fn8005438CNode* node = nodes;
+	while ((childIndex = node->childIndex) != 0) {
+		f32 scale;
+		f32 cellSize = grid->cellSizes[node->level];
+		scale        = grid->scaleX * grid->scaleZ;
+		f32 maxZ     = grid->baseZ + ((f32)node->zIndex * scale + cellSize);
+		f32 maxX     = grid->baseX + ((f32)node->xIndex * scale + cellSize);
+		u32 child    = (point->x >= maxX) ? 1 : 0;
+		if (point->z >= maxZ)
+			child |= 2;
+		node = &nodes[childIndex + child];
+	}
+	return node;
 }

--- a/tools/fix_fn_8005438C_object.py
+++ b/tools/fix_fn_8005438C_object.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+"""Restore the shared integer-conversion bias in fn_8005438C's split object.
+
+The retail function belonged to a larger translation unit, so its compiler-
+generated u16-to-float bias atom is shared and appears here as an undefined
+symbol. Compiling the reconstructed split TU creates an identical private
+atom. Retarget that one relocation to the retail symbol, then remove the
+private atom and the source-level anchor used to make the undefined symbol
+available to the ELF symbol table. No instruction byte is changed.
+"""
+
+import argparse
+import struct
+from pathlib import Path
+
+
+BIAS_SYMBOL = "lbl_8042D3A0"
+ANCHOR_SYMBOL = "fn_8005438C_bias_anchor"
+
+
+def cstring(blob: bytes, offset: int) -> str:
+    return blob[offset : blob.index(0, offset)].decode("ascii")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("object", type=Path)
+    parser.add_argument("stamp", type=Path)
+    args = parser.parse_args()
+
+    blob = bytearray(args.object.read_bytes())
+    if blob[:6] != b"\x7fELF\x01\x02":
+        raise SystemExit("expected a big-endian ELF32 object")
+
+    header = list(struct.unpack_from(">16sHHIIIIIHHHHHH", blob, 0))
+    shoff, shentsize, shnum, shstrndx = header[6], header[11], header[12], header[13]
+    sections = [
+        list(struct.unpack_from(">IIIIIIIIII", blob, shoff + i * shentsize))
+        for i in range(shnum)
+    ]
+    shstr = sections[shstrndx]
+    section_names = blob[shstr[4] : shstr[4] + shstr[5]]
+    by_name = {
+        cstring(section_names, section[0]): (index, section)
+        for index, section in enumerate(sections)
+    }
+
+    sdata2_index, sdata2 = by_name[".sdata2"]
+    _, symtab = by_name[".symtab"]
+    strtab = sections[symtab[6]]
+    strings = blob[strtab[4] : strtab[4] + strtab[5]]
+    private_bias_index = None
+    private_bias_offset = None
+    shared_bias_index = None
+    anchor_offset = None
+    symbol_offsets = range(symtab[4], symtab[4] + symtab[5], symtab[9])
+    for index, offset in enumerate(symbol_offsets):
+        name_offset, value, size, info, _, section_index = struct.unpack_from(
+            ">IIIBBH", blob, offset
+        )
+        name = cstring(strings, name_offset) if name_offset else ""
+        if section_index == sdata2_index and size == 8 and value == 0 and (info & 0xF) == 1:
+            private_bias_index = index
+            private_bias_offset = offset
+        elif name == BIAS_SYMBOL and section_index == 0:
+            shared_bias_index = index
+        elif name == ANCHOR_SYMBOL:
+            anchor_offset = offset
+
+    if sdata2[5] != 8 or private_bias_index is None:
+        raise SystemExit("unexpected private conversion-bias atom")
+    if shared_bias_index is None or anchor_offset is None:
+        raise SystemExit("missing shared bias or source anchor symbol")
+
+    _, rela_text = by_name[".rela.text"]
+    replacements = 0
+    for offset in range(rela_text[4], rela_text[4] + rela_text[5], rela_text[9]):
+        relocation_offset, info, addend = struct.unpack_from(">IIi", blob, offset)
+        if info >> 8 == private_bias_index:
+            info = (shared_bias_index << 8) | (info & 0xFF)
+            struct.pack_into(">IIi", blob, offset, relocation_offset, info, addend)
+            replacements += 1
+    if replacements != 1:
+        raise SystemExit(f"expected one conversion-bias relocation, found {replacements}")
+
+    # Keep MWCC's object metadata and file layout intact so MWLink preserves
+    # the original exception-table packing. Remove only the section headers
+    # for the two temporary source atoms and their relocation section.
+    removed_indices = {
+        by_name[".sdata"][0],
+        by_name[".sdata2"][0],
+        by_name[".rela.sdata"][0],
+    }
+    for offset in (private_bias_offset, anchor_offset):
+        name_offset = struct.unpack_from(">I", blob, offset)[0]
+        struct.pack_into(">IIIBBH", blob, offset, name_offset, 0, 0, 0, 0, 0xFFF1)
+    symtab[7] = shared_bias_index
+
+    kept_indices = [index for index in range(shnum) if index not in removed_indices]
+    old_to_new = {old: new for new, old in enumerate(kept_indices)}
+    for offset in symbol_offsets:
+        section_index = struct.unpack_from(">H", blob, offset + 14)[0]
+        if section_index in removed_indices:
+            struct.pack_into(">H", blob, offset + 14, 0xFFF1)
+        elif 0 < section_index < shnum:
+            struct.pack_into(">H", blob, offset + 14, old_to_new[section_index])
+
+    kept_sections = []
+    for old_index in kept_indices:
+        section = sections[old_index].copy()
+        if section[6]:
+            section[6] = old_to_new[section[6]]
+        if section[1] == 4:  # SHT_RELA
+            section[7] = old_to_new[section[7]]
+        kept_sections.append(section)
+    for index, section in enumerate(kept_sections):
+        struct.pack_into(">IIIIIIIIII", blob, shoff + index * shentsize, *section)
+    header[12] = len(kept_sections)
+    header[13] = old_to_new[shstrndx]
+    struct.pack_into(">16sHHIIIIIHHHHHH", blob, 0, *header)
+    args.object.write_bytes(blob)
+
+    args.stamp.parent.mkdir(parents=True, exist_ok=True)
+    args.stamp.touch()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Completes `game/fn_8005438C.cpp` as one fully matching C++ translation unit. The function traverses the spatial-list hierarchy and selects a child from the query point and per-level cell bounds.

The post-compile step handles one split-TU-only compiler atom: retail shares the unsigned-integer conversion bias with the original larger TU, while isolated MWCC emits a private duplicate. The repair retargets that relocation and removes only the temporary source anchor/private atom; it does not modify instruction bytes.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the current file extension or a byte match alone.
- [x] This is a C++ path; the target object records `fn_8005438C.cpp`, emits C++ exception metadata, and exposes the function with C linkage.
- [x] Names and types come from the GameCube object layout and instruction offsets. Descriptive struct and field names are reconstruction labels, not recovered retail names.
- [x] No PS2 metadata was used.
- [x] No inline flags were changed. The existing `-fp_contract off` and scheduling flags were retained and verified in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or links to those materials.

Evidence and references:

- Node offsets `0x14`/`0x16` and grid offsets `0x30`/`0x38` establish the X/Z field order.
- An explicit child-index lifetime and the recovered arithmetic grouping reproduce the retail integer and floating-point register allocation.
- The target relocation names shared bias `lbl_8042D3A0`; the compiler-atom repair preserves MWCC ELF metadata so the exception tables retain retail link placement.

## Verification

- [x] `python3 tools/check_language_policy.py`
- [x] `python3 -m unittest tools.test_check_language_policy`
- [x] `clang-format -i src/game/fn_8005438C.cpp`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:

- Before: 98.53571% for `fn_8005438C`
- After: 100.0%, 1/1 function, 224/224 `.text` bytes
- `extab`: 8/8 bytes (100.0%)
- `extabindex`: 12/12 bytes (100.0%)
- Full build: 18 files OK

## AI assistance

AI assistance was used to explore compiler-equivalent C++ forms and the split-object metadata repair. Every candidate was rebuilt and checked in objdiff; the final TU is byte-exact and the full artifact SHA-1 gate passes.