### PR TITLE
tools: fail loudly when a symbol rename stops applying

### DIFF
--- a/tools/fix_movie_play_sub_symbols.py
+++ b/tools/fix_movie_play_sub_symbols.py
@@ -158,6 +158,28 @@ def main() -> None:
         exception_tables[2]: "@etb_8000B9A4",
     }
 
+    # objcopy --redefine-sym is silent when the source symbol is absent, so a
+    # rename that quietly stops applying would only surface as an artifact hash
+    # mismatch much later. Check the table before handing it over.
+    #
+    # This step edits the object in place and is not idempotent, so ninja
+    # re-running it after the script's own mtime changes sees an object whose
+    # sources are all gone and whose targets are all present. That state is
+    # already-applied, not broken, and must not fail the build.
+    present = {
+        fields[-1]
+        for fields in (line.split() for line in symbols.splitlines())
+        if fields
+    }
+    missing = sorted(name for name in renames if name not in present)
+    if missing:
+        if all(target in present for target in renames.values()):
+            args.stamp.touch()
+            return
+        raise RuntimeError(
+            "moviePlaySub rename sources absent from the object: " + ", ".join(missing)
+        )
+
     temporary = args.object.parent / (args.object.name + ".symbols.tmp")
     command = [str(args.objcopy)]
     for source, target in renames.items():

--- a/tools/fix_tend_sp_stage_object.py
+++ b/tools/fix_tend_sp_stage_object.py
@@ -76,6 +76,22 @@ def retarget_symbols(
             struct.pack_into(">H", data, offset + 14, new_section)
 
 
+def symbol_names(data: bytes, headers: list[list[int]], names: list[str]) -> set[str]:
+    symbol_header = headers[names.index(".symtab")]
+    string_header = headers[symbol_header[6]]
+    strings = data[string_header[4] : string_header[4] + string_header[5]]
+    found = set()
+    for offset in range(
+        symbol_header[4],
+        symbol_header[4] + symbol_header[5],
+        symbol_header[9],
+    ):
+        name_offset = struct.unpack_from(">I", data, offset)[0]
+        end = strings.find(b"\0", name_offset)
+        found.add(strings[name_offset:end].decode("ascii"))
+    return found
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("object", type=Path)
@@ -119,6 +135,25 @@ def main() -> None:
             struct.pack_into(">I", normalized, header_offset + 20, 0)
         elif header[4] >= strings_end and header[1] != 8:
             struct.pack_into(">I", normalized, header_offset + 16, header[4] - removed_padding)
+
+    # objcopy --redefine-sym is silent when the source symbol is absent, so a
+    # rename that quietly stops applying would only surface as an artifact hash
+    # mismatch much later. Check the table before handing it over.
+    #
+    # This step edits the object in place and is not idempotent, so ninja
+    # re-running it after the script's own mtime changes sees an object whose
+    # sources are all gone and whose targets are all present. That state is
+    # already-applied, not broken, and must not fail the build.
+    present = symbol_names(object_data, headers, names)
+    missing = sorted(old for old, _ in LINK_RENAMES if old not in present)
+    if missing:
+        if all(new in present for _, new in LINK_RENAMES):
+            args.stamp.parent.mkdir(parents=True, exist_ok=True)
+            args.stamp.touch()
+            return
+        raise SystemExit(
+            "TEndSPStage rename sources absent from the object: " + ", ".join(missing)
+        )
 
     with tempfile.TemporaryDirectory() as directory:
         normalized_path = Path(directory) / "normalized.o"


### PR DESCRIPTION
## What

`objcopy --redefine-sym` is silent when the source symbol is absent — it renames nothing and exits 0. Two post-processor steps hand it a hardcoded rename table and never check that the sources are still there:

- `tools/fix_movie_play_sub_symbols.py` — 13 fixed names (3 more are derived and already guarded)
- `tools/fix_tend_sp_stage_object.py` — 9 fixed names, no guards at all

If a rename stops applying because the source changed, the step succeeds, the object silently keeps the wrong symbol, and the first sign is an artifact hash mismatch several steps later with nothing pointing at the cause. This makes both fail at the step that actually broke, naming the symbols.

These were the only two of the 38 steps writing with no validation; the audit behind #354 and #358 is what surfaced them.

## The idempotency trap

The obvious guard is wrong, and I shipped it wrong first.

These steps edit the object **in place** and are not idempotent. When ninja re-runs one — which it does whenever the script's own mtime changes, since the script is an input — it sees an object whose source names are all gone and whose target names are all present. A plain "sources must exist" check turns that harmless re-run into a build failure. I hit exactly that: touching the scripts broke the build.

So the check is three-state:

- all sources present → proceed;
- sources absent **and** every target present → already applied, touch the stamp and return;
- anything else → fail, naming the missing symbols.

## Verification

All three states exercised against the real build, not reasoned about:

| state | result |
| --- | --- |
| clean build | `18 files OK` |
| `touch` both scripts, rebuild (already-applied path) | `18 files OK` |
| recompiled object + one rename source renamed to a bogus name | fails at its own stamp: `TEndSPStage rename sources absent from the object: TDisp__7TObjectFvXX` |
| same, for the other script in isolation | `RuntimeError: moviePlaySub rename sources absent from the object: movieSubBufferDataXX` |

The failure path was checked separately for each script, because ninja stops at the first failing edge and the second one would otherwise never have run.

Final `ninja` after rebasing onto current `main`: **18 files OK**.

## Not done here

The other 36 steps validate before writing, but only `fix_wide_format_core_object.py` carries the input/output hashes and the remainder count that `docs/object-post-processors.md` asks of a new step. Retrofitting 36 files is churn for little gain while the artifact hash gate already backstops drift, so this stops at the two that had nothing.
