### PR TITLE
Match CRI SJCRS translation unit

### DIFF
--- a/config/G9SE8P/language_policy.json
+++ b/config/G9SE8P/language_policy.json
@@ -23,6 +23,7 @@
     "game/cri/gcci.c",
     "game/cri/lsc.c",
     "game/cri/mfci.c",
+    "game/cri/sjcrs.c",
     "movieD/cri/sfxahn.c",
     "movieD/cri/sfxcnv.c",
     "movieD/cri/sfxset.c",

--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -950,6 +950,10 @@ game/cri/lsc.c:
 	.rodata     start:0x8023FDF8 end:0x8023FF50
 	.bss        start:0x80420878 end:0x80422C10
 
+game/cri/sjcrs.c:
+	.text       start:0x80220544 end:0x802205DC
+	.bss        start:0x80422C10 end:0x80422C18
+
 game/cri/mfci.c:
 	.text       start:0x80222A14 end:0x80223424
 	.rodata     start:0x80240168 end:0x80240400

--- a/configure.py
+++ b/configure.py
@@ -556,6 +556,11 @@ config.libs = [
                 ],
             ),
             Object(
+                Matching,
+                "game/cri/sjcrs.c",
+                extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
+            ),
+            Object(
                 NonMatching,
                 "game/cri/axrna.c",
                 extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],

--- a/src/game/cri/sjcrs.c
+++ b/src/game/cri/sjcrs.c
@@ -1,0 +1,27 @@
+#include "types.h"
+
+// CRI SJ critical-section nesting. This complete TU is the two-function run
+// at 0x80220544..0x802205DC and its exclusive eight-byte BSS state.
+// MATCHING: both functions and the complete BSS block are byte-exact.
+
+u32 OSDisableInterrupts(void);
+void OSRestoreInterrupts(u32 enabled);
+
+static volatile s32 lbl_80422C10;
+static u32 lbl_80422C14;
+
+void fn_80220544(void)
+{
+	lbl_80422C10--;
+	if (lbl_80422C10 == 0) {
+		OSRestoreInterrupts(lbl_80422C14);
+	}
+}
+
+void fn_80220590(void)
+{
+	if (lbl_80422C10 == 0) {
+		lbl_80422C14 = OSDisableInterrupts();
+	}
+	lbl_80422C10++;
+}


### PR DESCRIPTION
## What

Reconstruct the complete `game/cri/sjcrs.c` C translation unit and mark the whole TU matching.

The unit implements CRI SJ's nestable interrupt-backed critical section and owns its complete two-word state.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and included only the minimum symbolic fact and independent GameCube correlation.
- [x] If I changed inline flags, I documented the source/emission order and compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or links to those materials.

Evidence and references:

- The two-function run (`0x80220544`-`0x802205DC`) exclusively owns the adjacent eight-byte BSS block (`0x80422C10`-`0x80422C18`). Both functions operate on the same nesting count and saved interrupt state; the next function switches to SJMEM object state.
- Calls to the Dolphin C OS interrupt API and use by the surrounding established CRI C units provide positive C source evidence.
- Function names remain GameCube address names because original identifiers are not evidenced; private state names retain their GameCube address labels. No PS2 or PC metadata was used.

## Verification

- [x] `python tools/check_language_policy.py`
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:

- Initial reconstruction: `.text` 93.1579%; `.bss` 100%.
- After recovering the volatile nesting counter: `.text` 100% (152/152) and `.bss` 100% (8/8).
- Both functions and both owned BSS symbols are 100%; objdiff reports no mismatched symbols.
- Language policy: 565 managed sources, 14 reviewed C ABI boundaries, 0 pending evidence.
- Postprocessor policy: 43 steps checked.
- Full build: `18 files OK`.
