### PR TITLE
decomp: reconstruct scaled angle components

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -319,6 +319,9 @@ game/fn_800D7BD8.cpp:
 	extabindex  start:0x8000F388 end:0x8000F394
 	.text       start:0x800D7BD8 end:0x800D7E5C
 
+game/fn_800D7E5C.cpp:
+	.text       start:0x800D7E5C end:0x800D7E94
+
 game/texture.cpp:
 	extab       start:0x80008CA0 end:0x80008CA8
 	extabindex  start:0x8000F3D0 end:0x8000F3DC

--- a/configure.py
+++ b/configure.py
@@ -642,6 +642,7 @@ config.libs = [
             Object(NonMatching, "game/fn_800D7A54.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7B18.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7BD8.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
+            Object(NonMatching, "game/fn_800D7E5C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(
                 Matching,
                 "game/fn_80053FB8.cpp",

--- a/src/game/fn_800D7E5C.cpp
+++ b/src/game/fn_800D7E5C.cpp
@@ -1,0 +1,11 @@
+#include "types.h"
+
+extern "C" {
+extern f32 lbl_803A7028[0x10000];
+}
+
+extern "C" void fn_800D7E5C(u32 angle, f32 scale, f32* sine, f32* cosine)
+{
+    *sine = scale * lbl_803A7028[(u16)angle];
+    *cosine = scale * lbl_803A7028[(u16)(angle + 0x4000)];
+}


### PR DESCRIPTION
Reconstruct the scaled sine and cosine lookup helper with complete byte matching.