### PR TITLE
tools: enforce the object post-processor criteria in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,8 @@ jobs:
         ninja build/${{ matrix.version }}/config.json
         python -m unittest tools.test_check_language_policy
         python tools/check_language_policy.py
+        python -m unittest tools.test_check_post_processors
+        python tools/check_post_processors.py
         ninja all_source progress build/${{ matrix.version }}/report.json
 
     - name: Upload map

--- a/docs/object-post-processors.md
+++ b/docs/object-post-processors.md
@@ -44,9 +44,16 @@ branch offsets recomputed from where the blocks landed. Nothing is copied in
 from retail; the bytes all came from MWCC.
 
 The fourth shape — writing bytes taken from the retail object — is the one that
-is out, and today nothing in `tools/` does it. `fix_wide_format_core_object.py`
-uses a retail literal in exactly one place, an assertion, which is the opposite
-of carrying one.
+is out. One step still does it: `fix_game_action_object.py` replaces the whole
+`extab` section with `TARGET_EXTAB`, a hex table of retail's exception records.
+It predates these criteria, and `action.cpp` is a 77 KB source compiled into
+five split objects, so producing that table from source is its own piece of
+work. `tools/check_post_processors.py` records it as named debt so the rule can
+be enforced everywhere else and this one stays visible rather than passing
+quietly. Nothing may be added to that list.
+
+Elsewhere the line holds. `fix_wide_format_core_object.py` uses a retail literal
+in exactly one place, an assertion, which is the opposite of carrying one.
 
 **Telling slicing from injection.** Slicing only removes; the bytes that remain
 are still at the offsets MWCC put them, or shifted whole. Injection introduces a
@@ -124,6 +131,20 @@ Two things that have each closed a wall recently, both cheaper than a patch:
   new-expression. The hand-written `alloc(); if (p) ctor(p, ...)` idiom emits
   identical instructions and no exception table, so the unit links short while
   every function reads 100%.
+
+## Enforcement
+
+`tools/check_post_processors.py` decides the two properties that can be decided
+mechanically, and CI runs it alongside the language policy:
+
+- **no retail content** — a module-level `bytes.fromhex()` constant must never
+  reach a write, whether through `pack_into`, `insert`, or a slice assignment.
+  Comparing against one is a guard and stays allowed.
+- **fails closed** — a step that writes must validate something first, so a
+  stale table stops the build instead of quietly not applying.
+
+The remainder count and the input/output hashes are not machine-checkable and
+stay a review matter.
 
 ## Reviewing one
 

--- a/tools/check_post_processors.py
+++ b/tools/check_post_processors.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+"""Enforce the object post-processor criteria in docs/object-post-processors.md.
+
+A post-processor may permute what our own compiler produced. It may not carry
+bytes taken from the retail object: a hex literal that is *compared* is a guard,
+the same literal *written* is the answer copied into the tool, and the artifact
+hash gate can no longer tell the reconstruction from the patch.
+
+This checks the two properties that can be decided mechanically:
+
+  no retail content  a module-level bytes.fromhex() constant must never reach a
+                     write -- pack_into, insert, or a slice assignment
+  fails closed       a step that writes must validate something first, so a
+                     stale table stops the build instead of quietly not applying
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+TOOLS = Path(__file__).resolve().parent
+WRITE_CALLS = {"pack_into", "insert", "write_bytes", "pack_into_"}
+
+# Known debt, recorded rather than hidden. fix_game_action_object.py overwrites
+# the whole extab section with TARGET_EXTAB, a hex table of retail's exception
+# records. It predates these criteria and covers action.cpp, a 77 KB source
+# compiled into five split objects, so producing that table from source is its
+# own piece of work. Listed here so the rule can be enforced for everything else
+# and this one stays visible instead of passing silently.
+#
+# Nothing may be added to this list. A new step gets the bytes from source.
+CARRIED_RETAIL_DEBT = {
+    "fix_game_action_object.py": {"TARGET_EXTAB"},
+}
+
+
+def hex_constants(tree: ast.Module) -> set[str]:
+    """Module-level names bound to a bytes.fromhex(...) literal."""
+    found = set()
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "fromhex"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "bytes"
+        ):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    found.add(target.id)
+    return found
+
+
+def names_in(node: ast.AST) -> set[str]:
+    return {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+
+
+def written_names(tree: ast.Module) -> set[str]:
+    """Names that flow into a write."""
+    written = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name in WRITE_CALLS:
+                for argument in node.args:
+                    written |= names_in(argument)
+        elif isinstance(node, ast.Assign):
+            # blob[a:b] = CONST
+            for target in node.targets:
+                if isinstance(target, ast.Subscript):
+                    written |= names_in(node.value)
+    return written
+
+
+def validates(tree: ast.Module) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Raise):
+            return True
+        if isinstance(node, ast.Assert):
+            return True
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name in {"check_output", "index"}:
+                continue
+    return False
+
+
+def writes_anything(tree: ast.Module) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name in WRITE_CALLS:
+                return True
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Subscript):
+                    return True
+    return False
+
+
+def check(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text())
+    problems = []
+    carried = hex_constants(tree) & written_names(tree)
+    carried -= CARRIED_RETAIL_DEBT.get(path.name, set())
+    for name in sorted(carried):
+        problems.append(
+            f"{path.name}: {name} is a hex literal that gets written. "
+            "A post-processor may compare retail bytes, never carry them. "
+            "See docs/object-post-processors.md."
+        )
+    if writes_anything(tree) and not validates(tree):
+        problems.append(
+            f"{path.name}: edits the object but never validates what it found. "
+            "A stale table has to stop the build, not quietly not apply."
+        )
+    return problems
+
+
+def main() -> int:
+    scripts = sorted(TOOLS.glob("fix_*.py"))
+    if not scripts:
+        print("no object post-processors found", file=sys.stderr)
+        return 1
+    problems = [problem for script in scripts for problem in check(script)]
+    if problems:
+        print("object post-processor violations:")
+        for problem in problems:
+            print(f"  - {problem}")
+        return 1
+    print(f"object post-processors OK: {len(scripts)} steps checked")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_check_post_processors.py
+++ b/tools/test_check_post_processors.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import ast
+import tempfile
+import unittest
+from pathlib import Path
+
+import tools.check_post_processors as checker
+
+
+def parse(source: str) -> ast.Module:
+    return ast.parse(source)
+
+
+class HexLiteralTests(unittest.TestCase):
+    def test_a_compared_hex_literal_is_allowed(self) -> None:
+        tree = parse(
+            "import struct\n"
+            "GUARD = bytes.fromhex('deadbeef')\n"
+            "def main(data, section):\n"
+            "    if data[0:4] != GUARD:\n"
+            "        raise SystemExit('changed')\n"
+            "    struct.pack_into('>I', data, 0, 1)\n"
+        )
+        self.assertEqual(checker.hex_constants(tree) & checker.written_names(tree), set())
+
+    def test_a_written_hex_literal_is_rejected(self) -> None:
+        tree = parse(
+            "RETAIL = bytes.fromhex('deadbeef')\n"
+            "def main(data):\n"
+            "    raise_if = 1\n"
+            "    data[0:4] = RETAIL\n"
+        )
+        self.assertEqual(checker.hex_constants(tree) & checker.written_names(tree), {"RETAIL"})
+
+    def test_a_hex_literal_passed_to_insert_is_rejected(self) -> None:
+        tree = parse(
+            "TAIL = bytes.fromhex('00ff')\n"
+            "def main(section):\n"
+            "    insert(section, TAIL)\n"
+        )
+        self.assertEqual(checker.hex_constants(tree) & checker.written_names(tree), {"TAIL"})
+
+
+class ValidationTests(unittest.TestCase):
+    def test_a_step_that_writes_without_validating_is_rejected(self) -> None:
+        tree = parse(
+            "import struct\n"
+            "def main(data):\n"
+            "    struct.pack_into('>I', data, 0, 1)\n"
+        )
+        self.assertTrue(checker.writes_anything(tree))
+        self.assertFalse(checker.validates(tree))
+
+    def test_a_step_that_raises_counts_as_validating(self) -> None:
+        tree = parse(
+            "import struct\n"
+            "def main(data):\n"
+            "    if len(data) != 4:\n"
+            "        raise SystemExit('bad')\n"
+            "    struct.pack_into('>I', data, 0, 1)\n"
+        )
+        self.assertTrue(checker.validates(tree))
+
+    def test_a_step_that_writes_nothing_needs_no_validation(self) -> None:
+        tree = parse("def main(path):\n    print(path)\n")
+        self.assertFalse(checker.writes_anything(tree))
+
+
+class RepositoryTests(unittest.TestCase):
+    def test_every_shipped_step_passes(self) -> None:
+        scripts = sorted(checker.TOOLS.glob("fix_*.py"))
+        self.assertGreater(len(scripts), 0)
+        problems = [problem for script in scripts for problem in checker.check(script)]
+        self.assertEqual(problems, [], "\n".join(problems))
+
+    def test_the_debt_list_is_not_grown(self) -> None:
+        # A new step gets its bytes from source. This list only ever shrinks.
+        self.assertEqual(
+            checker.CARRIED_RETAIL_DEBT,
+            {"fix_game_action_object.py": {"TARGET_EXTAB"}},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

#354 and #358 wrote down the object post-processor criteria; nothing enforced them. This makes the two mechanical properties checkable and runs them in CI next to the language policy.

- `tools/check_post_processors.py` — the check
- `tools/test_check_post_processors.py` — 8 tests over it
- `.github/workflows/build.yml` — both wired in

## It found a real violation, and it is one I had claimed did not exist

I wrote in #354 that none of the 38 steps writes a byte copied from the retail object. That was wrong, and the checker caught it. `tools/fix_game_action_object.py` replaces the whole `extab` section:

```python
if len(TARGET_EXTAB) != extab[5]:
    raise SystemExit("retail action.cpp extab size changed")
data[extab[4] : extab[4] + extab[5]] = TARGET_EXTAB
```

`TARGET_EXTAB` is a hex table of retail's exception records. My earlier pass only looked for `pack_into(..., retail)` and `insert(section, CONST)` and never considered slice assignment, which is exactly why the rule needed to be machine-checked instead of eyeballed.

It is recorded as named debt in `CARRIED_RETAIL_DEBT` rather than waved through or hidden. `action.cpp` is a 77 KB source compiled into five split objects, so producing that table from source is its own piece of work. A test asserts the list is never grown. The page now says all of this instead of the sentence that was wrong.

## What is enforced

- **No retail content** — a module-level `bytes.fromhex()` constant must never reach a write, through `pack_into`, `insert`, or a slice assignment. Comparing against one stays allowed; that is a guard, and it is what `fix_wide_format_core_object.py` does with its single retail literal.
- **Fails closed** — a step that writes must validate something first, so a stale table stops the build instead of quietly not applying.

The remainder count and the input/output hashes are not machine-checkable and stay a review matter. The page says so.

## Verification

Behaviour, not inference:

| | result |
| --- | --- |
| all 38 shipped steps | `object post-processors OK: 38 steps checked` |
| a step given a written `bytes.fromhex` constant | rejected by name, exit 1, and the suite goes red |
| `python -m unittest tools.test_check_post_processors` | 8 tests OK |
| `python tools/check_language_policy.py` | OK |
| `ninja` | **18 files OK** |

Re-verified after rebasing onto current `main`.
