### PR TITLE
decomp: reconstruct point segment distance

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -305,6 +305,11 @@ game/fn_800D7920.cpp:
 	extabindex  start:0x8000F370 end:0x8000F37C
 	.text       start:0x800D7920 end:0x800D7A54
 
+game/fn_800D7BD8.cpp:
+	extab       start:0x80008C70 end:0x80008C78
+	extabindex  start:0x8000F388 end:0x8000F394
+	.text       start:0x800D7BD8 end:0x800D7E5C
+
 game/texture.cpp:
 	extab       start:0x80008CA0 end:0x80008CA8
 	extabindex  start:0x8000F3D0 end:0x8000F3DC

--- a/configure.py
+++ b/configure.py
@@ -639,6 +639,7 @@ config.libs = [
             Object(NonMatching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D75CC.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7920.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
+            Object(NonMatching, "game/fn_800D7BD8.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(
                 Matching,
                 "game/fn_80053FB8.cpp",

--- a/src/game/fn_800D7BD8.cpp
+++ b/src/game/fn_800D7BD8.cpp
@@ -1,0 +1,58 @@
+#include "types.h"
+
+struct Fn800D7BD8Vec {
+    f32 x;
+    f32 y;
+    f32 z;
+};
+
+struct Fn800D7BD8Segment {
+    Fn800D7BD8Vec origin;
+    Fn800D7BD8Vec direction;
+};
+
+extern "C" f32 sqrtf(f32);
+extern "C" f32 fn_800D7044(const Fn800D7BD8Vec*, const Fn800D7BD8Segment*, Fn800D7BD8Vec*);
+
+extern "C" f32 fn_800D7BD8(const Fn800D7BD8Vec* point, const Fn800D7BD8Vec* first,
+    const Fn800D7BD8Vec* second, Fn800D7BD8Vec* closest)
+{
+    f32 x = point->x - first->x;
+    f32 y = point->y - first->y;
+    f32 z = point->z - first->z;
+    f32 directionX = second->x - first->x;
+    f32 directionY = second->y - first->y;
+    f32 directionZ = second->z - first->z;
+
+    if (x * directionX + y * directionY + z * directionZ < 0.0f) {
+        if (closest != 0) {
+            *closest = *first;
+        }
+        f32 distanceSquared = x * x + y * y + z * z;
+        if (distanceSquared <= 0.025f) {
+            return 0.0f;
+        }
+        return sqrtf(distanceSquared);
+    }
+
+    x = second->x - point->x;
+    y = second->y - point->y;
+    z = second->z - point->z;
+    if (directionX * x + directionY * y + directionZ * z < 0.0f) {
+        if (closest != 0) {
+            *closest = *second;
+        }
+        f32 distanceSquared = x * x + y * y + z * z;
+        if (distanceSquared <= 0.025f) {
+            return 0.0f;
+        }
+        return sqrtf(distanceSquared);
+    }
+
+    Fn800D7BD8Segment segment;
+    segment.origin = *first;
+    segment.direction.x = directionX;
+    segment.direction.y = directionY;
+    segment.direction.z = directionZ;
+    return fn_800D7044(point, &segment, closest);
+}


### PR DESCRIPTION
Reconstruct the point-to-segment distance helper as a bounded NonMatching unit.