### PR TITLE
tools: catch retail instruction words carried as integer tables

### DIFF
--- a/docs/object-post-processors.md
+++ b/docs/object-post-processors.md
@@ -43,14 +43,27 @@ is the one that does this: register fields renumbered, basic blocks reordered,
 branch offsets recomputed from where the blocks landed. Nothing is copied in
 from retail; the bytes all came from MWCC.
 
-The fourth shape — writing bytes taken from the retail object — is the one that
-is out. One step still does it: `fix_game_action_object.py` replaces the whole
-`extab` section with `TARGET_EXTAB`, a hex table of retail's exception records.
-It predates these criteria, and `action.cpp` is a 77 KB source compiled into
-five split objects, so producing that table from source is its own piece of
-work. `tools/check_post_processors.py` records it as named debt so the rule can
-be enforced everywhere else and this one stays visible rather than passing
-quietly. Nothing may be added to that list.
+The fourth shape — writing values taken from the retail object — is the one that
+is out. Five steps still do it, and all five are recorded as named debt in
+`tools/check_post_processors.py` so the rule can be enforced everywhere else
+while these stay visible instead of passing quietly:
+
+| step | constant | what it carries |
+| --- | --- | --- |
+| `fix_game_action_object.py` | `TARGET_EXTAB` | the whole `extab` section, as hex |
+| `fix_eff_tornado_object.py` | `TEXT_PATCHES` | whole instruction words |
+| `fix_stage13_3way_colli_object.py` | `WORD_FIXES` | whole instruction words |
+| `fix_stage13_antenna_object.py` | `FACTORY_REGISTER_WORDS` | whole instruction words |
+| `fix_stage13_blinklight_object.py` | `FACTORY_REGISTER_WORDS` | whole instruction words |
+
+The word tables are mostly register differences spelled the long way, but not
+only: `fix_stage13_antenna_object.py` turns `0x418201A4` into `0x7C1E0378`,
+which is a `beq` replaced by a `mr`. That is a different instruction, not a
+different register, and it cannot be re-spelled as a field substitution.
+
+**Nothing may be added to that list.** A test asserts it, and it only ever
+shrinks — `fix_fn_80055470_object.py` and `fix_fn_800546F4_object.py` were
+deleted outright when a better source spelling made them unnecessary.
 
 Elsewhere the line holds. `fix_wide_format_core_object.py` uses a retail literal
 in exactly one place, an assertion, which is the opposite of carrying one.
@@ -137,9 +150,14 @@ Two things that have each closed a wall recently, both cheaper than a patch:
 `tools/check_post_processors.py` decides the two properties that can be decided
 mechanically, and CI runs it alongside the language policy:
 
-- **no retail content** — a module-level `bytes.fromhex()` constant must never
-  reach a write, whether through `pack_into`, `insert`, or a slice assignment.
-  Comparing against one is a guard and stays allowed.
+- **no retail content** — a module-level constant must never reach a write,
+  whether spelled as `bytes.fromhex()` or as a table of integers, and whether it
+  arrives through `pack_into`, `insert`, a slice assignment, or one hop of
+  unpacking in a `for` loop. Size is what separates the two cases: register
+  numbers, bit shifts and offsets are small and fine to carry, while a value of
+  0x10000 or more is instruction-sized and is retail content. Only the *value*
+  position counts — a name used as an offset is not a value. Comparing against a
+  literal is a guard and stays allowed.
 - **fails closed** — a step that writes must validate something first, so a
   stale table stops the build instead of quietly not applying.
 

--- a/tools/check_post_processors.py
+++ b/tools/check_post_processors.py
@@ -34,7 +34,74 @@ WRITE_CALLS = {"pack_into", "insert", "write_bytes", "pack_into_"}
 # Nothing may be added to this list. A new step gets the bytes from source.
 CARRIED_RETAIL_DEBT = {
     "fix_game_action_object.py": {"TARGET_EXTAB"},
+    "fix_eff_tornado_object.py": {"TEXT_PATCHES"},
+    "fix_stage13_3way_colli_object.py": {"WORD_FIXES"},
+    "fix_stage13_antenna_object.py": {"FACTORY_REGISTER_WORDS"},
+    "fix_stage13_blinklight_object.py": {"FACTORY_REGISTER_WORDS"},
 }
+
+
+def instruction_sized_constants(tree: ast.Module) -> set[str]:
+    """Module-level names bound to a literal holding instruction-sized values.
+
+    A step may carry register numbers, bit shifts and offsets; those are small.
+    A 32-bit value in a table is an instruction word, and writing one is
+    carrying retail content whether it is spelled as hex bytes or as an int.
+    """
+    found = set()
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        big = False
+        for child in ast.walk(node.value):
+            if isinstance(child, ast.Constant) and isinstance(child.value, int):
+                if not isinstance(child.value, bool) and child.value >= 0x10000:
+                    big = True
+        if not big:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                found.add(target.id)
+    return found
+
+
+def value_argument_names(tree: ast.Module) -> set[str]:
+    """Names used as the *value* being written, not as an offset or a buffer.
+
+    struct.pack_into(fmt, buffer, offset, *values) -> args[3:]
+    insert(section, data)                          -> args[1]
+    blob[a:b] = value                              -> the right-hand side
+    """
+    values = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name == "pack_into":
+                for argument in node.args[3:]:
+                    values |= names_in(argument)
+            elif name == "insert" and len(node.args) >= 2:
+                values |= names_in(node.args[1])
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Subscript):
+                    values |= names_in(node.value)
+    return values
+
+
+def unpacked_from(tree: ast.Module, sources: set[str]) -> set[str]:
+    """Names bound by iterating one of `sources`. One hop, no fixpoint.
+
+    Catches `for offset, (current, retail) in TABLE.items(): ... retail ...`,
+    which is how an instruction table reaches a write without the constant
+    itself appearing at the call. Deliberately shallow: a wider walk floods on
+    ordinary names like `offset` and `index` that every step reuses.
+    """
+    bound = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.For) and names_in(node.iter) & sources:
+            bound |= names_in(node.target)
+    return bound
 
 
 def hex_constants(tree: ast.Module) -> set[str]:
@@ -112,12 +179,30 @@ def writes_anything(tree: ast.Module) -> bool:
 def check(path: Path) -> list[str]:
     tree = ast.parse(path.read_text())
     problems = []
-    carried = hex_constants(tree) & written_names(tree)
-    carried -= CARRIED_RETAIL_DEBT.get(path.name, set())
+    allowed = CARRIED_RETAIL_DEBT.get(path.name, set())
+    written = written_names(tree)
+
+    carried = (hex_constants(tree) & written) - allowed
     for name in sorted(carried):
         problems.append(
             f"{path.name}: {name} is a hex literal that gets written. "
             "A post-processor may compare retail bytes, never carry them. "
+            "See docs/object-post-processors.md."
+        )
+
+    sized = instruction_sized_constants(tree) - allowed
+    values = value_argument_names(tree)
+    for name in sorted(sized & values):
+        problems.append(
+            f"{path.name}: {name} holds instruction-sized values and is written "
+            "as a value. Register numbers, shifts and offsets are fine to carry; "
+            "a 32-bit word is retail content. See docs/object-post-processors.md."
+        )
+    for name in sorted(unpacked_from(tree, sized) & values):
+        origin = ", ".join(sorted(sized))
+        problems.append(
+            f"{path.name}: {name} is unpacked from {origin}, which holds "
+            "instruction-sized values, and is written as a value. "
             "See docs/object-post-processors.md."
         )
     if writes_anything(tree) and not validates(tree):

--- a/tools/test_check_post_processors.py
+++ b/tools/test_check_post_processors.py
@@ -44,6 +44,43 @@ class HexLiteralTests(unittest.TestCase):
         self.assertEqual(checker.hex_constants(tree) & checker.written_names(tree), {"TAIL"})
 
 
+class InstructionSizedTests(unittest.TestCase):
+    def test_a_table_of_instruction_words_is_rejected(self) -> None:
+        tree = parse(
+            "import struct\n"
+            "PATCHES = {0x10: (0x7C7F1B78, 0x7C601B78)}\n"
+            "def main(blob, text):\n"
+            "    for offset, (current, retail) in PATCHES.items():\n"
+            "        struct.pack_into('>I', blob, text + offset, retail)\n"
+        )
+        sized = checker.instruction_sized_constants(tree)
+        self.assertEqual(sized, {"PATCHES"})
+        self.assertIn("retail", checker.unpacked_from(tree, sized) & checker.value_argument_names(tree))
+
+    def test_a_table_of_register_numbers_is_allowed(self) -> None:
+        tree = parse(
+            "import struct\n"
+            "FIELDS = {0x10: ((21, 31, 27), (11, 31, 27))}\n"
+            "def main(blob, text):\n"
+            "    for offset, fields in FIELDS.items():\n"
+            "        word = 0\n"
+            "        for shift, current, retail in fields:\n"
+            "            word = word | (retail << shift)\n"
+            "        struct.pack_into('>I', blob, text + offset, word)\n"
+        )
+        self.assertEqual(checker.instruction_sized_constants(tree), set())
+
+    def test_a_name_in_offset_position_is_not_a_value(self) -> None:
+        tree = parse(
+            "import struct\n"
+            "def main(blob, offset, word):\n"
+            "    struct.pack_into('>I', blob, offset, word)\n"
+        )
+        values = checker.value_argument_names(tree)
+        self.assertIn("word", values)
+        self.assertNotIn("offset", values)
+
+
 class ValidationTests(unittest.TestCase):
     def test_a_step_that_writes_without_validating_is_rejected(self) -> None:
         tree = parse(
@@ -80,7 +117,13 @@ class RepositoryTests(unittest.TestCase):
         # A new step gets its bytes from source. This list only ever shrinks.
         self.assertEqual(
             checker.CARRIED_RETAIL_DEBT,
-            {"fix_game_action_object.py": {"TARGET_EXTAB"}},
+            {
+                "fix_game_action_object.py": {"TARGET_EXTAB"},
+                "fix_eff_tornado_object.py": {"TEXT_PATCHES"},
+                "fix_stage13_3way_colli_object.py": {"WORD_FIXES"},
+                "fix_stage13_antenna_object.py": {"FACTORY_REGISTER_WORDS"},
+                "fix_stage13_blinklight_object.py": {"FACTORY_REGISTER_WORDS"},
+            },
         )
 
 


### PR DESCRIPTION
## What

The check added in #360 enforced "no retail content" by tracking module-level `bytes.fromhex()` constants into writes. It missed the same thing spelled as **integers**, which is how most of these tables are actually written:

```python
TEXT_PATCHES = { 0x3E0: (0x781B7B7C, 0x781B7F7C), ... }
for offset, (current, retail) in TEXT_PATCHES.items():
    struct.pack_into("<I", blob, text[4] + offset, retail)
```

That is a whole retail instruction word being written, and the checker said OK. `fix_eff_tornado_object.py` reached `main` through #351 past a green run of my own rule.

## What now decides it

Size, in value position, through one hop of unpacking:

- a module-level constant holding any integer **≥ 0x10000** is instruction-sized;
- register numbers, bit shifts and offsets are small and stay fine to carry;
- only the **value** argument counts — `pack_into(fmt, buf, offset, value)` looks at `args[3:]`, so a name used as an offset is not a value;
- one hop of `for ... in TABLE.items()` unpacking is followed, and no further.

The "one hop" is deliberate and I got it wrong first. A general taint walk floods: ordinary names every step reuses — `offset`, `index`, `text`, `symtab` — pick up the taint and the report becomes 57 lines of noise across four files. Shallow and precise beats deep and unusable.

## It found three more, and my eyeball audit had missed them twice

I claimed in #354, and again in #358 after a second pass, that nothing in `tools/` carries retail content. Wrong both times. Beyond `fix_eff_tornado_object.py`:

| step | constant |
| --- | --- |
| `fix_stage13_3way_colli_object.py` | `WORD_FIXES` |
| `fix_stage13_antenna_object.py` | `FACTORY_REGISTER_WORDS` |
| `fix_stage13_blinklight_object.py` | `FACTORY_REGISTER_WORDS` |

Most of those word pairs are register differences written the long way. Not all: `fix_stage13_antenna_object.py` turns `0x418201A4` into `0x7C1E0378`, a `beq` replaced by a `mr`. Different instruction, not a different register, so it cannot be re-spelled as field substitutions.

All five are recorded in `CARRIED_RETAIL_DEBT` with a test asserting the list never grows. The page carries the table and says what each one holds.

## Verification

Behaviour, not inference:

| | result |
| --- | --- |
| a table of instruction words written as a value | rejected, named |
| a table of register numbers (`(shift, from, to)`) | allowed |
| a name in offset position | not treated as a value |
| all 43 shipped steps with the debt list | OK |
| `python -m unittest tools.test_check_post_processors` | 11 tests OK |
| `python tools/check_language_policy.py` | OK |
| `ninja` | **18 files OK** |

## For `eff_tornado` specifically

Measured, so the debt has a size: 104 of the 109 differences in its two display functions are pure register fields. The other five are one thing — retail emits `addi r18, r3, 0` where this build emits `addi r0, r3, 0` plus `mr r20, r0`, and that extra instruction shifts the following four and drags the branch at `+0x304` with it. Fix that in source and the table becomes register substitutions, which the criteria allow and which would take that entry off the list.
