### PR TITLE
ci: verify the built artifacts against build.sha1 explicitly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,17 @@ jobs:
         python tools/check_post_processors.py
         ninja all_source progress build/${{ matrix.version }}/report.json
 
+    # The `progress` target already reaches this through build/<version>/ok, so
+    # a mismatch fails the step above. That guarantee is a dependency edge, not
+    # a line anyone reads: if `progress` ever stops depending on `ok`, the byte
+    # comparison disappears silently and every build still looks green.
+    #
+    # So state it. Hashing eighteen artifacts costs about a second, and this
+    # fails independently of what the ninja graph happens to look like.
+    - name: Verify the artifacts match retail
+      run: |
+        build/tools/dtk shasum -c config/${{ matrix.version }}/build.sha1
+
     - name: Upload map
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:


### PR DESCRIPTION
Adds a step that runs `dtk shasum -c config/<version>/build.sha1` after the build.

**This is not new coverage.** The comparison already happens: `ninja … progress` reaches `build/<version>/ok`, which is produced by the `check` rule running exactly this command, and `dtk shasum -c` exits 1 on a mismatch — so a divergent artifact already fails the build today. I checked that rather than assuming it, by feeding the tool a deliberately wrong hash: exit 1 with the right ones, exit 0 with them correct.

What the step changes is that the guarantee stops being a dependency edge and becomes a line someone can read. Today it holds only while `progress` keeps depending on `ok`. If that edge is ever dropped — a refactor of the target list, a new progress implementation — the byte-for-byte comparison against retail disappears with it, and every build still reports green. That is a silent failure of the one check the whole project rests on.

Hashing eighteen artifacts costs about a second, and the step fails independently of what the ninja graph happens to look like.

The comment above the step says all of this, so the next person does not delete it as redundant without understanding what it guards.