### PR TITLE
decomp: recover dropped call arguments in capture and turtle

### DIFF
--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -237,6 +237,16 @@ parameter: `fn_8_C4BBC` read `arg1` while the target reads r4, meaning the
 function takes two parameters and uses the second. 84.32% to 84.65%, and the
 unit's remaining 32 are now all length.
 
+Swept tree-wide, this is smaller than it looks. Of the 322 ellipsis externs,
+only 14 sit in a file where the tree agrees on an arity *and* every call site
+has fewer arguments than that — the shape where a dropped argument is the
+explanation. Filling those from the enclosing function's own parameters, in
+order, holds in two units and breaks in eight, which is the right ratio to
+expect: the register the call reads is not always the enclosing function's
+parameter, and where it is not, the fill has to come from the target. The two
+that held are `rel/e_capture` (`fn_800A5A54`, `fn_8014FF2C`; +124 bytes of
+matched code) and `rel/e_turtle_stage11` (`fn_80017800`; +124 bytes).
+
 ## Where to start
 
 The six closest are within sixty instructions:

--- a/src/rel/e_capture.cpp
+++ b/src/rel/e_capture.cpp
@@ -225,7 +225,7 @@ M2C_UNK fn_800A4668(void*);                                       /* extern */
 M2C_UNK fn_800A4A8C(void*, f32);                                  /* extern */
 s32 fn_800A5844(s32);                                             /* extern */
 s32 fn_800A5888(void*, f32*, f32);                                /* extern */
-s32 fn_800A5A54(...);                                             /* extern */
+s32 fn_800A5A54(void*);                                           /* extern */
 f32 fn_800A5AC0(...);                                             /* extern */
 M2C_UNK fn_800A5B34(TObject*);                                    /* extern */
 M2C_UNK fn_800A5B50(void*, M2C_UNK);                              /* extern */
@@ -275,7 +275,7 @@ u32 fn_8011B5A8(RwFrame*, M2C_UNK);                               /* extern */
 M2C_UNK fn_8011C188(u32, s32);                                    /* extern */
 M2C_UNK fn_8011C1F8(u32, s32, M2C_UNK);                           /* extern */
 M2C_UNK fn_8011C6EC();                                            /* extern */
-M2C_UNK fn_8014FF2C(...);                                         /* extern */
+M2C_UNK fn_8014FF2C(void*);                                       /* extern */
 void* fn_80150588(s32);                                           /* extern */
 M2C_UNK fn_80150958();                                            /* extern */
 M2C_UNK fn_80195A74(M2C_UNK*, M2C_UNK*, M2C_UNK, f32, f32, f32);  /* extern */
@@ -860,7 +860,7 @@ s32 fn_8_98C34(void* arg0, f32 farg0, f32 farg1)
 		return 1;
 	}
 	if (temp_cr0_eq == 0) {
-		temp_r31                     = fn_800A5A54();
+		temp_r31                     = fn_800A5A54(arg0);
 		M2C_FIELD(arg0, s32*, 0x150) = fn_800D7A94(M2C_FIELD(arg0, s32*, 0x150),
 		    M2C_FIELD(arg0, s32*, 0x174), M2C_FIELD(arg0, s32*, 0x180));
 		if (temp_r31 < 0x80) {
@@ -940,7 +940,7 @@ s32 fn_8_98F30(void* arg0)
 	if ((s32)M2C_FIELD(arg0, s32*, 0x574) == 0) {
 		return 0;
 	}
-	temp_r31                     = fn_800A5A54();
+	temp_r31                     = fn_800A5A54(arg0);
 	M2C_FIELD(arg0, s32*, 0x150) = fn_800D7A94(
 	    M2C_FIELD(arg0, s32*, 0x150), M2C_FIELD(arg0, s32*, 0x174), M2C_FIELD(arg0, s32*, 0x180));
 	if (temp_r31 < 0x80) {
@@ -1025,13 +1025,13 @@ void fn_8_990C4(void* arg0, M2C_UNK arg_sp0)
 			var_r29 += 1;
 		} while (var_r29 < 8);
 		if ((u32)M2C_FIELD(arg0, u32*, 0x2D8) != 0U) {
-			fn_8014FF2C();
+			fn_8014FF2C(arg0);
 		}
 		if ((u32)M2C_FIELD(arg0, u32*, 0x2DC) != 0U) {
-			fn_8014FF2C();
+			fn_8014FF2C(arg0);
 		}
 		if ((u32)M2C_FIELD(arg0, u32*, 0x2E0) != 0U) {
-			fn_8014FF2C();
+			fn_8014FF2C(arg0);
 		}
 		temp_r28  = M2C_FIELD(M2C_FIELD(arg0, void**, 0x2E4), RwFrame**, 4);
 		var_r27   = 0;
@@ -1071,7 +1071,7 @@ void fn_8_99254(void* arg0)
 	fn_80113874();
 	fn_8014FF2C(M2C_FIELD(arg0, void**, 0xE8));
 	if ((u32)M2C_FIELD(arg0, u32*, 0x2E8) != 0U) {
-		fn_8014FF2C();
+		fn_8014FF2C(arg0);
 	}
 }
 
@@ -1280,7 +1280,7 @@ void fn_8_99800(void* arg0, s32 arg1)
 				if ((s32)M2C_FIELD(arg0, s32*, 0x574) == 0) {
 					var_r0 = 0;
 				} else {
-					temp_r30                     = fn_800A5A54();
+					temp_r30                     = fn_800A5A54(arg0);
 					M2C_FIELD(arg0, s32*, 0x150) = fn_800D7A94(M2C_FIELD(arg0, s32*, 0x150),
 					    M2C_FIELD(arg0, s32*, 0x174), M2C_FIELD(arg0, s32*, 0x180));
 					if (temp_r30 < 0x80) {
@@ -1791,7 +1791,7 @@ void fn_8_9A710(void* arg0, s32 arg1)
 			if ((s32)M2C_FIELD(arg0, s32*, 0x574) == 0) {
 
 			} else {
-				temp_r30                     = fn_800A5A54();
+				temp_r30                     = fn_800A5A54(arg0);
 				M2C_FIELD(arg0, s32*, 0x150) = fn_800D7A94(M2C_FIELD(arg0, s32*, 0x150),
 				    M2C_FIELD(arg0, s32*, 0x174), M2C_FIELD(arg0, s32*, 0x180));
 				if (temp_r30 < 0x80) {
@@ -2258,7 +2258,7 @@ void fn_8_9AB68(void* arg0, u32 arg1, s32 arg2)
 						if ((s32)M2C_FIELD(arg0, s32*, 0x574) == 0) {
 							var_r0 = 0;
 						} else {
-							temp_r30_3                   = fn_800A5A54();
+							temp_r30_3                   = fn_800A5A54(arg0);
 							M2C_FIELD(arg0, s32*, 0x150) = fn_800D7A94(M2C_FIELD(arg0, s32*, 0x150),
 							    M2C_FIELD(arg0, s32*, 0x174), M2C_FIELD(arg0, s32*, 0x180));
 							if (temp_r30_3 < 0x80) {

--- a/src/rel/e_turtle_stage11.cpp
+++ b/src/rel/e_turtle_stage11.cpp
@@ -193,7 +193,7 @@ M2C_UNK __dl__FPv(void* arg0);                                                  
 void* __dt__10HAnimClassFv(...);                                                 /* extern */
 M2C_UNK __register_global_object(M2C_UNK*, M2C_UNK*);                            /* extern */
 M2C_UNK dtor_800FE334(M2C_UNK);                                                  /* extern */
-s32 fn_80017800(...);                                                            /* extern */
+s32 fn_80017800(void*);                                                          /* extern */
 M2C_UNK fn_800189A4(s32, void*);                                                 /* extern */
 TEnemyParalysis* fn_80018A34(s32, ...);                                          /* extern */
 u32 fn_800207C4(M2C_UNK*, M2C_UNK, M2C_UNK);                                     /* extern */
@@ -230,7 +230,7 @@ M2C_UNK fn_800A4668(void*);                                                     
 M2C_UNK fn_800A4A8C(void*, M2C_UNK*, f32);                                       /* extern */
 s32 fn_800A5888(void*, M2C_UNK*, f32);                                           /* extern */
 s32 fn_800A5998(void*);                                                          /* extern */
-s32 fn_800A5A54(...);                                                            /* extern */
+s32 fn_800A5A54(void*);                                                          /* extern */
 f32 fn_800A5AC0();                                                               /* extern */
 M2C_UNK fn_800A5B34(TObject*);                                                   /* extern */
 M2C_UNK fn_800A5B50(void*, M2C_UNK);                                             /* extern */
@@ -1413,7 +1413,7 @@ s32 fn_8_BF684(void* arg0)
 	if ((s32)M2C_FIELD(arg0, s32*, 0x2F0) == 0) {
 		return 0;
 	}
-	temp_r31                     = fn_800A5A54();
+	temp_r31                     = fn_800A5A54(arg0);
 	M2C_FIELD(arg0, s32*, 0x150) = fn_800D7A94(
 	    M2C_FIELD(arg0, s32*, 0x150), M2C_FIELD(arg0, s32*, 0x174), M2C_FIELD(arg0, s32*, 0x180));
 	if (temp_r31 < 0x10) {
@@ -1736,7 +1736,7 @@ void fn_8_BFF94(void* arg0, s32 arg1)
 			return;
 		case 1:
 			if ((void*)M2C_FIELD(arg0, void**, 0x2EC) != NULL) {
-				if (fn_80017800() == 0) {
+				if (fn_80017800(arg0) == 0) {
 					M2C_FIELD(arg0, void**, 0x2EC) = NULL;
 					return;
 				}
@@ -2041,7 +2041,7 @@ void fn_8_C08C8(void* arg0, s32 arg1)
 			if ((s32)M2C_FIELD(arg0, s32*, 0x2F0) == 0) {
 
 			} else {
-				temp_r31                     = fn_800A5A54();
+				temp_r31                     = fn_800A5A54(arg0);
 				M2C_FIELD(arg0, s32*, 0x150) = fn_800D7A94(M2C_FIELD(arg0, s32*, 0x150),
 				    M2C_FIELD(arg0, s32*, 0x174), M2C_FIELD(arg0, s32*, 0x180));
 				if (temp_r31 < 0x10) {


### PR DESCRIPTION
Follow-on to #478, which found that a `(...)` extern can hide an argument m2c
never saw: the value was already in the right register when the call was
reached, so m2c wrote the call short. Giving the extern the prototype the tree
already states turns each of those into a compiler error naming the site.

Swept tree-wide, and the honest result is that this is a small shape, not a
sweep. Of the 322 ellipsis externs, only **14** sit in a file where the tree
agrees on an arity *and* every call site has fewer arguments than that. Filling
those from the enclosing function's own parameters, in order, held in two units
and broke in eight — which is the ratio to expect, because the register the
call reads is not always the enclosing function's parameter. Where it is not,
the value has to come from the target, one site at a time.

The two that held:

```c
s32     fn_800A5A54(void*);   /* was (...) */
M2C_UNK fn_8014FF2C(void*);   /* was (...) */
s32     fn_80017800(void*);   /* was (...) */

temp_r31 = fn_800A5A54();     ->  fn_800A5A54(arg0)
fn_8014FF2C();                ->  fn_8014FF2C(arg0)
```

## Measured

| unit | fuzzy | matched code |
| --- | ---: | ---: |
| `rel/e_capture` | 79.88 -> 80.04 | +124 |
| `rel/e_turtle_stage11` | 82.79 -> 82.77 | +124 |

`rel/e_turtle_stage11` is worth stating plainly: its fuzzy percentage moved
-0.02 while 124 more bytes of code became byte-exact. Recovered arguments make
previously-hidden differences visible in the functions around them, the same
effect #477 documented for the `left` column. `matched_code` is the measure
that only moves for real, so the change stays.

`rel/e_s12bone_stage11` also compiled clean with eight prototypes adopted and
measured nothing at all — those eight are declared and never called, so the
change is cosmetic. Dropped rather than landed.

Both units stay `NonMatching`.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
