### PR TITLE
decomp: spell the empty-case switch idiom in stage11 m2c units

### DIFF
--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -41,27 +41,27 @@ all, usually a missing or extra block.
 | `rel/e_grass_stage11` | 69 | 19 | 1 | 49 | 1385 |
 | `rel/e_s11_flag_stage11` | 82 | 18 | 13 | 51 | 1741 |
 | `rel/e_rinoliner_stage11` | 90 | 15 | 0 | 75 | 1929 |
-| `rel/e_flyer_path_stage11` | 96 | 0 | 0 | 96 | 2268 |
+| `rel/e_flyer_path_stage11` | 92 | 0 | 0 | 92 | 2268 |
 | `rel/e_spider_stage11` | 108 | 10 | 31 | 67 | 965 |
 | `rel/o_s11_door` | 109 | 25 | 47 | 37 | 1352 |
 | `rel/o_s12_celestial_sphere` | 142 | 13 | 104 | 25 | 799 |
 | `rel/object_effects_stage11` | 150 | 0 | 0 | 150 | 935 |
-| `rel/e_strategy_rinoliner_stage11` | 156 | 8 | 24 | 124 | 990 |
+| `rel/e_strategy_rinoliner_stage11` | 151 | 8 | 24 | 119 | 990 |
 | `rel/e_strategy_magician_stage11` | 175 | 2 | 50 | 123 | 2199 |
 | `rel/e_s11_key_stage11` | 222 | 13 | 139 | 70 | 1640 |
 | `rel/e_flyer_collision_stage11` | 232 | 8 | 39 | 185 | 1377 |
-| `rel/e_rinoliner_collision_stage11` | 281 | 14 | 8 | 259 | 2574 |
+| `rel/e_rinoliner_collision_stage11` | 276 | 14 | 8 | 254 | 2574 |
 | `rel/particle_test` | 317 | 0 | 0 | 317 | 735 |
-| `rel/e_strategy_flyer_stage11` | 341 | 52 | 81 | 208 | 4833 |
+| `rel/e_strategy_flyer_stage11` | 334 | 52 | 81 | 201 | 4833 |
 | `rel/e_capture` | 362 | 33 | 31 | 298 | 5335 |
 | `rel/put_particle` | 420 | 0 | 0 | 420 | 808 |
-| `rel/e_wall_stage11` | 470 | 34 | 37 | 399 | 6670 |
+| `rel/e_wall_stage11` | 461 | 34 | 37 | 390 | 6670 |
 | `rel/sp_dashpanel` | 475 | 0 | 0 | 475 | 740 |
 | `game/rw_gcn_raster` | 483 | 165 | 291 | 27 | 3771 |
 | `rel/light_collision_stage11` | 489 | 6 | 8 | 475 | 1168 |
 | `rel/spboss_throw_object` | 517 | 0 | 1 | 516 | 794 |
-| `rel/e_turtle_stage11` | 623 | 53 | 236 | 334 | 5025 |
-| `rel/e_flyer_stage11` | 649 | 39 | 8 | 602 | 4582 |
+| `rel/e_turtle_stage11` | 617 | 53 | 236 | 328 | 5025 |
+| `rel/e_flyer_stage11` | 641 | 39 | 8 | 594 | 4582 |
 | `rel/sp_dashring` | 697 | 0 | 0 | 697 | 954 |
 | `rel/propeller_stage11` | 805 | 5 | 6 | 794 | 2655 |
 | `game/rw_gcn_allinone` | 818 | 13 | 51 | 754 | 2558 |
@@ -76,6 +76,53 @@ all, usually a missing or extra block.
 | `rel/goal_ring_stage11` | 1761 | 6 | 18 | 1737 | 3081 |
 | `game/rw_gcn_core` | 2020 | 32 | 288 | 1700 | 7601 |
 | `rel/sp_eff_dash` | 4490 | 0 | 0 | 4490 | 4561 |
+
+## Idioms that close a whole column at once
+
+These sources are m2c output, so their control flow is a transcription of the
+branches rather than the source that produced them. Some of that transcription
+is wrong in the same way in many places at once, and recognising the shape is
+worth far more than grinding one function.
+
+**A two-armed `if` that returns either way is a `switch` with empty cases.**
+m2c writes this:
+
+```c
+if (arg1 != 0) {
+    if (arg1 >= 0) {
+        return;
+    }
+    return;
+}
+/* body */
+```
+
+The two `return`s are the same return, so nothing in that C makes the compiler
+emit the compare that retail has. The original is a `switch` whose other case
+labels have empty bodies:
+
+```c
+switch (arg1) {
+case 0:
+    /* body */
+    break;
+case 1:
+case 2:
+case 3:
+    break;
+}
+```
+
+mwcc lowers a small dense switch as: equality test on the first label, `bltlr`
+for anything below the range, then a compare against **one past the largest
+label** whose result is discarded because both edges return. That last compare
+is what a hand-written `if` chain never produces, and its immediate is what
+tells you how many labels the original had — retail's `cmpwi rX, 0x4` means the
+labels ran 0 through 3. Read the immediate out of the target rather than
+guessing it.
+
+Thirty-eight sites across seven units had exactly this shape, all with the same
+bound, and converting them closed 44 instructions.
 
 ## Where to start
 

--- a/src/rel/e_flyer_path_stage11.cpp
+++ b/src/rel/e_flyer_path_stage11.cpp
@@ -1050,24 +1050,28 @@ void fn_8_A9E94(void* arg0, s32 arg1)
 
 void fn_8_A9F48(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
 }
 
 void fn_8_A9F68(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x24;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x24;
 }
 
 void fn_8_A9F88(void* arg0, s32 arg1)
@@ -1096,24 +1100,28 @@ void fn_8_A9F88(void* arg0, s32 arg1)
 
 void fn_8_AA04C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 2;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 2;
 }
 
 void fn_8_AA06C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 1;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 1;
 }
 
 void fn_8_AA08C(void* arg0, u32 arg1)

--- a/src/rel/e_flyer_stage11.cpp
+++ b/src/rel/e_flyer_stage11.cpp
@@ -200,24 +200,28 @@ void fn_8_A2584(s32 arg0)
 
 void fn_8_A258C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x5C;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x5C;
 }
 
 void fn_8_A25AC(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
 }
 
 void fn_8_A25CC(void* arg0, s32 arg1)
@@ -244,13 +248,15 @@ void fn_8_A25CC(void* arg0, s32 arg1)
 
 void fn_8_A2690(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x44;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x44;
 }
 
 void fn_8_A26B0(void* arg0, s32 arg1)
@@ -297,13 +303,15 @@ void fn_8_A2768(void* arg0, s32 arg1)
 
 void fn_8_A2820(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x42;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x42;
 }
 
 void fn_8_A2840(void* arg0, s32 arg1)
@@ -346,13 +354,15 @@ void fn_8_A2840(void* arg0, s32 arg1)
 
 void fn_8_A29E0(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 1;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 1;
 }
 
 void fn_8_A2A00(void* arg0, u32 arg1)

--- a/src/rel/e_rinoliner_collision_stage11.cpp
+++ b/src/rel/e_rinoliner_collision_stage11.cpp
@@ -558,13 +558,15 @@ void fn_8_B533C(void* arg0, s32 arg1)
 
 void fn_8_B5408(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
 }
 
 void fn_8_B5428(void* arg0, s32 arg1)
@@ -595,13 +597,15 @@ void fn_8_B5428(void* arg0, s32 arg1)
 
 void fn_8_B54E4(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x26;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x26;
 }
 
 void fn_8_B5504(void* arg0, s32 arg1)
@@ -632,35 +636,41 @@ void fn_8_B5504(void* arg0, s32 arg1)
 
 void fn_8_B55C0(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 2;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 2;
 }
 
 void fn_8_B55E0(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x27;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x27;
 }
 
 void fn_8_B5600(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 1;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 1;
 }
 
 void fn_8_B5620(void* arg0, u32 arg1)

--- a/src/rel/e_strategy_flyer_stage11.cpp
+++ b/src/rel/e_strategy_flyer_stage11.cpp
@@ -252,24 +252,28 @@ void fn_8_9DA00(s32 arg0)
 
 void fn_8_9DA08(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x15;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x15;
 }
 
 void fn_8_9DA28(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x2F;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x2F;
 }
 
 void fn_8_9DA48(void* arg0, s32 arg1)
@@ -375,13 +379,15 @@ void fn_8_9DCE8(void* arg0)
 
 void fn_8_9DD28(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 6;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 6;
 }
 
 void fn_8_9DD48(void* arg0, s32 arg1)
@@ -449,13 +455,15 @@ void fn_8_9DEC8(void* arg0, s32 arg1)
 
 void fn_8_9DF7C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x25;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x25;
 }
 
 void fn_8_9DF9C(void* arg0, s32 arg1)
@@ -481,13 +489,15 @@ void fn_8_9DF9C(void* arg0, s32 arg1)
 
 void fn_8_9E054(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x1A;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x1A;
 }
 
 void fn_8_9E074(void* arg0, s32 arg1)
@@ -547,13 +557,15 @@ void fn_8_9E12C(void* arg0, s32 arg1)
 
 void fn_8_9E250(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
 }
 
 void fn_8_9E270(void* arg0, s32 arg1)
@@ -1923,13 +1935,15 @@ void fn_8_A07B4(void* arg0, s32 arg1)
 
 void fn_8_A0A10(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0xD4) = 0;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0xD4) = 0;
 }
 
 void fn_8_A0A30(void* arg0, s32 arg1, s32 arg2)

--- a/src/rel/e_strategy_rinoliner_stage11.cpp
+++ b/src/rel/e_strategy_rinoliner_stage11.cpp
@@ -158,13 +158,15 @@ void fn_8_AFD40(void* arg0, s32 arg1)
 
 void fn_8_AFE00(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x25;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x25;
 }
 
 void fn_8_AFE20(void* arg0, s32 arg1)
@@ -190,24 +192,28 @@ void fn_8_AFE20(void* arg0, s32 arg1)
 
 void fn_8_AFED8(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x1A;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x1A;
 }
 
 void fn_8_AFEF8(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x20;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x20;
 }
 
 void fn_8_AFF18(void* arg0, s32 arg1)
@@ -279,13 +285,15 @@ void fn_8_AFF18(void* arg0, s32 arg1)
 
 void fn_8_B0158(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
 }
 
 void fn_8_B0178(void* arg0, s32 arg1)
@@ -328,13 +336,15 @@ void fn_8_B022C(void* arg0, s32 arg1)
 
 void fn_8_B02E0(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 1;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 1;
 }
 
 void fn_8_B0300(void* arg0, u32 arg1)

--- a/src/rel/e_turtle_stage11.cpp
+++ b/src/rel/e_turtle_stage11.cpp
@@ -450,24 +450,28 @@ void fn_8_BDA50(void* arg0, s32 arg1)
 
 void fn_8_BDB0C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x1A;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x1A;
 }
 
 void fn_8_BDB2C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x20;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x20;
 }
 
 void fn_8_BDB4C(void* arg0, s32 arg1)
@@ -505,24 +509,28 @@ void fn_8_BDB4C(void* arg0, s32 arg1)
 
 void fn_8_BDC5C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
 }
 
 void fn_8_BDC7C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x29;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x29;
 }
 
 void fn_8_BDC9C(void* arg0, s32 arg1)

--- a/src/rel/e_wall_stage11.cpp
+++ b/src/rel/e_wall_stage11.cpp
@@ -625,13 +625,15 @@ void fn_8_B7608(void* arg0, s32 arg1)
 
 void fn_8_B76FC(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x25;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x25;
 }
 
 void fn_8_B771C(void* arg0, s32 arg1)
@@ -678,24 +680,28 @@ void fn_8_B77D4(void* arg0, s32 arg1)
 
 void fn_8_B788C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x20;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x20;
 }
 
 void fn_8_B78AC(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 0x1D;
 }
 
 void fn_8_B78CC(void* arg0, s32 arg1)
@@ -776,24 +782,28 @@ void fn_8_B7AA4(void* arg0, s32 arg1)
 
 void fn_8_B7B5C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 7;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 7;
 }
 
 void fn_8_B7B7C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0x10) = 2;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0x10) = 2;
 }
 
 void fn_8_B7B9C(void* arg0, s32 arg1)
@@ -2240,13 +2250,15 @@ void fn_8_BA3A4(TObject* arg0)
 
 void fn_8_BA8C0(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0xD4) = 8;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0xD4) = 8;
 }
 
 void fn_8_BA8E0(TObject* arg0, s32 arg1)
@@ -2765,13 +2777,15 @@ void fn_8_BB5E4(TObject* arg0, s32 arg1)
 
 void fn_8_BB99C(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0xD4) = 0xB;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0xD4) = 0xB;
 }
 
 void fn_8_BB9BC(void* arg0, s32 arg1)
@@ -2796,24 +2810,28 @@ void fn_8_BB9BC(void* arg0, s32 arg1)
 
 void fn_8_BBA90(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0xD4) = 1;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0xD4) = 1;
 }
 
 void fn_8_BBAB0(void* arg0, s32 arg1)
 {
-	if (arg1 != 0) {
-		if (arg1 >= 0) {
-			return;
-		}
-		return;
+	switch (arg1) {
+		case 0:
+			M2C_FIELD(arg0, s32*, 0xD4) = 0;
+			break;
+		case 1:
+		case 2:
+		case 3:
+			break;
 	}
-	M2C_FIELD(arg0, s32*, 0xD4) = 0;
 }
 
 void fn_8_BBAD0(void* arg0, u32 arg1, s32 arg2)


### PR DESCRIPTION
The stage11 sources returned to `NonMatching` by #470 are m2c output, so their
control flow transcribes retail's branches instead of reproducing the source
that produced them. Thirty-eight sites across seven units share one wrong
transcription, and it costs one instruction each.

m2c wrote:

```c
if (arg1 != 0) {
    if (arg1 >= 0) {
        return;
    }
    return;
}
/* body */
```

Both `return`s are the same return, so nothing in that C asks the compiler for
the compare retail has. The original is a switch whose other labels have empty
bodies:

```c
switch (arg1) {
case 0:
    /* body */
    break;
case 1:
case 2:
case 3:
    break;
}
```

mwcc lowers a small dense switch as an equality test on the first label,
`bltlr` for anything below the range, then a compare against one past the
largest label whose result is discarded because both edges return. That
discarded compare is the instruction the `if` chain never produces:

```
  cmpwi r4, 0x0        cmpwi r4, 0x0
  beq   body           beq   body
  bltlr                bgelr
  cmpwi r4, 0x4        <missing>
  blr                  blr
```

The immediate says how many labels the original had — `cmpwi rX, 0x4` means
labels 0 through 3. It was read out of each target function rather than
assumed; all thirty-eight came back with the same bound, which is what makes a
mechanical conversion safe here.

## Measured

Instructions left against the dtk target, relocated fields masked:

| unit | before | after | closed |
| --- | ---: | ---: | ---: |
| `rel/e_flyer_path_stage11` | 96 | 92 | 4 |
| `rel/e_strategy_rinoliner_stage11` | 156 | 151 | 5 |
| `rel/e_rinoliner_collision_stage11` | 281 | 276 | 5 |
| `rel/e_strategy_flyer_stage11` | 341 | 334 | 7 |
| `rel/e_wall_stage11` | 470 | 461 | 9 |
| `rel/e_turtle_stage11` | 623 | 617 | 6 |
| `rel/e_flyer_stage11` | 649 | 641 | 8 |
| **total** | **2616** | **2572** | **44** |

Every one of the thirty-eight functions is byte-exact now. All seven units stay
`NonMatching`; the rest of each unit is untouched.

`docs/units-returned-to-nonmatching.md` gets the new row values and a section
describing the idiom, since reading the bound out of the target is the part
that does not generalise by itself.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```

Project measure: 9.28% -> 9.29% fuzzy, 7.44% -> 7.45% matched.
