### PR TITLE
decomp: complete grid radius query translation unit

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -632,7 +632,7 @@ config.libs = [
             Object(Matching, "game/fn_80054524.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"]),
             Object(NonMatching, "game/fn_80055470.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(Matching, "game/fn_800556A0.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"]),
-            Object(NonMatching, "game/fn_80055874.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
+            Object(Matching, "game/fn_80055874.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800546F4.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(

--- a/src/game/fn_80055874.cpp
+++ b/src/game/fn_80055874.cpp
@@ -1,28 +1,36 @@
 #include "types.h"
 
-// Traversal, clipping, circle tests, layouts, and exception metadata match the
-// retail unit. The remaining GC/1.3.2 delta is only floating-register choice.
+// Recursive grid-radius query split from the original game translation unit.
 
-struct Fn80055874Vec { f32 x; f32 y; f32 z; };
-struct Fn80055874Result { u16 value; u16 padding; Fn80055874Result* previous; Fn80055874Result* next; };
+struct Fn80055874Vec {
+	f32 x;
+	f32 y;
+	f32 z;
+};
+struct Fn80055874Result {
+	u16 value;
+	u16 padding;
+	Fn80055874Result* previous;
+	Fn80055874Result* next;
+};
 struct Fn80055874Node {
-    u16 value;
-    u16 padding;
-    u16 firstChild;
-    u16 neighbours[4];
-    u16 count;
-    u8 padding2[8];
-    u8 level;
-    u8 padding3[7];
+	u16 value;
+	u16 padding;
+	u16 firstChild;
+	u16 neighbours[4];
+	u16 count;
+	u8 padding2[8];
+	u8 level;
+	u8 padding3[7];
 };
 struct Fn80055874Grid {
-    Fn80055874Node* root;
-    u8 padding[16];
-    u32* visited;
-    u8 padding2[8];
-    u32 visitedGroups;
-    u8 padding3[48];
-    f32 cellExtents[1];
+	Fn80055874Node* root;
+	u8 padding[16];
+	u32* visited;
+	u8 padding2[8];
+	u32 visitedGroups;
+	u8 padding3[48];
+	f32 cellExtents[1];
 };
 
 extern "C" u32 lbl_80242B28[4];
@@ -34,90 +42,104 @@ extern "C" Fn80055874Result* fn_80055874(Fn80055874Grid* grid, Fn80055874Result*
     Fn80055874Node* node, const Fn80055874Vec* point, f32 radius, const Fn80055874Vec* upper,
     const Fn80055874Vec* lower)
 {
-    u8 selection = 0;
-    f32 extent = grid->cellExtents[node->level];
-    Fn80055874Vec center;
-    {
-        u16 value = node->value;
-        grid->visited[value >> 5] |= 1 << (value & 31);
-        grid->visitedGroups |= 1 << (value >> 11);
-    }
-    fn_8005430C(grid, node, &center);
+	s32 neighbourIndex;
+	u8 selection = 0;
+	f32 extent   = grid->cellExtents[node->level];
+	Fn80055874Vec center;
+	{
+		u16 value = node->value;
+		grid->visited[value >> 5] |= 1 << (value & 31);
+		grid->visitedGroups |= 1 << (value >> 11);
+	}
+	fn_8005430C(grid, node, &center);
 
-    if (node->firstChild != 0) {
-        if (upper->x < center.x) selection = 0xA;
-        else if (center.x < lower->x) selection = 5;
-        if (upper->z < center.z) selection |= 0xC;
-        else if (center.z < lower->z) selection |= 3;
+	if (node->firstChild != 0) {
+		if (upper->x < center.x)
+			selection = 0xA;
+		else if (center.x < lower->x)
+			selection = 5;
+		if (upper->z < center.z)
+			selection |= 0xC;
+		else if (center.z < lower->z)
+			selection |= 3;
 
-        for (s32 index = 0; index < 4; index++) {
-            s32 child = node->firstChild + index;
-            u16 childIndex = child;
-            if ((s32)(grid->visited[childIndex >> 5] & (1 << (childIndex & 31))) == 0 &&
-                (s32)(selection & lbl_80242B28[index]) == 0) {
-                result = fn_80055874(grid, result, &grid->root[child], point, radius, upper, lower);
-            }
-        }
-    } else if (node->count != 0) {
-        f32 leafExtent = grid->cellExtents[node->level];
-        s32 region = 0;
-        f32 deltaX;
-        f32 deltaZ;
-        deltaX = point->x - center.x;
-        deltaZ = point->z - center.z;
-        s32 intersects;
+		for (s32 index = 0; index < 4; index++) {
+			s32 child      = node->firstChild + index;
+			u16 childIndex = child;
+			if ((s32)(grid->visited[childIndex >> 5] & (1 << (childIndex & 31))) == 0
+			    && (s32)(selection & lbl_80242B28[index]) == 0) {
+				result = fn_80055874(grid, result, &grid->root[child], point, radius, upper, lower);
+			}
+		}
+	} else if (node->count != 0) {
+		f32 leafExtent = grid->cellExtents[node->level];
+		s32 region     = 0;
+		f32 deltaX;
+		deltaX           = point->x - center.x;
+		const f32 deltaZ = point->z - center.z;
+		s32 intersects;
 
-        if (leafExtent < deltaX) region = 1;
-        else if (deltaX < -leafExtent) region = 2;
-        if (leafExtent < deltaZ) region += 3;
-        else if (deltaZ < -leafExtent) region += 6;
+		if (leafExtent < deltaX)
+			region = 1;
+		else if (deltaX < -leafExtent)
+			region = 2;
+		if (leafExtent < deltaZ)
+			region += 3;
+		else if (deltaZ < -leafExtent)
+			region += 6;
 
-        switch (region) {
-        case 0:
-            intersects = true;
-            break;
-        case 1:
-        case 2:
-            intersects = (f32)__fabs(deltaX) <= leafExtent + radius;
-            break;
-        case 3:
-        case 6:
-            intersects = (f32)__fabs(deltaZ) <= leafExtent + radius;
-            break;
-        case 4:
-        case 5:
-        case 7:
-        case 8:
-            deltaX = (f32)__fabs(deltaX) - leafExtent;
-            deltaZ = (f32)__fabs(deltaZ) - leafExtent;
-            intersects = deltaX * deltaX + deltaZ * deltaZ <= radius * radius;
-            break;
-        default:
-            intersects = false;
-            break;
-        }
-        if (intersects) result = fn_8005428C(result, node->value);
-    }
+		switch (region) {
+			case 0:
+				intersects = true;
+				break;
+			case 1:
+			case 2:
+				intersects = (f32)__fabs(deltaX) <= leafExtent + radius;
+				break;
+			case 3:
+			case 6:
+				intersects = (f32)__fabs(deltaZ) <= leafExtent + radius;
+				break;
+			case 4:
+			case 5:
+			case 7:
+			case 8:
+				f32 cornerX = (f32)__fabs(deltaX) - leafExtent;
+				f32 cornerZ = (f32)__fabs(deltaZ) - leafExtent;
+				intersects  = cornerX * cornerX + cornerZ * cornerZ <= radius * radius;
+				break;
+			default:
+				intersects = false;
+				break;
+		}
+		if (intersects)
+			result = fn_8005428C(result, node->value);
+	}
 
-    for (s32 index = 0; index <= 3; index++) {
-        u16 neighbour = node->neighbours[index];
-        if ((s32)neighbour != 0 && (s32)(grid->visited[neighbour >> 5] & (1 << (neighbour & 31))) == 0) {
-            switch (index) {
-            case 0:
-                if (upper->x < center.x + extent) continue;
-                break;
-            case 1:
-                if (lower->x > center.x - extent) continue;
-                break;
-            case 2:
-                if (upper->z < center.z + extent) continue;
-                break;
-            case 3:
-                if (lower->z > center.z - extent) continue;
-                break;
-            }
-            result = fn_80055874(grid, result, &grid->root[neighbour], point, radius, upper, lower);
-        }
-    }
-    return result;
+	for (neighbourIndex = 0; neighbourIndex <= 3; neighbourIndex++) {
+		u16 neighbour = node->neighbours[neighbourIndex];
+		if ((s32)neighbour != 0
+		    && (s32)(grid->visited[neighbour >> 5] & (1 << (neighbour & 31))) == 0) {
+			switch (neighbourIndex) {
+				case 0:
+					if (upper->x < center.x + extent)
+						continue;
+					break;
+				case 1:
+					if (lower->x > center.x - extent)
+						continue;
+					break;
+				case 2:
+					if (upper->z < center.z + extent)
+						continue;
+					break;
+				case 3:
+					if (lower->z > center.z - extent)
+						continue;
+					break;
+			}
+			result = fn_80055874(grid, result, &grid->root[neighbour], point, radius, upper, lower);
+		}
+	}
+	return result;
 }


### PR DESCRIPTION
## What

Complete the whole `src/game/fn_80055874.cpp` C++ translation unit and mark it matching. This TU contains the recursive grid-radius query function.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and included only the minimum symbolic fact and independent GameCube correlation.
- [x] If I changed inline flags, I documented the source/emission order and compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or links to those materials.

Evidence and references:

- The target GameCube object identifies one externally linked function, `fn_80055874`, plus C++ exception metadata (`extab` and `extabindex`).
- The recursive public C-linkage boundary and exception metadata support retaining this as C++.
- Structure field and local variable names describe the observed GameCube layout and behavior; names without public symbols are descriptive guesses.
- No PS2 metadata or proprietary artifacts were used.
- No inline flags were changed; the existing `-Cpp_exceptions on -opt noschedule,nopeephole -fp_contract off` flags are retained.

## Verification

- [x] `python tools/check_language_policy.py`
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:

- Before: 99.709305% `.text`
- After: 100.0% whole TU
- `.text`: 1032/1032 bytes (1/1 function)
- `extab`: 8/8 bytes
- `extabindex`: 12/12 bytes
- Full build: 18 files OK

## AI assistance

AI assistance was used to compare compiler output, iterate source forms, run verification, and prepare this pull request. The resulting source and complete object match were independently validated by objdiff and the repository build checks.