### PR TITLE
decomp: reconstruct angle helpers

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -305,6 +305,9 @@ game/fn_800D7920.cpp:
 	extabindex  start:0x8000F370 end:0x8000F37C
 	.text       start:0x800D7920 end:0x800D7A54
 
+game/fn_800D7A54.cpp:
+	.text       start:0x800D7A54 end:0x800D7B18
+
 game/fn_800D7B18.cpp:
 	extab       start:0x80008C68 end:0x80008C70
 	extabindex  start:0x8000F37C end:0x8000F388

--- a/configure.py
+++ b/configure.py
@@ -639,6 +639,7 @@ config.libs = [
             Object(NonMatching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D75CC.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7920.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
+            Object(NonMatching, "game/fn_800D7A54.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7B18.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7BD8.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(

--- a/src/game/fn_800D7A54.cpp
+++ b/src/game/fn_800D7A54.cpp
@@ -1,0 +1,47 @@
+#include "types.h"
+
+extern "C" {
+extern f32 lbl_803A7028[0x10000];
+}
+
+extern "C" u16 fn_800D7A54(u32 first, u32 second)
+{
+    u16 firstAngle = (u16)first;
+    u16 secondAngle = (u16)second;
+    s16 difference = (s16)(secondAngle - firstAngle);
+    if (difference < 0) {
+        difference = (s16)-difference;
+    }
+    return (u16)difference;
+}
+
+extern "C" s16 fn_800D7A80(u32 first, u32 second)
+{
+    u16 firstAngle = (u16)first;
+    u16 secondAngle = (u16)second;
+    return (s16)(secondAngle - firstAngle);
+}
+
+extern "C" u16 fn_800D7A94(u32 first, u32 second, s32 limit)
+{
+    u16 firstAngle = (u16)first;
+    u16 secondAngle = (u16)second;
+    s16 difference = (s16)(secondAngle - firstAngle);
+    if (difference > limit || difference < -limit) {
+        if (difference < 0) {
+            return (u16)(firstAngle - limit);
+        }
+        return (u16)(firstAngle + limit);
+    }
+    return secondAngle;
+}
+
+extern "C" f32 fn_800D7AE4(u16 angle)
+{
+    return lbl_803A7028[(u16)(angle + 0x4000)];
+}
+
+extern "C" f32 fn_800D7B00(u16 angle)
+{
+    return lbl_803A7028[angle];
+}


### PR DESCRIPTION
Reconstruct angle-difference, limiting, and trigonometric lookup helpers as a bounded NonMatching unit.