### PR TITLE
decomp: recover a lost argument in the stage11 tree unit

### DIFF
--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -39,7 +39,7 @@ decide whether a change helped with `build/G9SE8P/report.json`.
 
 | unit | left | registers | other | length | size | previous |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `rel/e_tree_stage11` | 36 | 1 | 0 | 35 | 935 | 36 |
+| `rel/e_tree_stage11` | 32 | 0 | 0 | 32 | 935 | 36 |
 | `game/cri/axrna` | 48 | 20 | 11 | 17 | 1541 | 48 |
 | `game/cri/svm` | 50 | 0 | 24 | 26 | 1115 | 50 |
 | `rel/e_capture_collision_stage11` | 51 | 8 | 20 | 23 | 401 | 51 |
@@ -222,11 +222,26 @@ knowing why before someone tries. Two obstacles came up:
   has to be settled against the target's register setup at the call site rather
   than by majority.
 
+**A `(...)` extern can hide a lost argument.** m2c cannot see an argument that
+was already in the right register. `fn_8_C4B58` in `rel/e_tree_stage11` calls
+`fn_8013F484` right after `mr r30, r3`, so r3 still holds the function's own
+first parameter and m2c wrote `fn_8013F484()` — no arguments at all. Give the
+extern its prototype and the compiler names the omission for you:
+
+```
+function call 'fn_8013F484()' does not match 'fn_8013F484(int)'
+```
+
+Three functions in that unit went byte-exact from this plus one wrong
+parameter: `fn_8_C4BBC` read `arg1` while the target reads r4, meaning the
+function takes two parameters and uses the second. 84.32% to 84.65%, and the
+unit's remaining 32 are now all length.
+
 ## Where to start
 
 The six closest are within sixty instructions:
 
-- `rel/e_tree_stage11` (36; 1 register, 35 length)
+- `rel/e_tree_stage11` (32, all length)
 - `game/cri/axrna` (48; 20 registers, 11 other, 17 length)
 - `game/cri/svm` (50; 24 other, 26 length)
 - `rel/e_capture_collision_stage11` (51; 8 registers, 20 other, 23 length)

--- a/src/rel/e_tree_stage11.cpp
+++ b/src/rel/e_tree_stage11.cpp
@@ -59,7 +59,7 @@ M2C_UNK fn_800BC9F4(s32, M2C_UNK*);                                /* extern */
 f32 fn_800D7AE4(s32);                                              /* extern */
 f32 fn_800D7B00(s32);                                              /* extern */
 M2C_UNK fn_8013F3A4(void*);                                        /* extern */
-void* fn_8013F484(...);                                            /* extern */
+void* fn_8013F484(s32);                                            /* extern */
 M2C_UNK fn_8013FC30(void*);                                        /* extern */
 M2C_UNK fn_8014FFBC(void*, void* (*)(void*, s32), void*);          /* extern */
 s32 fn_80150588(u32);                                              /* extern */
@@ -483,7 +483,7 @@ s32 fn_8_C4B58(s32 arg0, void** arg1)
 {
 	void* temp_r3;
 
-	temp_r3 = fn_8013F484();
+	temp_r3 = fn_8013F484(arg0);
 	if (temp_r3 == NULL) {
 		fn_8019EB10(arg0, fn_8_C4B58, arg1);
 		return arg0;
@@ -492,7 +492,7 @@ s32 fn_8_C4B58(s32 arg0, void** arg1)
 	return 0;
 }
 
-void fn_8_C4BBC(void* arg1)
+void fn_8_C4BBC(void* arg0, void* arg1)
 {
 	void* temp_r3;
 


### PR DESCRIPTION
`rel/e_tree_stage11` is the closest unit on the roadmap. Three of its functions
were one instruction from exact, for two related reasons.

**A `(...)` extern can hide a lost argument.** m2c cannot see an argument that
was already sitting in the right register. `fn_8_C4B58` calls `fn_8013F484`
immediately after `mr r30, r3`, so r3 still holds the function's own first
parameter, and m2c wrote the call with no arguments at all:

```c
void* fn_8013F484(...);          /* extern */
temp_r3 = fn_8013F484();
```

Giving the extern the prototype the rest of the tree already states makes the
compiler name the omission:

```
function call 'fn_8013F484()' does not match 'fn_8013F484(int)'
```

`fn_8013F484(arg0)` is the call, and the spurious `crclr cr1eq` before it goes
away in `fn_8_C4AFC` and `fn_8_C4B58` at the same time.

**`fn_8_C4BBC` was reading the wrong parameter.** The target loads from r4:

```
  lwz r3, 0x2c(r4)        |  lwz r3, 0x2c(r3)
```

m2c gave the function one parameter and read it. It takes two and uses the
second; the body is unchanged.

## Measured

`rel/e_tree_stage11` 84.32% -> 84.65% fuzzy, `matched_code` 268 -> 552 of 3740.
Three functions byte-exact. `left` on the roadmap goes 36 -> 32, and all 32 are
now length gaps — no wrong instruction and no wrong register remains in the
unit.

The next one, `fn_8_C4474`, is not this kind of fix: the target saves one fewer
register (`_savegpr_27` against `_savegpr_26`) and stores the same float into
three stack slots where this build uses one, so its source has three locals
where m2c wrote one. Left for a reconstruction pass.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
