### PR TITLE
decomp: reconstruct trigonometric table

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -305,6 +305,12 @@ game/fn_800D7920.cpp:
 	extabindex  start:0x8000F370 end:0x8000F37C
 	.text       start:0x800D7920 end:0x800D7A54
 
+game/fn_800D7B18.cpp:
+	extab       start:0x80008C68 end:0x80008C70
+	extabindex  start:0x8000F37C end:0x8000F388
+	.text       start:0x800D7B18 end:0x800D7BD8
+	.bss        start:0x803A7028 end:0x803E7028
+
 game/fn_800D7BD8.cpp:
 	extab       start:0x80008C70 end:0x80008C78
 	extabindex  start:0x8000F388 end:0x8000F394

--- a/configure.py
+++ b/configure.py
@@ -639,6 +639,7 @@ config.libs = [
             Object(NonMatching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D75CC.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7920.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
+            Object(NonMatching, "game/fn_800D7B18.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7BD8.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(
                 Matching,

--- a/src/game/fn_800D7B18.cpp
+++ b/src/game/fn_800D7B18.cpp
@@ -1,0 +1,15 @@
+#include "types.h"
+
+extern "C" {
+f32 lbl_803A7028[0x10000];
+double sin(double);
+}
+
+extern "C" void fn_800D7B18()
+{
+    s32 angle = 0;
+    for (s32 index = 0; index < 0x10000; index++) {
+        lbl_803A7028[index] = (f32)sin(3.141592f * angle / 65536.0f);
+        angle += 2;
+    }
+}


### PR DESCRIPTION
Reconstruct the trigonometric lookup-table initializer and its backing storage as a bounded NonMatching unit.