### PR TITLE
decomp: adopt parameter lists without the return type

### DIFF
--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -178,12 +178,27 @@ That adopted 106 declarations, of which 100 held. It moved six units — up to
 +2.38% on `rel/e_strategy_magician_stage11` — and took the spurious `crclr`
 count from 241 to 228.
 
-Six files had to be reverted because an adopted return type or parameter
-conflicts with how m2c uses the result there:
-`rel/e_flyer_path_stage11`, `rel/e_magician_stage11`,
-`rel/o_colli_communication_stage11`, `rel/e_rinoliner_stage11`,
-`rel/e_turtle_stage11` and `rel/e_wall_stage11`. Each needs its call sites read
-against the target rather than a wider rule.
+Six files had to be reverted at that step. Most of it was the *return* type:
+m2c's `TObject*` is assigned to a `TObject*` in the file, and a canonicalised
+`void*` does not convert back implicitly in C++. The return type never affects
+whether mwcc emits `crclr` — only the ellipsis does — so adopting the parameter
+list alone and keeping m2c's return recovers `rel/e_magician_stage11` (+1.86%)
+and `rel/e_turtle_stage11` (+0.16%).
+
+Four are still out, for two different reasons. `rel/o_colli_communication_stage11`
+and `rel/e_rinoliner_stage11` do not compile even with the parameters alone.
+`rel/e_flyer_path_stage11` (-0.17%) and `rel/e_wall_stage11` (-0.07%) compile
+and measure *worse*, which means an adopted parameter is wrong for the call
+sites in those files.
+
+`rel/e_wall_stage11` is the case to study, because its 39 `crclr` come from
+eight callees and **not one of them has a consistent call arity inside the
+file**: `fn_80018A34` is called with two, three and four arguments;
+`fn_8019E8EC` with none, one and two; `fn_8019ED68` with four, five and six.
+m2c guessed a different shape at each site because it believed the function was
+variadic. There is no rule that resolves that — each call site has to be read
+against the target's register setup. Attribute them by scanning our `.text` for
+`0x4CC63242` and taking the symbol of the next `bl`.
 
 Beyond that, deriving the rest is not purely mechanical, and it is worth
 knowing why before someone tries. Two obstacles came up:

--- a/src/rel/e_magician_stage11.cpp
+++ b/src/rel/e_magician_stage11.cpp
@@ -141,70 +141,71 @@ typedef struct TEnemyParalysis {
 
 extern "C" {
 
-M2C_UNK SetPosAng__15TEnemyParalysisFPC5RwV3dPC6sAngle(...);               /* extern */
-M2C_UNK Vibrate__15TEnemyParalysisFP7RwFrame15RwOpCombineType(...);        /* extern */
-void* __ct__10HAnimClassFv(...);                                           /* extern */
-TEnemyParalysis* __ct__15TEnemyParalysisFP7TObjectP15sParalysisParam(...); /* extern */
-void* __dt__10HAnimClassFv(...);                                           /* extern */
-M2C_UNK fn_800189A4(...);                                                  /* extern */
-TEnemyParalysis* fn_80018A34(...);                                         /* extern */
-M2C_UNK fn_8003C200(...);                                                  /* extern */
-u32 fn_80057644(...);                                                      /* extern */
-s32 fn_8005B8D8(...);                                                      /* extern */
-M2C_UNK fn_8005BF5C(...);                                                  /* extern */
-M2C_UNK fn_8005D5C8(...);                                                  /* extern */
-s32 fn_8005D9A0(...);                                                      /* extern */
-M2C_UNK fn_8005D9F4(...);                                                  /* extern */
-M2C_UNK fn_8005E00C(...);                                                  /* extern */
-s32 fn_8005EA04(...);                                                      /* extern */
-M2C_UNK fn_8005FD8C(...);                                                  /* extern */
-void* fn_8006298C(...);                                                    /* extern */
-M2C_UNK fn_800A31B8(...);                                                  /* extern */
-M2C_UNK fn_800A4668(...);                                                  /* extern */
-M2C_UNK fn_800A4A8C(...);                                                  /* extern */
-s32 fn_800A5888(...);                                                      /* extern */
-s32 fn_800A5A54(...);                                                      /* extern */
-f32 fn_800A5AC0(...);                                                      /* extern */
-M2C_UNK fn_800A5B50(...);                                                  /* extern */
-M2C_UNK fn_800A5C6C(...);                                                  /* extern */
-M2C_UNK fn_800A7088(...);                                                  /* extern */
-M2C_UNK fn_800A714C(...);                                                  /* extern */
-s32 fn_800D7A94(...);                                                      /* extern */
-f32 fn_800D7B00(...);                                                      /* extern */
-f32 fn_800D8BC4(...);                                                      /* extern */
-M2C_UNK fn_800E1208(...);                                                  /* extern */
-u32 fn_800FD8A0(...);                                                      /* extern */
-M2C_UNK fn_800FE248(...);                                                  /* extern */
-M2C_UNK fn_800FE274(...);                                                  /* extern */
-u32 fn_80100280(...);                                                      /* extern */
-u32 fn_80100328(...);                                                      /* extern */
-u32 fn_8010037C(...);                                                      /* extern */
-M2C_UNK fn_801007F4(...);                                                  /* extern */
-M2C_UNK fn_8010096C(...);                                                  /* extern */
-M2C_UNK fn_80100AAC(...);                                                  /* extern */
-s32 fn_80103324(...);                                                      /* extern */
-M2C_UNK fn_8010AFE4(...);                                                  /* extern */
-s32 fn_8010B708(...);                                                      /* extern */
-void* fn_80150588(...);                                                    /* extern */
-M2C_UNK fn_80150958(...);                                                  /* extern */
-M2C_UNK fn_80195A74(...);                                                  /* extern */
-M2C_UNK fn_80196050(...);                                                  /* extern */
-M2C_UNK fn_801990E0(...);                                                  /* extern */
-M2C_UNK fn_8019941C(...);                                                  /* extern */
-void* fn_8019E8EC(...);                                                    /* extern */
-M2C_UNK fn_8019EB94(...);                                                  /* extern */
-M2C_UNK fn_8019EC30(...);                                                  /* extern */
-M2C_UNK fn_8019ED68(...);                                                  /* extern */
-s32 fn_801C28D8(...);                                                      /* extern */
-M2C_UNK fn_8_B0300(...);                                                   /* extern */
-u32 fn_8_B08F0(...);                                                       /* extern */
-void fn_8_AE604(TEnemyParalysis* arg0);                                    /* static */
-void fn_8_AEB80(TEnemyParalysis* arg0);                                    /* static */
-void fn_8_AEE04(TEnemyParalysis* arg0);                                    /* static */
-TEnemyParalysis* fn_8_AF05C(TEnemyParalysis* arg0, s16 arg1, s32 arg2);    /* static */
-void magicianObjectCreate();                                               /* static */
-void magicianObjectLoad();                                                 /* static */
-void magicianObjectUnload();                                               /* static */
+M2C_UNK SetPosAng__15TEnemyParalysisFPC5RwV3dPC6sAngle(void*, void*, void*);      /* extern */
+M2C_UNK Vibrate__15TEnemyParalysisFP7RwFrame15RwOpCombineType(void*, void*, s32); /* extern */
+void* __ct__10HAnimClassFv(void*);                                                /* extern */
+TEnemyParalysis* __ct__15TEnemyParalysisFP7TObjectP15sParalysisParam(
+    void*, void*, void*);                                               /* extern */
+void* __dt__10HAnimClassFv(...);                                        /* extern */
+M2C_UNK fn_800189A4(...);                                               /* extern */
+TEnemyParalysis* fn_80018A34(...);                                      /* extern */
+M2C_UNK fn_8003C200(...);                                               /* extern */
+u32 fn_80057644(...);                                                   /* extern */
+s32 fn_8005B8D8(void*);                                                 /* extern */
+M2C_UNK fn_8005BF5C(...);                                               /* extern */
+M2C_UNK fn_8005D5C8(...);                                               /* extern */
+s32 fn_8005D9A0(...);                                                   /* extern */
+M2C_UNK fn_8005D9F4(void*);                                             /* extern */
+M2C_UNK fn_8005E00C(...);                                               /* extern */
+s32 fn_8005EA04(void*);                                                 /* extern */
+M2C_UNK fn_8005FD8C(...);                                               /* extern */
+void* fn_8006298C(...);                                                 /* extern */
+M2C_UNK fn_800A31B8(...);                                               /* extern */
+M2C_UNK fn_800A4668(void*);                                             /* extern */
+M2C_UNK fn_800A4A8C(...);                                               /* extern */
+s32 fn_800A5888(void*, void*, f32);                                     /* extern */
+s32 fn_800A5A54(void*);                                                 /* extern */
+f32 fn_800A5AC0(...);                                                   /* extern */
+M2C_UNK fn_800A5B50(void*, s32);                                        /* extern */
+M2C_UNK fn_800A5C6C(void*, s32);                                        /* extern */
+M2C_UNK fn_800A7088(...);                                               /* extern */
+M2C_UNK fn_800A714C(...);                                               /* extern */
+s32 fn_800D7A94(s32, s32, s32);                                         /* extern */
+f32 fn_800D7B00(s32);                                                   /* extern */
+f32 fn_800D8BC4(void*, void*, s32);                                     /* extern */
+M2C_UNK fn_800E1208(...);                                               /* extern */
+u32 fn_800FD8A0(...);                                                   /* extern */
+M2C_UNK fn_800FE248(s32, void*);                                        /* extern */
+M2C_UNK fn_800FE274(s32, void*);                                        /* extern */
+u32 fn_80100280(s32, s32, s32);                                         /* extern */
+u32 fn_80100328(s32, s32, s32);                                         /* extern */
+u32 fn_8010037C(s32, s32, s32);                                         /* extern */
+M2C_UNK fn_801007F4(s32, s32);                                          /* extern */
+M2C_UNK fn_8010096C(s32, s32, void*);                                   /* extern */
+M2C_UNK fn_80100AAC(void);                                              /* extern */
+s32 fn_80103324(void*, void*, f32);                                     /* extern */
+M2C_UNK fn_8010AFE4(...);                                               /* extern */
+s32 fn_8010B708(s32);                                                   /* extern */
+void* fn_80150588(...);                                                 /* extern */
+M2C_UNK fn_80150958(...);                                               /* extern */
+M2C_UNK fn_80195A74(...);                                               /* extern */
+M2C_UNK fn_80196050(...);                                               /* extern */
+M2C_UNK fn_801990E0(...);                                               /* extern */
+M2C_UNK fn_8019941C(...);                                               /* extern */
+void* fn_8019E8EC(...);                                                 /* extern */
+M2C_UNK fn_8019EB94(...);                                               /* extern */
+M2C_UNK fn_8019EC30(...);                                               /* extern */
+M2C_UNK fn_8019ED68(...);                                               /* extern */
+s32 fn_801C28D8(...);                                                   /* extern */
+M2C_UNK fn_8_B0300(...);                                                /* extern */
+u32 fn_8_B08F0(...);                                                    /* extern */
+void fn_8_AE604(TEnemyParalysis* arg0);                                 /* static */
+void fn_8_AEB80(TEnemyParalysis* arg0);                                 /* static */
+void fn_8_AEE04(TEnemyParalysis* arg0);                                 /* static */
+TEnemyParalysis* fn_8_AF05C(TEnemyParalysis* arg0, s16 arg1, s32 arg2); /* static */
+void magicianObjectCreate();                                            /* static */
+void magicianObjectLoad();                                              /* static */
+void magicianObjectUnload();                                            /* static */
 extern M2C_UNK lbl_80239978;
 extern M2C_UNK lbl_80239984;
 extern M2C_UNK lbl_80239990;

--- a/src/rel/e_turtle_stage11.cpp
+++ b/src/rel/e_turtle_stage11.cpp
@@ -182,11 +182,12 @@ typedef struct TObject {
 
 extern "C" {
 
-M2C_UNK SetPosAng__15TEnemyParalysisFPC5RwV3dPC6sAngle(...);                     /* extern */
-s32 SetPosition__18TObjEffTornadoSpinFv(...);                                    /* extern */
-M2C_UNK Vibrate__15TEnemyParalysisFP7RwFrame15RwOpCombineType(...);              /* extern */
-void* __ct__10HAnimClassFv(...);                                                 /* extern */
-TEnemyParalysis* __ct__15TEnemyParalysisFP7TObjectP15sParalysisParam(...);       /* extern */
+M2C_UNK SetPosAng__15TEnemyParalysisFPC5RwV3dPC6sAngle(void*, void*, void*);      /* extern */
+s32 SetPosition__18TObjEffTornadoSpinFv(void*);                                   /* extern */
+M2C_UNK Vibrate__15TEnemyParalysisFP7RwFrame15RwOpCombineType(void*, void*, s32); /* extern */
+void* __ct__10HAnimClassFv(void*);                                                /* extern */
+TEnemyParalysis* __ct__15TEnemyParalysisFP7TObjectP15sParalysisParam(
+    void*, void*, void*);                                                        /* extern */
 void* __ct__15sParalysisParamFv(...);                                            /* extern */
 M2C_UNK __dl__FPv(void* arg0);                                                   /* extern */
 void* __dt__10HAnimClassFv(...);                                                 /* extern */


### PR DESCRIPTION
#475 reverted six files whole. Most of what they choked on was the *return*
type, not the parameters:

```
illegal implicit conversion from 'void *' to 'TObject *'
```

m2c's `TObject*` return is assigned to a `TObject*` in the file, and the
canonicalised `void*` does not convert back implicitly in C++. The return type
never affects whether mwcc emits `crclr` — only the ellipsis does — so there is
no reason to touch it. Adopting the parameter list alone and keeping m2c's
return recovers two of the six.

## Measured

| unit | fuzzy |
| --- | ---: |
| `rel/e_magician_stage11` | +1.86 |
| `rel/e_turtle_stage11` | +0.16 |

No regressions. Spurious `crclr` across the eighteen affected units: 228 -> 224.
Both units stay `NonMatching`.

## The other four, and why they are not a rule

`rel/o_colli_communication_stage11` and `rel/e_rinoliner_stage11` still do not
compile with the parameters alone. `rel/e_flyer_path_stage11` (-0.17%) and
`rel/e_wall_stage11` (-0.07%) compile and measure worse, so an adopted
parameter is wrong for the call sites there.

`rel/e_wall_stage11` shows why no wider rule reaches these. Its 39 `crclr` come
from eight callees, and not one of them has a consistent call arity inside the
file:

| callee | crclr | arities in the file |
| --- | ---: | --- |
| `fn_8019ED68` | 16 | 4, 5, 6 |
| `fn_8019E8EC` | 8 | 0, 1, 2 |
| `fn_800D8BC4` | 5 | 3, 4 |
| `fn_8010B208` | 5 | 1, 2, 4 |
| `fn_800D7B00` | 2 | 1, 2 |

m2c guessed a different shape at each site because it believed the function was
variadic. Each site has to be read against the target's register setup; there
is nothing to derive from the file itself. Attribute them by scanning our
`.text` for the word `0x4CC63242` and taking the symbol of the next `bl`.
Recorded in `docs/units-returned-to-nonmatching.md`.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
