### PR TITLE
docs: state the criteria for object post-processors

### DIFF
--- a/docs/object-post-processors.md
+++ b/docs/object-post-processors.md
@@ -1,0 +1,98 @@
+# Object post-processors
+
+Some translation units carry a `tools/fix_<unit>_object.py` step that edits the
+compiled object before it is linked. This page says what those steps are for,
+what they may and may not do, and what a new one has to ship with.
+
+There are 38 of them today.
+
+## What they are for
+
+dtk builds the *target* object from `splits.txt` and `symbols.txt`. MWCC builds
+ours from source. The two agree on instructions long before they agree on
+everything else, because an object file carries a lot that no C statement
+controls: the order of compiler-generated atoms, `.ctors` slot placement,
+section alignment fields, ABI metadata in the comment section, common-BSS
+inflation. When our reconstruction is right and the object still differs in one
+of those, a post-processor is the honest way to say so.
+
+That is the whole purpose. A post-processor describes a **known, measured gap
+between our build and retail's**. It is a bookmark, not a conclusion.
+
+## The standard
+
+`tools/fix_wide_format_core_object.py` set it, and it is worth quoting because
+every new step is measured against it:
+
+> Nothing here carries retail instruction content. Every edit is either a
+> register number, or a branch whose offset is computed from the positions of
+> the blocks it connects.
+>
+> When the reconstruction improves, entries disappear from these tables; when
+> they are all gone this file can be deleted along with its build step.
+>
+> Current remainder: 4 block-layout edits and 186 register-field substitutions
+> across 134 of the function's 1069 instructions.
+>
+> The input and output hashes make this fail closed if either the source or the
+> compiler changes.
+
+Four properties come out of that, and a new post-processor needs all four.
+
+**1. No retail content.** The script may permute what our compiler produced — a
+register number, an atom's position, a branch offset recomputed from the blocks
+it connects. It may not contain bytes copied out of the retail object. A
+hardcoded instruction word, or a hardcoded table of exception-table bytes, is
+the answer written into the tool. Assertions are fine: comparing against a
+literal to fail loudly is the opposite of carrying it.
+
+**2. A published remainder.** Say in the docstring how large the gap is, in the
+units a reader can check — how many instructions, how many fields, out of how
+many. A step with no number attached cannot be seen to shrink.
+
+**3. Fail closed.** Hash the input and the output text. If the source improves
+or the compiler changes, the step must break rather than silently paper over
+something new. Every edit should also assert the byte it expects before writing.
+
+**4. A path out.** The file header of the unit says what was tried in source and
+what is still unexplained, so the next person starts where this one stopped.
+
+## Why the line is at instruction content
+
+Artifact matching is not the goal. It is the *evidence* that the reconstruction
+is right, and `build.sha1` is a test of the source. A step that injects retail
+instruction bytes makes the gate test source-plus-patch instead, and a patch
+that carries the answer can never fail in a way that teaches anything.
+
+The cost is concrete. `fn_8005EA04` in `game/fn_8005E8EC.cpp` differed from
+retail by six register fields, and patching those six fields would have closed
+it. The actual cause was that retail's source wrote two conditions as one
+short-circuit `&&`, which emits a `bne`/`b` pair where a single `if` folds to
+one `beq`. Writing it that way made the function byte-exact from source, and the
+rule generalises to every folded branch pair in the tree. Had the six fields
+been patched first, the unit would have read `Matching` and nobody would have
+gone looking.
+
+`NonMatching` with the finding written down is worth more than `Matching` with
+the answer hidden in a `.py`. The first is an open problem someone solves; the
+second looks finished and never gets opened again.
+
+## Before reaching for one
+
+Two things that have each closed a wall recently, both cheaper than a patch:
+
+- **A folded branch pair** (`bne .L_next; b .L_out` in retail, one `beq` here)
+  usually means a short-circuit `&&` or `||` in the source. No pragma or
+  compiler flag restores it — that has been swept exhaustively.
+- **A `__dl__FPv` cleanup in `extab`** means the source used a real
+  new-expression. The hand-written `alloc(); if (p) ctor(p, ...)` idiom emits
+  identical instructions and no exception table, so the unit links short while
+  every function reads 100%.
+
+## Reviewing one
+
+- Does it carry any retail byte it writes, rather than asserts?
+- Does the docstring state the remainder as a count?
+- Does it hash input and output?
+- Does the unit's file header say what was tried in source?
+- Does the build still produce `18 files OK`?


### PR DESCRIPTION
## What

`tools/fix_<unit>_object.py` steps have no written criteria, and there are 38 of them. This writes down the standard that `tools/fix_wide_format_core_object.py` already set, so it can be applied in review instead of re-argued per PR.

## The standard, as it already exists

The wide-formatter step states it in its own docstring:

> Nothing here carries retail instruction content. Every edit is either a register number, or a branch whose offset is computed from the positions of the blocks it connects.
>
> When the reconstruction improves, entries disappear from these tables; when they are all gone this file can be deleted along with its build step.
>
> Current remainder: 4 block-layout edits and 186 register-field substitutions across 134 of the function's 1069 instructions.
>
> The input and output hashes make this fail closed if either the source or the compiler changes.

Four properties fall out of that and the page asks a new step for all four: no retail content, a published remainder count, fail-closed input/output hashes, and a note in the unit's file header saying what was tried in source.

I checked the 38 steps on `main` against it. None of them writes a byte copied from the retail object — `fix_wide_format_core_object.py` uses a literal only in an assertion, which is the opposite of carrying one.

## Why the line sits at instruction content

Artifact matching is the evidence that a reconstruction is right, not the goal; `build.sha1` is a test of the source. A step that injects retail instruction bytes turns the gate into a test of source-plus-patch, and a patch that carries the answer cannot fail in a way that teaches anything.

The page gives the concrete case, because it happened this week. `fn_8005EA04` differed from retail by six register fields. Patching those six fields would have closed it. The actual cause was that retail wrote two conditions as one short-circuit `&&` — which emits the `bne`/`b` pair where a single `if` folds to one `beq` — and writing it that way made the function byte-exact from source (#350). That rule generalises to every folded branch pair in the tree. Patched first, the unit would have read `Matching` and the cause would never have been looked for.

## Also on the page

Two findings that each closed a wall recently and are cheaper than a patch, so they belong in front of anyone reaching for one:

- a folded branch pair usually means a short-circuit `&&`/`||`, and no pragma or compiler flag restores it — that has been swept exhaustively;
- a `__dl__FPv` cleanup in `extab` means the source used a real new-expression, and the hand-written `alloc(); if (p) ctor(p, ...)` idiom emits identical instructions with no exception table, so the unit links short while every function reads 100%.

## Verification

Documentation only — no build inputs touched. `ninja` still gives **18 files OK** on this branch.
