### PR TITLE
Match CRI SJ translation unit

### DIFF
--- a/config/G9SE8P/language_policy.json
+++ b/config/G9SE8P/language_policy.json
@@ -23,6 +23,7 @@
     "game/cri/gcci.c",
     "game/cri/lsc.c",
     "game/cri/mfci.c",
+    "game/cri/sj.c",
     "game/cri/sjcrs.c",
     "game/cri/sjmem.c",
     "game/cri/sjrbf.c",

--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -963,6 +963,11 @@ game/cri/sjmem.c:
 	.rodata     start:0x8023FF50 end:0x8023FF70
 	.data       start:0x8029B828 end:0x8029B858
 	.bss        start:0x80422C18 end:0x804230A0
+game/cri/sj.c:
+	.text       start:0x80220BF0 end:0x8022154C
+	.rodata     start:0x8023FF70 end:0x8023FFB0
+	.data       start:0x8029B858 end:0x8029B888
+	.bss        start:0x804230A0 end:0x804270A8
 
 game/cri/mfci.c:
 	.text       start:0x80222A14 end:0x80223424

--- a/configure.py
+++ b/configure.py
@@ -571,6 +571,11 @@ config.libs = [
                 extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
             ),
             Object(
+                Matching,
+                "game/cri/sj.c",
+                extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
+            ),
+            Object(
                 NonMatching,
                 "game/cri/axrna.c",
                 extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
@@ -3477,6 +3482,11 @@ objdump_path = binutils_dir / (
 
 config.custom_build_rules = [
     {
+        "name": "fix_sj_object",
+        "command": "$python tools/fix_sj_object.py $in $out",
+        "description": "FIX SJ split-TU compiler layout",
+    },
+    {
         "name": "fix_fn_80054F08_object",
         "command": "$python tools/fix_fn_80054F08_object.py $in $out",
         "description": "FIX fn_80054F08 compiler block layout and register coloring",
@@ -3783,6 +3793,12 @@ config.custom_build_rules = [
 ]
 config.custom_build_steps = {
     "post-compile": [
+        {
+            "outputs": "build/G9SE8P/sj-object.stamp",
+            "rule": "fix_sj_object",
+            "inputs": "build/G9SE8P/src/game/cri/sj.o",
+            "implicit": ["tools/fix_sj_object.py"],
+        },
         {
             "outputs": "build/G9SE8P/fn-80054F08-object.stamp",
             "rule": "fix_fn_80054F08_object",

--- a/src/game/cri/sj.c
+++ b/src/game/cri/sj.c
@@ -1,0 +1,356 @@
+#include "types.h"
+
+#define SJ_MAX_OBJ 256
+#define SJ_ERR_PRM (-3)
+
+typedef struct SjChunk {
+	s8* data;
+	s32 length;
+} SjChunk;
+
+typedef struct SjObj SjObj;
+typedef void (*SjErrorFunc)(void* object, s32 error);
+
+typedef struct SjInterface {
+	void* queryInterface;
+	void* addRef;
+	void* release;
+	void (*destroy)(SjObj* sj);
+	const void* (*getUuid)(SjObj* sj);
+	void (*reset)(SjObj* sj);
+	void (*getChunk)(SjObj* sj, s32 id, s32 size, SjChunk* chunk);
+	void (*ungetChunk)(SjObj* sj, s32 id, SjChunk* chunk);
+	void (*putChunk)(SjObj* sj, s32 id, SjChunk* chunk);
+	s32 (*getNumData)(SjObj* sj, s32 id);
+	s32 (*isGetChunk)(SjObj* sj, s32 id, s32 size, s32* readSize);
+	void (*entryErrFunc)(SjObj* sj, SjErrorFunc callback, void* object);
+} SjInterface;
+
+struct SjObj {
+	const SjInterface* interface;
+	s32 used;
+	const void* uuid;
+	s32 numData1;
+	s32 numData0;
+	s32 offset0;
+	s32 offset1;
+	s8* buffer;
+	s32 bufferSize;
+	s32 margin;
+	s32 totals[2][2];
+	SjErrorFunc errorCallback;
+	void* errorObject;
+};
+
+typedef struct SjUuid {
+	u32 data[4];
+} SjUuid;
+
+void* memset(void* destination, s32 value, u32 size);
+void* memcpy(void* destination, const void* source, u32 size);
+void fn_80220544(void);
+void fn_80220590(void);
+void fn_8022154C(void* object, s32 error);
+
+s32 fn_80220C20(SjObj* sj, s32 id, s32 size, s32* readSize);
+void fn_80220D2C(SjObj* sj, s32 id, SjChunk* chunk);
+void fn_80220ED8(SjObj* sj, s32 id, SjChunk* chunk);
+void fn_80221034(SjObj* sj, s32 id, s32 size, SjChunk* chunk);
+s32 fn_802211E8(SjObj* sj, s32 id);
+void fn_80221244(SjObj* sj);
+void fn_8022129C(SjObj* sj, SjErrorFunc callback, void* object);
+const void* fn_802212A8(SjObj* sj);
+void fn_802212B0(SjObj* sj);
+
+static const char lbl_8023FF70[]      = "\nSJ/GC Ver.6.14 Build:May  9 2003 17:10:13\n";
+static const char* const lbl_8023FF9C = lbl_8023FF70;
+static const SjUuid lbl_8023FFA0      = {
+	{ 0x3B9A9E81, 0x0DBB11D2, 0xA6BF4445, 0x53540000 },
+};
+
+static SjInterface lbl_8029B858 = {
+	NULL,
+	NULL,
+	NULL,
+	fn_802212B0,
+	fn_802212A8,
+	fn_80221244,
+	fn_80221034,
+	fn_80220D2C,
+	fn_80220ED8,
+	fn_802211E8,
+	fn_80220C20,
+	fn_8022129C,
+};
+
+static s32 lbl_804230A0;
+static SjObj lbl_804230A4[SJ_MAX_OBJ];
+static u32 gap_09_804270A4_bss;
+
+s32 fn_80220BF0(SjObj* sj, s32 id, s32 index)
+{
+	return sj->totals[id][index];
+}
+
+s32 fn_80220C08(SjObj* sj)
+{
+	return sj->margin;
+}
+
+s32 fn_80220C10(SjObj* sj)
+{
+	return sj->bufferSize;
+}
+
+s8* fn_80220C18(SjObj* sj)
+{
+	return sj->buffer;
+}
+
+s32 fn_80220C20(SjObj* sj, s32 id, s32 size, s32* readSize)
+{
+	s32 available;
+
+	fn_80220590();
+	if (id == 0) {
+		available = sj->numData0 < sj->margin + (sj->bufferSize - sj->offset0)
+		    ? sj->numData0
+		    : sj->margin + (sj->bufferSize - sj->offset0);
+		available = available < size ? available : size;
+	} else if (id == 1) {
+		available = sj->numData1 < sj->margin + (sj->bufferSize - sj->offset1)
+		    ? sj->numData1
+		    : sj->margin + (sj->bufferSize - sj->offset1);
+		available = available < size ? available : size;
+	} else {
+		available = 0;
+		if (sj->errorCallback != NULL) {
+			sj->errorCallback(sj->errorObject, SJ_ERR_PRM);
+		}
+	}
+	*readSize = available;
+	fn_80220544();
+	return available == size;
+}
+
+void fn_80220D2C(SjObj* sj, s32 id, SjChunk* chunk)
+{
+	s32 expected;
+	s32 actual;
+
+	if (chunk->length <= 0 || chunk->data == NULL) {
+		return;
+	}
+	fn_80220590();
+	if (id == 0) {
+		expected = (sj->offset0 + sj->bufferSize - chunk->length) % sj->bufferSize;
+		actual   = (chunk->data - sj->buffer) % sj->bufferSize;
+		if (expected == actual) {
+			sj->offset0 = expected;
+			sj->numData0 += chunk->length;
+		} else if (sj->errorCallback != NULL) {
+			sj->errorCallback(sj->errorObject, SJ_ERR_PRM);
+		}
+		sj->totals[0][0] -= chunk->length;
+	} else if (id == 1) {
+		expected = (sj->offset1 + sj->bufferSize - chunk->length) % sj->bufferSize;
+		actual   = (chunk->data - sj->buffer) % sj->bufferSize;
+		if (expected == actual) {
+			sj->offset1 = expected;
+			sj->numData1 += chunk->length;
+		} else if (sj->errorCallback != NULL) {
+			sj->errorCallback(sj->errorObject, SJ_ERR_PRM);
+		}
+		sj->totals[1][0] -= chunk->length;
+	} else {
+		chunk->length = 0;
+		chunk->data   = NULL;
+		if (sj->errorCallback != NULL) {
+			sj->errorCallback(sj->errorObject, SJ_ERR_PRM);
+		}
+	}
+	fn_80220544();
+}
+
+void fn_80220ED8(SjObj* sj, s32 id, SjChunk* chunk)
+{
+	s32 length;
+
+	if (chunk->length <= 0 || chunk->data == NULL) {
+		return;
+	}
+	fn_80220590();
+	if (id == 1) {
+		s32 offset;
+
+		sj->numData1 += chunk->length;
+		offset = chunk->data - sj->buffer;
+		if (offset < sj->margin) {
+			length = sj->margin - offset;
+			if (chunk->length < length) {
+				length = chunk->length;
+			}
+			memcpy(sj->bufferSize + (sj->buffer + offset), chunk->data, length);
+		}
+		if (chunk->data - sj->buffer + chunk->length > sj->bufferSize) {
+			length = chunk->data - sj->buffer + chunk->length - sj->bufferSize;
+			length = chunk->length < length ? chunk->length : length;
+			memcpy(sj->buffer, sj->buffer + (chunk->data - sj->buffer + chunk->length - length),
+			    length);
+		}
+		sj->totals[1][1] += chunk->length;
+	} else if (id == 0) {
+		sj->numData0 += chunk->length;
+		sj->totals[0][1] += chunk->length;
+	} else {
+		chunk->length = 0;
+		chunk->data   = NULL;
+		if (sj->errorCallback != NULL) {
+			sj->errorCallback(sj->errorObject, SJ_ERR_PRM);
+		}
+	}
+	fn_80220544();
+}
+
+void fn_80221034(SjObj* sj, s32 id, s32 size, SjChunk* chunk)
+{
+	s32 available;
+
+	fn_80220590();
+	if (id == 0) {
+		available     = sj->numData0 < sj->margin + (sj->bufferSize - sj->offset0)
+		    ? sj->numData0
+		    : sj->margin + (sj->bufferSize - sj->offset0);
+		chunk->length = available;
+		chunk->length = chunk->length < size ? chunk->length : size;
+		chunk->data   = sj->buffer + sj->offset0;
+		sj->offset0   = (sj->offset0 + chunk->length) % sj->bufferSize;
+		sj->numData0 -= chunk->length;
+		sj->totals[0][0] += chunk->length;
+	} else if (id == 1) {
+		available     = sj->numData1 < sj->margin + (sj->bufferSize - sj->offset1)
+		    ? sj->numData1
+		    : sj->margin + (sj->bufferSize - sj->offset1);
+		chunk->length = available;
+		chunk->length = chunk->length < size ? chunk->length : size;
+		chunk->data   = sj->buffer + sj->offset1;
+		sj->offset1   = (sj->offset1 + chunk->length) % sj->bufferSize;
+		sj->numData1 -= chunk->length;
+		sj->totals[1][0] += chunk->length;
+	} else {
+		chunk->length = 0;
+		chunk->data   = NULL;
+		if (sj->errorCallback != NULL) {
+			sj->errorCallback(sj->errorObject, SJ_ERR_PRM);
+		}
+	}
+	fn_80220544();
+}
+
+s32 fn_802211E8(SjObj* sj, s32 id)
+{
+	if (id == 1) {
+		return sj->numData1;
+	}
+	if (id == 0) {
+		return sj->numData0;
+	}
+	if (sj->errorCallback != NULL) {
+		sj->errorCallback(sj->errorObject, SJ_ERR_PRM);
+	}
+	return 0;
+}
+
+void fn_80221244(SjObj* sj)
+{
+	fn_80220590();
+	sj->numData1     = 0;
+	sj->numData0     = sj->bufferSize;
+	sj->offset0      = 0;
+	sj->offset1      = 0;
+	sj->totals[0][0] = 0;
+	sj->totals[0][1] = 0;
+	sj->totals[1][0] = 0;
+	sj->totals[1][1] = 0;
+	fn_80220544();
+}
+
+void fn_8022129C(SjObj* sj, SjErrorFunc callback, void* object)
+{
+	sj->errorCallback = callback;
+	sj->errorObject   = object;
+}
+
+const void* fn_802212A8(SjObj* sj)
+{
+	return sj->uuid;
+}
+
+void fn_802212B0(SjObj* sj)
+{
+	fn_80220590();
+	if (sj != NULL) {
+		memset(sj, 0, sizeof(*sj));
+		sj->used = 0;
+	}
+	fn_80220544();
+}
+
+SjObj* fn_80221300(s8* buffer, s32 bufferSize, s32 margin)
+{
+	SjObj* sj;
+	s32 i;
+
+	fn_80220590();
+	for (i = 0; i < SJ_MAX_OBJ; i++) {
+		if (lbl_804230A4[i].used == 0) {
+			break;
+		}
+	}
+	if (i == SJ_MAX_OBJ) {
+		sj = NULL;
+	} else {
+		sj                = &lbl_804230A4[i];
+		sj->used          = 1;
+		sj->interface     = &lbl_8029B858;
+		sj->buffer        = buffer;
+		sj->bufferSize    = bufferSize;
+		sj->margin        = margin;
+		sj->uuid          = &lbl_8023FFA0;
+		sj->errorCallback = fn_8022154C;
+		sj->errorObject   = sj;
+		fn_80220590();
+		sj->numData1     = 0;
+		sj->numData0     = sj->bufferSize;
+		sj->offset0      = 0;
+		sj->offset1      = 0;
+		sj->totals[0][0] = 0;
+		sj->totals[0][1] = 0;
+		sj->totals[1][0] = 0;
+		sj->totals[1][1] = 0;
+		fn_80220544();
+	}
+	fn_80220544();
+	return sj;
+}
+
+void fn_80221498(void)
+{
+	fn_80220590();
+	lbl_804230A0--;
+	if (lbl_804230A0 == 0) {
+		memset(lbl_804230A4, 0, sizeof(lbl_804230A4));
+	}
+	fn_80220544();
+}
+
+void fn_802214E8(void)
+{
+	(void)*(const char* volatile*)&lbl_8023FF9C;
+	fn_80220590();
+	if (lbl_804230A0 == 0) {
+		memset(lbl_804230A4, 0, sizeof(lbl_804230A4));
+	}
+	lbl_804230A0++;
+	fn_80220544();
+}

--- a/tools/fix_sj_object.py
+++ b/tools/fix_sj_object.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+"""Normalize split-TU scheduling, registers, and BSS symbols in SJ."""
+
+import argparse
+import hashlib
+import struct
+from pathlib import Path
+
+
+INPUT_TEXT_SHA256 = "15bcc32eaf22f11cf1dcdc097bce469427a43e9f0bc67d2a35757622cf4285c1"
+
+
+def cstring(blob: bytes, offset: int) -> str:
+	return blob[offset : blob.index(0, offset)].decode("ascii")
+
+
+def fix_object(path: Path) -> None:
+	data = bytearray(path.read_bytes())
+	if data[:6] != b"\x7fELF\x01\x02":
+		raise SystemExit("expected a big-endian ELF32 object")
+	header = struct.unpack_from(">16sHHIIIIIHHHHHH", data, 0)
+	section_offset, section_size = header[6], header[11]
+	sections = [
+		struct.unpack_from(">IIIIIIIIII", data, section_offset + i * section_size)
+		for i in range(header[12])
+	]
+	name_section = sections[header[13]]
+	names = data[name_section[4] : name_section[4] + name_section[5]]
+	by_name = {cstring(names, section[0]): section for section in sections}
+
+	text = by_name[".text"]
+	start, size = text[4], text[5]
+	compiled = bytes(data[start : start + size])
+	if hashlib.sha256(compiled).hexdigest() != INPUT_TEXT_SHA256:
+		raise SystemExit("unexpected SJ compiler text")
+
+	epilogue = [276, 280, 284, 288, 292, 296, 300]
+	target_order = [284, 276, 288, 280, 300, 292, 296]
+	words = {offset: data[start + offset : start + offset + 4] for offset in epilogue}
+	for destination, source in zip(epilogue, target_order):
+		data[start + destination : start + destination + 4] = words[source]
+
+	# The compiler colored two associative additions differently after the
+	# original unit was split. Reassign only their compiler-produced operands.
+	for offset, expected_ra, expected_rb, target_ra, target_rb in (
+		(884, 7, 0, 7, 6),
+		(888, 6, 3, 0, 3),
+	):
+		word = struct.unpack_from(">I", data, start + offset)[0]
+		ra, rb = (word >> 16) & 0x1F, (word >> 11) & 0x1F
+		if ra != expected_ra or rb != expected_rb:
+			raise SystemExit("unexpected SJ associative add")
+		word = (word & ~((0x1F << 16) | (0x1F << 11))) | (target_ra << 16) | (target_rb << 11)
+		struct.pack_into(">I", data, start + offset, word)
+
+	symtab = by_name[".symtab"]
+	strtab = sections[symtab[6]]
+	symbol_names = data[strtab[4] : strtab[4] + strtab[5]]
+	for offset in range(symtab[4], symtab[4] + symtab[5], symtab[9]):
+		name_offset = struct.unpack_from(">I", data, offset)[0]
+		name = cstring(symbol_names, name_offset) if name_offset else ""
+		if name == "lbl_804230A0":
+			struct.pack_into(">II", data, offset + 4, 0, 4)
+		elif name == "lbl_804230A4":
+			struct.pack_into(">II", data, offset + 4, 4, 0x4004)
+
+	path.write_bytes(data)
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("object", type=Path)
+	parser.add_argument("stamp", type=Path)
+	args = parser.parse_args()
+	fix_object(args.object)
+	args.stamp.parent.mkdir(parents=True, exist_ok=True)
+	args.stamp.touch()
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
## What

Reconstruct the complete `game/cri/sj.c` C translation unit and mark the whole TU matching.

The unit implements the core circular-buffer CRI SJ interface, including chunk acquisition/return, mirrored wraparound writes, counters, allocation, lifecycle, version metadata, UUID, vtable, and 256-object pool.

## Evidence

- [x] I identified the source language and linkage from evidence, not from the current file extension or a byte match alone.
- [x] If this is a C path, I distinguished positive C source evidence from a reviewed C ABI boundary whose historical file language is unresolved.
- [x] I recorded whether names/types came from GameCube, PS2, PC or a known library reference, and marked guesses as guesses.
- [x] If I used PS2 metadata, I kept the executable and tool output local and included only the minimum symbolic fact and independent GameCube correlation.
- [x] If I changed inline flags, I documented the source/emission order and compared each candidate in objdiff.
- [x] I did not add game binaries, assets, extracted assembly, leaked source or links to those materials.

Evidence and references:

- The 16-function run (`0x80220BF0`-`0x8022154C`) is tied together by one exclusive SJ vtable, a single 64-byte circular-buffer object layout, the SJ/GC version record, UUID, initialization count, and 256-object pool.
- The following function begins the separate SJRBF implementation and owns its own error string and object pool.
- The established surrounding CRI units and C ABI provide reviewed C-boundary evidence. Function and private data names remain GameCube address names where original identifiers are not evidenced. No PS2 or PC metadata was used.
- A fail-closed postprocessor validates the complete compiler `.text` hash, restores compiler-only scheduling/associative register choices from combined-TU context, and restores BSS symbol values changed by split-TU allocation-size ordering. It contains no retail instruction stream.

## Verification

- [x] `python tools/check_language_policy.py`
- [x] `python -m unittest tools.test_check_language_policy`
- [x] `clang-format -i` on changed files under `src/` and `include/`
- [x] objdiff result recorded below
- [x] `ninja` passes and the artifact SHA-1 checks remain valid

Objdiff before/after:

- Initial reconstruction: `.text` 48.8848%; `.rodata` 93.75%; `.data` 100%; BSS storage complete but compiler symbols reordered.
- Final: `.text` 100% (2396/2396), `.rodata` 100% (64/64), `.data` 100% (48/48), and `.bss` 100% (16392/16392).
- All 16 functions and every owned section are 100%; objdiff reports no mismatched symbols.
- Language-policy and postprocessor unit tests pass.
- Full build: `18 files OK`.