### PR TITLE
build: sort the CRI SJ splits back into address order

### DIFF
--- a/config/G9SE8P/splits.txt
+++ b/config/G9SE8P/splits.txt
@@ -953,21 +953,24 @@ game/cri/lsc.c:
 game/cri/sjcrs.c:
 	.text       start:0x80220544 end:0x802205DC
 	.bss        start:0x80422C10 end:0x80422C18
-game/cri/sjrbf.c:
-	.text       start:0x8022154C end:0x802218A8
-	.rodata     start:0x8023FFB0 end:0x8023FFC0
-	.data       start:0x8029B888 end:0x8029BA48
-	.bss        start:0x804270A8 end:0x80427CB0
+
 game/cri/sjmem.c:
 	.text       start:0x802205DC end:0x80220BF0
 	.rodata     start:0x8023FF50 end:0x8023FF70
 	.data       start:0x8029B828 end:0x8029B858
 	.bss        start:0x80422C18 end:0x804230A0
+
 game/cri/sj.c:
 	.text       start:0x80220BF0 end:0x8022154C
 	.rodata     start:0x8023FF70 end:0x8023FFB0
 	.data       start:0x8029B858 end:0x8029B888
 	.bss        start:0x804230A0 end:0x804270A8
+
+game/cri/sjrbf.c:
+	.text       start:0x8022154C end:0x802218A8
+	.rodata     start:0x8023FFB0 end:0x8023FFC0
+	.data       start:0x8029B888 end:0x8029BA48
+	.bss        start:0x804270A8 end:0x80427CB0
 
 game/cri/mfci.c:
 	.text       start:0x80222A14 end:0x80223424


### PR DESCRIPTION
`main` does not link. A clean checkout that runs `python configure.py` once and then `ninja` dies in the linker:

```
### mwldeppc.exe Linker Alert:
#   internal linker error: File: 'ELF_gen.c' Line: 2336.
Errors caused tool to abort.
```

The cause is ordering, not content. `config/G9SE8P/splits.txt` lists `game/cri/sjrbf.c` (`.text` at 0x8022154C) between `sjcrs.c` (0x80220544) and `sjmem.c` (0x802205DC), so the generated ldscript places output sections out of address order and mwld aborts. Each of #379, #381 and #382 was green against the main it branched from; the ordering only broke once all three had landed.

It hides well because `configure.py` rewrites `splits.txt` into address order as a side effect. The first run emits the ldscript from the file as committed — the broken one — and normalizes the file on its way out, so a *second* `configure.py` run makes the build pass locally and the working tree then looks dirty for no visible reason. That is why this can pass on a developer machine and fail in CI.

This commits the normalization: `sjrbf.c` moves after `sj.c`, and the blank lines between unit blocks come back. No range changes — the same four spans, in the right place.

Verified: `ninja` links and `sha1sum -c config/G9SE8P/build.sha1` is 18/18.