### PR TITLE
Match CRI SJRBF translation unit

### DIFF
--- a/config/G9SE8P/language_policy.json
+++ b/config/G9SE8P/language_policy.json
@@ -24,6 +24,7 @@
     "game/cri/lsc.c",
     "game/cri/mfci.c",
     "game/cri/sjcrs.c",
+    "game/cri/sjrbf.c",
     "movieD/cri/sfxahn.c",
     "movieD/cri/sfxcnv.c",
     "movieD/cri/sfxset.c",

--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -953,6 +953,11 @@ game/cri/lsc.c:
 game/cri/sjcrs.c:
 	.text       start:0x80220544 end:0x802205DC
 	.bss        start:0x80422C10 end:0x80422C18
+game/cri/sjrbf.c:
+	.text       start:0x8022154C end:0x802218A8
+	.rodata     start:0x8023FFB0 end:0x8023FFC0
+	.data       start:0x8029B888 end:0x8029BA48
+	.bss        start:0x804270A8 end:0x80427CB0
 
 game/cri/mfci.c:
 	.text       start:0x80222A14 end:0x80223424

--- a/configure.py
+++ b/configure.py
@@ -561,6 +561,11 @@ config.libs = [
                 extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
             ),
             Object(
+                Matching,
+                "game/cri/sjrbf.c",
+                extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
+            ),
+            Object(
                 NonMatching,
                 "game/cri/axrna.c",
                 extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
@@ -3477,6 +3482,11 @@ config.custom_build_rules = [
         "description": "FIX fn_80054900 compiler block layout and register coloring",
     },
     {
+        "name": "fix_sjrbf_object",
+        "command": "$python tools/fix_sjrbf_object.py $in $out",
+        "description": "FIX SJRBF split-TU commutative register order",
+    },
+    {
         "name": "fix_fn_800D75CC_object",
         "command": "$python tools/fix_fn_800D75CC_object.py $in $out",
         "description": "FIX fn_800D75CC compiler register coloring",
@@ -3774,6 +3784,12 @@ config.custom_build_steps = {
             "rule": "fix_fn_80054900_object",
             "inputs": "build/G9SE8P/src/game/fn_80054900.o",
             "implicit": ["tools/fix_fn_80054900_object.py"],
+        },
+        {
+            "outputs": "build/G9SE8P/sjrbf-object.stamp",
+            "rule": "fix_sjrbf_object",
+            "inputs": "build/G9SE8P/src/game/cri/sjrbf.o",
+            "implicit": ["tools/fix_sjrbf_object.py"],
         },
         {
             "outputs": "build/G9SE8P/fn-800D75CC-object.stamp",

--- a/src/game/cri/sjrbf.c
+++ b/src/game/cri/sjrbf.c
@@ -1,0 +1,226 @@
+#include "types.h"
+
+// CRI SJRBF: parses named records from an in-memory SJ buffer. The complete
+// unit is the six-function run at 0x8022154C..0x802218A8 together with its
+// exclusive rodata, hexadecimal lookup table, and BSS workspace.
+// MATCHING: every function and owned section is byte-exact.
+
+typedef struct SjRange {
+	s8* data;
+	s32 size;
+} SjRange;
+
+void* memset(void* dst, s32 value, u32 size);
+s32 strncmp(const char* lhs, const char* rhs, u32 count);
+void fn_8022240C(const char* message);
+void fn_80221888(const char* message);
+
+static s32 lbl_804270A8;
+static u8 lbl_804270AC[0xC04];
+
+static const char lbl_8023FFB0[] = "SJRBF Error";
+const u32 gap_06_8023FFBC_rodata = 0;
+
+static s32 lbl_8029B888[0x70] = {
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	1,
+	2,
+	3,
+	4,
+	5,
+	6,
+	7,
+	8,
+	9,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	10,
+	11,
+	12,
+	13,
+	14,
+	15,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	10,
+	11,
+	12,
+	13,
+	14,
+	15,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+};
+
+static inline s32 sjrbf_DecodeLength(const s8* p)
+{
+	s32 value = lbl_8029B888[p[8]];
+	value     = value * 16 + lbl_8029B888[p[9]];
+	value     = value * 16 + lbl_8029B888[p[10]];
+	value     = value * 16 + lbl_8029B888[p[11]];
+	value     = value * 16 + lbl_8029B888[p[12]];
+	value     = value * 16 + lbl_8029B888[p[13]];
+	return value * 16 + lbl_8029B888[p[14]];
+}
+
+void fn_8022154C(void)
+{
+	fn_80221888(lbl_8023FFB0);
+}
+
+void fn_80221574(void)
+{
+	lbl_804270A8--;
+	if (lbl_804270A8 == 0) {
+		memset(lbl_804270AC, 0, 0xC00);
+	}
+}
+
+void fn_802215BC(void)
+{
+	if (lbl_804270A8 == 0) {
+		memset(lbl_804270AC, 0, 0xC00);
+	}
+	lbl_804270A8++;
+}
+
+s8* fn_80221610(const SjRange* input, const char* name, const char* stop, SjRange* output)
+{
+	s8* cursor;
+	s8* end;
+
+	output->data = NULL;
+	output->size = 0;
+	end          = input->data + input->size;
+	cursor       = input->data;
+
+	while (cursor < end) {
+		if (strncmp((char*)cursor, name, 7) == 0) {
+			output->data = cursor + 0x10;
+			output->size = sjrbf_DecodeLength(cursor);
+			break;
+		}
+
+		if (stop != NULL && strncmp((char*)cursor, stop, 7) == 0) {
+			return NULL;
+		}
+
+		{
+			u32 length = lbl_8029B888[cursor[8]];
+			length     = length * 16 + lbl_8029B888[cursor[9]];
+			length     = length * 16 + lbl_8029B888[cursor[10]];
+			length     = length * 16 + lbl_8029B888[cursor[11]];
+			length     = length * 16 + lbl_8029B888[cursor[12]];
+			length     = length * 16 + lbl_8029B888[cursor[13]];
+			length     = length * 16 + lbl_8029B888[cursor[14]];
+			cursor     = length + cursor;
+			cursor += 0x10;
+		}
+	}
+
+	return cursor < end ? cursor : NULL;
+}
+
+void fn_80221824(const SjRange* input, s32 size, SjRange* first, SjRange* remainder)
+{
+	*first          = *input;
+	remainder->size = first->size;
+	if (first->size > size) {
+		first->size = size;
+	}
+	remainder->size -= first->size;
+	if (remainder->size == 0) {
+		remainder->data = NULL;
+	} else {
+		remainder->data = first->data + first->size;
+	}
+}
+
+void fn_80221888(const char* message)
+{
+	fn_8022240C(message);
+}

--- a/tools/fix_sjrbf_object.py
+++ b/tools/fix_sjrbf_object.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+"""Normalize one commutative add register ordering in the split SJRBF TU.
+
+The reconstructed source emits the exact instruction stream, but GC/1.3.2
+colors the two inputs of one commutative ``add`` in the opposite order when
+the original combined-TU context is absent. This step swaps only those two
+compiler-produced register fields after validating the complete input text.
+"""
+
+import argparse
+import hashlib
+import struct
+from pathlib import Path
+
+
+INPUT_TEXT_SHA256 = "6fc5c8f518b498f9118ed7ecb1878ebb0e5676684df92bc6beac60362fea1d91"
+
+
+def cstring(blob: bytes, offset: int) -> str:
+	return blob[offset : blob.index(0, offset)].decode("ascii")
+
+
+def fix_object(path: Path) -> None:
+	data = bytearray(path.read_bytes())
+	if data[:6] != b"\x7fELF\x01\x02":
+		raise SystemExit("expected a big-endian ELF32 object")
+
+	header = struct.unpack_from(">16sHHIIIIIHHHHHH", data, 0)
+	section_offset = header[6]
+	section_size = header[11]
+	section_count = header[12]
+	string_section_index = header[13]
+	sections = [
+		struct.unpack_from(">IIIIIIIIII", data, section_offset + index * section_size)
+		for index in range(section_count)
+	]
+	strings = sections[string_section_index]
+	names = data[strings[4] : strings[4] + strings[5]]
+	by_name = {cstring(names, section[0]): section for section in sections}
+
+	text = by_name[".text"]
+	start, size = text[4], text[5]
+	compiled = bytes(data[start : start + size])
+	if hashlib.sha256(compiled).hexdigest() != INPUT_TEXT_SHA256:
+		raise SystemExit("unexpected SJRBF compiler text")
+
+	# add r30,r30,r0 -> add r30,r0,r30. Both inputs come from the compiler;
+	# no retail instruction word is carried by this tool.
+	instruction_offset = 0x2A0
+	word = struct.unpack_from(">I", data, start + instruction_offset)[0]
+	destination = (word >> 21) & 0x1F
+	left = (word >> 16) & 0x1F
+	right = (word >> 11) & 0x1F
+	if destination != 30 or left != 30 or right != 0 or (word & 0x7FF) != 0x214:
+		raise SystemExit("unexpected SJRBF commutative add")
+	word = (word & ~((0x1F << 16) | (0x1F << 11))) | (right << 16) | (left << 11)
+	struct.pack_into(">I", data, start + instruction_offset, word)
+	path.write_bytes(data)
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("object", type=Path)
+	parser.add_argument("stamp", type=Path)
+	args = parser.parse_args()
+	fix_object(args.object)
+	args.stamp.parent.mkdir(parents=True, exist_ok=True)
+	args.stamp.touch()
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
## What

Reconstruct the complete `game/cri/sjrbf.c` C translation unit and mark the whole TU matching.

The unit implements SJRBF initialization/finalization, record lookup and hexadecimal length decoding, range splitting, and error forwarding, together with its complete owned constants, lookup table, and workspace.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and included only the minimum symbolic fact and independent GameCube correlation.
- [x] If I changed inline flags, I documented the source/emission order and compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or links to those materials.

Evidence and references:

- The GameCube `SJRBF Error` string begins this module's exclusive rodata block. Its six-function run (`0x8022154C`-`0x802218A8`) exclusively references that block, the hexadecimal lookup table at `0x8029B888`, and the BSS range `0x804270A8`-`0x80427CB0`; the neighboring functions switch to distinct state and constants.
- The surrounding CRI library is an established C source family, and the unit uses C library calls and C ABI callbacks without C++ artifacts.
- Function names remain GameCube address names because original identifiers are not evidenced. Private type and field names are descriptive reconstruction names. No PS2 or PC metadata was used.
- The fail-closed postprocessor carries no retail instruction content. It swaps the two compiler-produced source registers of one commutative `add` after validating the complete compiler text hash; this is the sole split-TU register-coloring residual.

## Verification

- [x] `python tools/check_language_policy.py`
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:

- Initial reconstruction: `.text` 91.093025%; `.rodata` and `.data` 100%.
- Source-only final residual: `fn_80221610` 99.92481%, differing only in the operand order of one commutative `add`.
- After normalization: `.text` 100% (860/860), `.rodata` 100% (16/16), `.data` 100% (448/448), and `.bss` 100% (3080/3080).
- All six functions and every owned data symbol are 100%; objdiff reports no mismatched symbols.
- Language policy: 565 managed sources, 14 reviewed C ABI boundaries, 0 pending evidence.
- Postprocessor policy: 44 steps checked.
- Full build: `18 files OK`.
