### PR TITLE
feat: match fn_800D7920

### DIFF
--- a/src/game/fn_800D7920.cpp
+++ b/src/game/fn_800D7920.cpp
@@ -4,25 +4,36 @@
 // 16-bit turn representation. The optional orientation vector selects the
 // winding direction.
 
-struct Fn800D7920Vec { f32 x; f32 y; f32 z; };
+struct Fn800D7920Vec {
+	f32 x;
+	f32 y;
+	f32 z;
+};
 
 extern "C" double acos(double);
+extern "C" f32 lbl_8042E008;
+extern "C" f32 lbl_8042E00C;
+extern "C" f32 lbl_8042E030;
+extern "C" f32 lbl_8042E038;
 
-extern "C" s32 fn_800D7920(const Fn800D7920Vec* first, const Fn800D7920Vec* second,
-    const Fn800D7920Vec* orientation)
+extern "C" s32 fn_800D7920(
+    const Fn800D7920Vec* first, const Fn800D7920Vec* second, const Fn800D7920Vec* orientation)
 {
-    f32 dot = first->z * second->z + first->x * second->x + first->y * second->y;
-    if (dot <= -1.0f) return 0x8000;
-    if (dot >= 1.0f) return 0;
+	f32 dot = first->z * second->z + (first->x * second->x + first->y * second->y);
+	if (dot <= lbl_8042E038)
+		return 0x8000;
+	if (dot >= lbl_8042E00C)
+		return 0;
 
-    s32 angle = (s32)(10430.381f * (f32)acos(dot));
-    Fn800D7920Vec cross;
-    cross.x = first->y * second->z - first->z * second->y;
-    cross.y = first->z * second->x - first->x * second->z;
-    cross.z = first->x * second->y - first->y * second->x;
-    if (orientation != 0 &&
-        orientation->z * cross.z + orientation->x * cross.x + orientation->y * cross.y < 0.0f) {
-        return 0x10000 - angle;
-    }
-    return angle;
+	s32 angle = (s32)(lbl_8042E030 * (f32)acos(dot));
+	Fn800D7920Vec cross;
+	cross.x = first->y * second->z - first->z * second->y;
+	cross.y = first->z * second->x - first->x * second->z;
+	cross.z = first->x * second->y - first->y * second->x;
+	if (orientation != 0
+	    && lbl_8042E008
+	        > orientation->z * cross.z + (orientation->x * cross.x + orientation->y * cross.y)) {
+		return 0x10000 - angle;
+	}
+	return angle;
 }


### PR DESCRIPTION
## What

Describe the one logical unit changed by this pull request.

## Evidence

- [ ] I identified the source language and linkage from evidence, not from the
      current file extension or a byte match alone.
- [ ] If this is a C path, I distinguished positive C source evidence from a
      reviewed C ABI boundary whose historical file language is unresolved.
- [ ] I recorded whether names/types came from GameCube, PS2, PC or a known
      library reference, and marked guesses as guesses.
- [ ] If I used PS2 metadata, I kept the executable and tool output local and
      included only the minimum symbolic fact and independent GameCube
      correlation.
- [ ] If I changed inline flags, I documented the source/emission order and
      compared each candidate in objdiff.
- [ ] I did not add game binaries, assets, extracted assembly, leaked source or
      links to those materials.

Evidence and references:

<!-- Give symbol names, strings, vtable relationships, public references or
     compiler experiments. Do not attach proprietary artifacts. -->

## Verification

<!-- Full artifact CI for a fork runs only after a maintainer reviews the
     commits and tests them from a repository-owned integration branch. -->

- [ ] `python tools/check_language_policy.py`
- [ ] `python -m unittest tools.test_check_language_policy`
- [ ] `clang-format -i` on changed files under `src/` and `include/`
- [ ] objdiff result recorded below
- [ ] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:
