### PR TITLE
decomp: reconstruct normal angle query

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -300,6 +300,11 @@ game/fn_800D75CC.cpp:
 	extabindex  start:0x8000F364 end:0x8000F370
 	.text       start:0x800D75CC end:0x800D7920
 
+game/fn_800D7920.cpp:
+	extab       start:0x80008C60 end:0x80008C68
+	extabindex  start:0x8000F370 end:0x8000F37C
+	.text       start:0x800D7920 end:0x800D7A54
+
 game/texture.cpp:
 	extab       start:0x80008CA0 end:0x80008CA8
 	extabindex  start:0x8000F3D0 end:0x8000F3DC

--- a/configure.py
+++ b/configure.py
@@ -638,6 +638,7 @@ config.libs = [
             Object(NonMatching, "game/fn_800546F4.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D75CC.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
+            Object(NonMatching, "game/fn_800D7920.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(
                 Matching,
                 "game/fn_80053FB8.cpp",

--- a/src/game/fn_800D7920.cpp
+++ b/src/game/fn_800D7920.cpp
@@ -1,0 +1,28 @@
+#include "types.h"
+
+// Converts the angle between two normalized vectors to the engine's unsigned
+// 16-bit turn representation. The optional orientation vector selects the
+// winding direction.
+
+struct Fn800D7920Vec { f32 x; f32 y; f32 z; };
+
+extern "C" double acos(double);
+
+extern "C" s32 fn_800D7920(const Fn800D7920Vec* first, const Fn800D7920Vec* second,
+    const Fn800D7920Vec* orientation)
+{
+    f32 dot = first->z * second->z + first->x * second->x + first->y * second->y;
+    if (dot <= -1.0f) return 0x8000;
+    if (dot >= 1.0f) return 0;
+
+    s32 angle = (s32)(10430.381f * (f32)acos(dot));
+    Fn800D7920Vec cross;
+    cross.x = first->y * second->z - first->z * second->y;
+    cross.y = first->z * second->x - first->x * second->z;
+    cross.z = first->x * second->y - first->y * second->x;
+    if (orientation != 0 &&
+        orientation->z * cross.z + orientation->x * cross.x + orientation->y * cross.y < 0.0f) {
+        return 0x10000 - angle;
+    }
+    return angle;
+}


### PR DESCRIPTION
## Summary\n- reconstruct the normalized vector angle helper\n- register its 0x134-byte source and exception ranges as a NonMatching object\n\n## Validation\n- git diff --check\n- python3 -m unittest tools.test_check_language_policy\n- python3 tools/check_language_policy.py\n- ninja