### PR TITLE
decomp: mark scaled trig helper translation unit matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -642,7 +642,7 @@ config.libs = [
             Object(NonMatching, "game/fn_800D7A54.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7B18.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7BD8.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
-            Object(NonMatching, "game/fn_800D7E5C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
+            Object(Matching, "game/fn_800D7E5C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(
                 Matching,
                 "game/fn_80053FB8.cpp",


### PR DESCRIPTION
## What

Mark the complete `game/fn_800D7E5C.cpp` translation unit as Matching. Its sole function computes scaled sine and cosine components from the shared angle lookup table.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and included only the minimum symbolic fact and independent GameCube correlation.
- [x] If I changed inline flags, I documented the source/emission order and compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or links to those materials.

Evidence and references:

- This PR does not alter the existing source-language or linkage decision; it only promotes the already reconstructed C++ TU from `NonMatching` to `Matching`.
- GameCube split metadata identifies one `.text` range, `0x800D7E5C` through `0x800D7E94`, containing the single 56-byte `fn_800D7E5C` function.
- No PS2 or PC metadata, library reference, inline-flag change, or guessed name/type is introduced.

## Verification

- [x] `python tools/check_language_policy.py`
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `clang-format -i` on changed files under `src/` and `include/` (not applicable; no source/header file changed)
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:

- Before: configuration status `NonMatching`; `.text` 56/56 bytes, 100.0% match.
- After: configuration status `Matching`; `.text` 56/56 bytes, 100.0% match.
- Relocation section size is exact at 24 bytes.
- `python tools/check_post_processors.py`: 38 steps checked, OK.
- `ninja build/G9SE8P/ok`: 18 files OK.