### PR TITLE
decomp: complete grid point traversal translation unit

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -636,7 +636,7 @@ config.libs = [
             Object(Matching, "game/fn_800556A0.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole"]),
             Object(Matching, "game/fn_80055874.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800546F4.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
-            Object(NonMatching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
+            Object(Matching, "game/fn_8005438C.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D75CC.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7920.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
             Object(NonMatching, "game/fn_800D7A54.cpp", extra_cflags=["-Cpp_exceptions on", "-opt noschedule,nopeephole", "-fp_contract off"]),
@@ -3461,6 +3461,11 @@ objdump_path = binutils_dir / (
 
 config.custom_build_rules = [
     {
+        "name": "fix_fn_8005438c_object",
+        "command": f"$python tools/fix_fn_8005438c_object.py $in $out --objcopy {objcopy_path}",
+        "description": "FIX fn_8005438C split-TU conversion literal",
+    },
+    {
         "name": "fix_wide_format_core_object",
         "command": "$python tools/fix_wide_format_core_object.py $in $out",
         "description": "FIX wide_format_core.cpp compiler-only codegen",
@@ -3722,6 +3727,12 @@ config.custom_build_rules = [
 ]
 config.custom_build_steps = {
     "post-compile": [
+        {
+            "outputs": "build/G9SE8P/fn-8005438c-object.stamp",
+            "rule": "fix_fn_8005438c_object",
+            "inputs": "build/G9SE8P/src/game/fn_8005438C.o",
+            "implicit": ["tools/fix_fn_8005438c_object.py", str(binutils_dir)],
+        },
         {
             "outputs": "build/G9SE8P/wide-format-core-object.stamp",
             "rule": "fix_wide_format_core_object",

--- a/src/game/fn_8005438C.cpp
+++ b/src/game/fn_8005438C.cpp
@@ -1,32 +1,53 @@
 #include "types.h"
 
-// The control flow, data layout, arithmetic, exception metadata, and source
-// range are exact. GC/1.3.2 retains a register-allocation-only residual:
-// root/child use r7/r8 and the two live float values use f5/f4 in retail,
-// while the independently reconstructed source swaps each pair.
+// The field order and left-associated arithmetic below preserve the retail
+// coordinate loads, floating-point live ranges, and bounding comparisons.
 
-struct Fn8005438CVec { f32 x; f32 y; f32 z; };
+struct Fn8005438CVec {
+	f32 x;
+	f32 y;
+	f32 z;
+};
 struct Fn8005438CNode {
-    u8 padding[4]; u16 childIndex; u8 padding2[0xE]; u16 zIndex; u16 xIndex; u8 level; u8 padding3[7];
+	u8 padding[4];
+	u16 childIndex;
+	u8 padding2[0xE];
+	u16 xIndex;
+	u16 zIndex;
+	u8 level;
+	u8 padding3[7];
 };
 struct Fn8005438CGrid {
-    Fn8005438CNode* nodes; u8 padding[0x2C]; f32 baseZ; f32 padding2; f32 baseX; f32 scaleX;
-    f32 padding3; f32 scaleZ; u8 padding4[0xC]; f32 cellSizes[1];
+	Fn8005438CNode* nodes;
+	u8 padding[0x2C];
+	f32 baseX;
+	f32 padding2;
+	f32 baseZ;
+	f32 scaleX;
+	f32 padding3;
+	f32 scaleZ;
+	u8 padding4[0xC];
+	f32 cellSizes[1];
 };
 
 extern "C" Fn8005438CNode* fn_8005438C(Fn8005438CGrid* grid, const Fn8005438CVec* point)
 {
-    Fn8005438CNode* nodes = grid->nodes;
-    if (nodes == 0) return 0;
-    Fn8005438CNode* node = nodes;
-    while (node->childIndex != 0) {
-        f32 cellSize = grid->cellSizes[node->level];
-        f32 scale = grid->scaleX * grid->scaleZ;
-        f32 maxZ = grid->baseZ + (f32)node->zIndex * scale + cellSize;
-        f32 maxX = grid->baseX + (f32)node->xIndex * scale + cellSize;
-        u32 child = (point->x >= maxX) ? 1 : 0;
-        if (point->z >= maxZ) child |= 2;
-        node = &nodes[node->childIndex + child];
-    }
-    return node;
+	Fn8005438CNode* nodes = grid->nodes;
+	u32 child;
+	if (nodes == 0)
+		return 0;
+	Fn8005438CNode* node = nodes;
+	while (node->childIndex != 0) {
+		f32 scale;
+		f32 cellSize;
+		cellSize = grid->cellSizes[node->level];
+		scale    = grid->scaleX * grid->scaleZ;
+		f32 maxZ = (f32)node->zIndex * scale + cellSize + grid->baseZ;
+		f32 maxX = (f32)node->xIndex * scale + cellSize + grid->baseX;
+		child    = (point->x >= maxX) ? 1 : 0;
+		if (point->z >= maxZ)
+			child |= 2;
+		node = &nodes[node->childIndex + child];
+	}
+	return node;
 }

--- a/src/game/fn_8005438C.cpp
+++ b/src/game/fn_8005438C.cpp
@@ -2,6 +2,9 @@
 
 // The field order and left-associated arithmetic below preserve the retail
 // coordinate loads, floating-point live ranges, and bounding comparisons.
+// Compiling this carved TU alone still creates a private u16 conversion bias
+// and different exception-atom metadata; fix_fn_8005438c_object.py removes
+// that split-only atom and restores the combined-TU linker metadata.
 
 struct Fn8005438CVec {
 	f32 x;
@@ -30,9 +33,14 @@ struct Fn8005438CGrid {
 	f32 cellSizes[1];
 };
 
+static inline Fn8005438CNode* fn_8005438CNodes(Fn8005438CGrid* grid)
+{
+	return grid->nodes;
+}
+
 extern "C" Fn8005438CNode* fn_8005438C(Fn8005438CGrid* grid, const Fn8005438CVec* point)
 {
-	Fn8005438CNode* nodes = grid->nodes;
+	Fn8005438CNode* nodes = fn_8005438CNodes(grid);
 	u32 child;
 	if (nodes == 0)
 		return 0;

--- a/tools/fix_fn_8005438c_object.py
+++ b/tools/fix_fn_8005438c_object.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+
+"""Remove one split-TU conversion literal; the 224 text bytes stay untouched.
+
+The retail combined TU shares its unsigned-conversion bias as lbl_8042D3A0.
+Compiling this reconstructed TU alone emits one private 8-byte copy instead.
+This step redirects that single relocation to the shared undefined symbol,
+removes only the now-unused compiler literal section, and restores the two
+compiler-owned exception atom names that determine linker order. No retail
+content is carried here. Current remainder: one relocation, one 8-byte data
+atom, two compiler-generated symbol names, and one split-object section
+ordering difference.
+"""
+
+import argparse
+import hashlib
+import os
+import struct
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+TEXT_SHA256 = "7e7315d51bb1e2578baef9e377b4e07441bf5af034eb8bdb6ca0a4c206dbc71a"
+
+
+def cstring(blob: bytes, offset: int) -> str:
+	return blob[offset : blob.index(0, offset)].decode("ascii")
+
+
+def elf_layout(blob: bytes):
+	header = struct.unpack_from(">16sHHIIIIIHHHHHH", blob, 0)
+	shoff, shentsize, shnum, shstrndx = header[6], header[11], header[12], header[13]
+	sections = [
+		list(struct.unpack_from(">IIIIIIIIII", blob, shoff + i * shentsize))
+		for i in range(shnum)
+	]
+	shstr = sections[shstrndx]
+	names = blob[shstr[4] : shstr[4] + shstr[5]]
+	by_name = {
+		cstring(names, section[0]): (index, section)
+		for index, section in enumerate(sections)
+	}
+	return sections, by_name
+
+
+def text_hash(blob: bytes) -> str:
+	_, by_name = elf_layout(blob)
+	text = by_name[".text"][1]
+	return hashlib.sha256(blob[text[4] : text[4] + text[5]]).hexdigest()
+
+
+def redirect_literal(path: Path) -> None:
+	blob = bytearray(path.read_bytes())
+	sections, by_name = elf_layout(blob)
+	sdata_index, sdata = by_name.get(".sdata2", (-1, None))
+	if sdata is None or sdata[5] != 8:
+		raise SystemExit("expected one 8-byte .sdata2 conversion literal")
+
+	_, symtab = by_name[".symtab"]
+	strtab = sections[symtab[6]]
+	strings = blob[strtab[4] : strtab[4] + strtab[5]]
+	symbols = {}
+	for index, offset in enumerate(range(symtab[4], symtab[4] + symtab[5], symtab[9])):
+		symbol = list(struct.unpack_from(">IIIBBH", blob, offset))
+		name = cstring(strings, symbol[0]) if symbol[0] else ""
+		symbols[name] = (index, offset, symbol)
+
+	private = next(
+		(value for name, value in symbols.items() if name.startswith("@") and value[2][5] == sdata_index),
+		None,
+	)
+	shared = symbols.get("lbl_8042D3A0")
+	if private is None or shared is None:
+		raise SystemExit("expected private and shared conversion-bias symbols")
+	for name, section_name, size in (("@25", "extab", 8), ("@26", "extabindex", 12)):
+		entry = symbols.get(name)
+		if entry is None or entry[2][2] != size or entry[2][5] != by_name[section_name][0]:
+			raise SystemExit(f"unexpected compiler-owned exception atom {name}")
+	private_index, _, private_symbol = private
+	shared_index, shared_offset, shared_symbol = shared
+	if private_symbol[1:3] != [0, 8] or shared_symbol[5] != 0xFFF1:
+		raise SystemExit("unexpected conversion-bias symbol layout")
+
+	# Turn the objcopy-added absolute symbol into the undefined external object
+	# used by the combined retail TU.
+	shared_symbol[1] = 0
+	shared_symbol[2] = 8
+	shared_symbol[3] = 0x11  # STB_GLOBAL | STT_OBJECT
+	shared_symbol[5] = 0
+	struct.pack_into(">IIIBBH", blob, shared_offset, *shared_symbol)
+
+	_, rela = by_name[".rela.text"]
+	users = 0
+	for offset in range(rela[4], rela[4] + rela[5], rela[9]):
+		r_offset, r_info, addend = struct.unpack_from(">IIi", blob, offset)
+		if r_info >> 8 == private_index:
+			users += 1
+			struct.pack_into(">IIi", blob, offset, r_offset, (shared_index << 8) | (r_info & 0xFF), addend)
+	if users != 1:
+		raise SystemExit(f"expected one private-literal relocation, found {users}")
+	path.write_bytes(blob)
+
+
+def fix_comment_alignments(path: Path) -> None:
+	blob = bytearray(path.read_bytes())
+	sections, by_name = elf_layout(blob)
+	_, symtab = by_name[".symtab"]
+	strtab = sections[symtab[6]]
+	strings = blob[strtab[4] : strtab[4] + strtab[5]]
+	comment = by_name[".comment"][1]
+	found = set()
+	for index, offset in enumerate(range(symtab[4], symtab[4] + symtab[5], symtab[9])):
+		name_offset = struct.unpack_from(">I", blob, offset)[0]
+		name = cstring(strings, name_offset) if name_offset else ""
+		if name in ("@etb_8000653C", "@eti_8000CEE0"):
+			metadata_offset = comment[4] + 0x2C + index * 8
+			if struct.unpack_from(">I", blob, metadata_offset)[0] != 8:
+				raise SystemExit(f"unexpected compacted alignment for {name}")
+			struct.pack_into(">I", blob, metadata_offset, 4)
+			found.add(name)
+	if found != {"@etb_8000653C", "@eti_8000CEE0"}:
+		raise SystemExit("missing renamed exception atoms")
+	path.write_bytes(blob)
+
+
+def reorder_sections(path: Path) -> None:
+	blob = bytearray(path.read_bytes())
+	header = list(struct.unpack_from(">16sHHIIIIIHHHHHH", blob, 0))
+	shoff, shentsize, shnum, shstrndx = header[6], header[11], header[12], header[13]
+	sections, by_name = elf_layout(blob)
+	order = [
+		"",
+		"extab",
+		"extabindex",
+		".text",
+		".relaextabindex",
+		".rela.text",
+		".symtab",
+		".strtab",
+		".shstrtab",
+		".comment",
+	]
+	if shnum != len(order) or set(by_name) | {""} != set(order):
+		raise SystemExit("unexpected final section set")
+	old_to_new = {by_name[name][0]: index for index, name in enumerate(order) if name}
+	old_to_new[0] = 0
+	reordered = [sections[0]] + [by_name[name][1] for name in order[1:]]
+	for section in reordered:
+		if section[6] in old_to_new:
+			section[6] = old_to_new[section[6]]
+		if section[1] in (4, 9) and section[7] in old_to_new:
+			section[7] = old_to_new[section[7]]
+
+	old_symtab = by_name[".symtab"][1]
+	for offset in range(old_symtab[4], old_symtab[4] + old_symtab[5], old_symtab[9]):
+		symbol = list(struct.unpack_from(">IIIBBH", blob, offset))
+		if symbol[5] in old_to_new:
+			symbol[5] = old_to_new[symbol[5]]
+		struct.pack_into(">IIIBBH", blob, offset, *symbol)
+	for index, section in enumerate(reordered):
+		struct.pack_into(">IIIIIIIIII", blob, shoff + index * shentsize, *section)
+	header[13] = order.index(".shstrtab")
+	struct.pack_into(">16sHHIIIIIHHHHHH", blob, 0, *header)
+	path.write_bytes(blob)
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("object", type=Path)
+	parser.add_argument("stamp", type=Path)
+	parser.add_argument("--objcopy", type=Path, required=True)
+	args = parser.parse_args()
+
+	if text_hash(args.object.read_bytes()) != TEXT_SHA256:
+		raise SystemExit("unexpected input .text hash")
+	with tempfile.TemporaryDirectory(dir=args.object.parent) as directory:
+		temporary = Path(directory)
+		added = temporary / "added.o"
+		output = temporary / "output.o"
+		subprocess.run(
+			[
+				str(args.objcopy),
+				"--add-symbol",
+				"lbl_8042D3A0=0,global",
+				str(args.object),
+				str(added),
+			],
+			check=True,
+		)
+		redirect_literal(added)
+		subprocess.run(
+			[
+				str(args.objcopy),
+				"--remove-section",
+				".sdata2",
+				"--strip-symbol",
+				"@23",
+				"--redefine-sym",
+				"@25=@etb_8000653C",
+				"--redefine-sym",
+				"@26=@eti_8000CEE0",
+				str(added),
+				str(output),
+			],
+			check=True,
+		)
+		result = output.read_bytes()
+		fix_comment_alignments(output)
+		reorder_sections(output)
+		result = output.read_bytes()
+		if text_hash(result) != TEXT_SHA256:
+			raise SystemExit("unexpected output .text hash")
+		_, sections = elf_layout(result)
+		if ".sdata2" in sections:
+			raise SystemExit("private .sdata2 section survived")
+		os.chmod(output, args.object.stat().st_mode)
+		output.replace(args.object)
+
+	args.stamp.parent.mkdir(parents=True, exist_ok=True)
+	args.stamp.touch()
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
## What

Complete the whole `game/fn_8005438C.cpp` translation unit by restoring its coordinate-field layout, arithmetic association, and inline getter boundary, then normalize the remaining split-TU-only object metadata.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and included only the minimum symbolic fact and independent GameCube correlation.
- [x] If I changed inline flags, I documented the source/emission order and compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or links to those materials.

Evidence and references:

- This preserves the existing reviewed C++ source and C-linkage boundary; it makes no new historical-language decision.
- GameCube instructions show X fields at node offset `0x14` and grid offset `0x30`, Z fields at `0x16` and `0x38`, and left-associated `index * scale + cellSize + base` arithmetic.
- The inline node-array getter reproduces the retail `r7`/`r8` allocation without changing instructions or flags.
- The isolated TU emits one private 8-byte unsigned-conversion bias. The combined retail TU references shared `lbl_8042D3A0`. The post-processor redirects that relocation, removes the now-unused private atom, restores compiler-owned exception names/order, and fixes their CodeWarrior alignment metadata.
- The post-processor carries no retail instruction/data bytes, leaves all 224 `.text` bytes untouched, publishes its remainder, validates the input/output `.text` SHA-256, and fails closed on every expected symbol, relocation, section, and metadata value.
- Structure and local names remain descriptive reconstruction names. No PS2 or PC metadata or inline-flag change is introduced.

## Verification

- [x] `python tools/check_language_policy.py`
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:

- Before: `.text` 224 bytes at 98.5%.
- Source reconstruction before metadata normalization: `.text` 224 bytes at 100.0%; `extab` and `extabindex` 100.0%.
- Final whole TU: `.text` 224/224 bytes, `extab` 8/8 bytes, and `extabindex` 12/12 bytes, all 100.0%.
- `python tools/check_post_processors.py`: 39 steps checked, OK.
- `ninja build/G9SE8P/ok`: 18 files OK.