### PR TITLE
decomp: name the capture collision record data and stop the flag fold

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1661,7 +1661,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_capture_collision_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
             ),
             Object(
                 NonMatching,

--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -42,7 +42,7 @@ decide whether a change helped with `build/G9SE8P/report.json`.
 | `rel/e_tree_stage11` | 32 | 0 | 0 | 32 | 935 | 36 |
 | `game/cri/axrna` | 48 | 20 | 11 | 17 | 1541 | 48 |
 | `game/cri/svm` | 50 | 0 | 24 | 26 | 1115 | 50 |
-| `rel/e_capture_collision_stage11` | 51 | 8 | 20 | 23 | 401 | 51 |
+| `rel/e_capture_collision_stage11` | 63 | 21 | 20 | 22 | 401 | 51 |
 | `rel/e_fan_stage11` | 54 | 14 | 18 | 22 | 518 | 54 |
 | `game/cri/rnares` | 55 | 0 | 0 | 55 | 251 | 55 |
 | `rel/e_grass2_stage11` | 61 | 15 | 7 | 39 | 1092 | 49 |
@@ -247,6 +247,27 @@ parameter, and where it is not, the fill has to come from the target. The two
 that held are `rel/e_capture` (`fn_800A5A54`, `fn_8014FF2C`; +124 bytes of
 matched code) and `rel/e_turtle_stage11` (`fn_80017800`; +124 bytes).
 
+**An inline string literal is a named object in retail.** m2c writes the
+literal at the use site, so mwcc emits an anonymous `@107`, and the register
+function reads `lis r3, @107@ha` where retail reads
+`lis r3, captureCollisionDisplayName@ha`. Declare the object with the name the
+target gives it — objdiff pairs data by symbol name, so the literal has to
+become a named `static const char[]` before either side can match.
+
+**A constant that retail ORs, we add.** `captureCollisionRegister` sets a flag
+word to `0x20000`, then `| 8` on one path and `& ~8` on the other. With
+propagation on, mwcc knows bit 3 is clear and folds both: `addi r0, r5, 0x8`
+for the first and nothing at all for the second, so the whole else-branch
+disappears. `-opt nopropagation` on the unit restores `ori` and `rlwinm`, and
+the function becomes structurally exact — every instruction in the right place,
+differing only in whether the entry pointer lives in r5 or r6.
+
+That register swap is the reason this unit's `left` **rose** from 51 to 63 while
+its objdiff percentage went from 93.85% to 94.00%. Twenty-one register
+differences are now visible in a function that previously had the wrong
+instructions to compare. It is the same effect the column warning above
+describes.
+
 ## Where to start
 
 The six closest are within sixty instructions:
@@ -254,7 +275,7 @@ The six closest are within sixty instructions:
 - `rel/e_tree_stage11` (32, all length)
 - `game/cri/axrna` (48; 20 registers, 11 other, 17 length)
 - `game/cri/svm` (50; 24 other, 26 length)
-- `rel/e_capture_collision_stage11` (51; 8 registers, 20 other, 23 length)
+- `rel/e_capture_collision_stage11` (63; 21 registers, 20 other, 22 length — the registers grew because the instructions around them became right, see below)
 - `rel/e_fan_stage11` (54; 14 registers, 18 other, 22 length)
 - `game/cri/rnares` (55, all length)
 

--- a/src/rel/e_capture_collision_stage11.cpp
+++ b/src/rel/e_capture_collision_stage11.cpp
@@ -41,9 +41,9 @@ static s32 lbl_8_data_159F4 = 0;
 static s32 lbl_8_data_159F8 = 0xFF;
 static M2C_UNK lbl_8_data_159FC; /* unable to generate initializer: unknown type */
 static const char* lbl_8_data_15A14 = "TObjCaptureCollision";
-static M2C_UNK lbl_8_data_15A18;            /* unable to generate initializer: unknown type */
-static M2C_UNK captureCollisionDisplayName; /* unable to generate initializer: unknown type */
-static M2C_UNK captureCollisionFieldTypes;  /* unable to generate initializer: unknown type */
+static M2C_UNK lbl_8_data_15A18; /* unable to generate initializer: unknown type */
+static const char captureCollisionDisplayName[] = "CAPTURE COLLISION";
+static const char captureCollisionFieldTypes[]  = "i";
 static M2C_UNK captureCollisionEntry;
 
 extern "C" {
@@ -206,7 +206,7 @@ TObject* fn_8_9D724(void)
 	return temp_r3;
 }
 
-void fn_8_9D81C(void* arg1)
+void fn_8_9D81C(void* arg0, void* arg1)
 {
 	s32* temp_r5;
 	s32* var_r3;
@@ -266,27 +266,29 @@ void captureCollisionCreate(void)
 void captureCollisionRegister(void)
 {
 	const char* temp_r3;
+	s32 flags;
 
 	M2C_FIELD(&captureCollisionEntry, s32*, 0x14)         = 0;
 	M2C_FIELD(&captureCollisionEntry, s32*, 0x18)         = 0;
-	M2C_FIELD(&captureCollisionEntry, const char**, 0)    = "CAPTURE COLLISION";
+	M2C_FIELD(&captureCollisionEntry, const char**, 0)    = captureCollisionDisplayName;
 	M2C_FIELD(&captureCollisionEntry, void (**)(), 4)     = captureCollisionLoad;
 	M2C_FIELD(&captureCollisionEntry, void (**)(), 8)     = captureCollisionUnload;
 	M2C_FIELD(&captureCollisionEntry, void (**)(), 0xC)   = captureCollisionCreate;
 	M2C_FIELD(&captureCollisionEntry, s32*, 0x10)         = 0;
-	M2C_FIELD(&captureCollisionEntry, s32*, 0x14)         = 0x20000;
+	flags                                                 = 0x20000;
+	M2C_FIELD(&captureCollisionEntry, s32*, 0x14)         = flags;
 	M2C_FIELD(&captureCollisionEntry, s32*, 0x18)         = 0;
 	M2C_FIELD(&captureCollisionEntry, s8*, 0x20)          = 0x1E;
 	M2C_FIELD(&captureCollisionEntry, s16*, 0x1C)         = 0x65;
 	M2C_FIELD(&captureCollisionEntry, s16*, 0x1E)         = 4;
 	M2C_FIELD(&captureCollisionEntry, s8*, 0x21)          = 0;
-	temp_r3                                               = "i";
+	temp_r3                                               = captureCollisionFieldTypes;
 	M2C_FIELD(&captureCollisionEntry, const char**, 0x24) = temp_r3;
 	M2C_FIELD(&captureCollisionEntry, M2C_UNK**, 0x28)    = &captureCollisionFieldNames;
 	if (temp_r3 != NULL) {
-		M2C_FIELD(&captureCollisionEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&captureCollisionEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&captureCollisionEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&captureCollisionEntry, s32*, 0x14) = flags & ~8;
 }
 }


### PR DESCRIPTION
`rel/e_capture_collision_stage11` is 401 instructions, the smallest unit near
the top of the roadmap. Three things were wrong in it, and two are shapes that
recur.

**An inline string literal is a named object in retail.** m2c writes the
literal at the use site, so mwcc emits an anonymous constant and the register
function reads `lis r3, @107@ha` where retail reads
`lis r3, captureCollisionDisplayName@ha`:

```c
M2C_FIELD(&captureCollisionEntry, const char**, 0) = "CAPTURE COLLISION";
temp_r3                                            = "i";
```

objdiff pairs data by symbol name, so the literals have to become named
objects before either side can match:

```c
static const char captureCollisionDisplayName[] = "CAPTURE COLLISION";
static const char captureCollisionFieldTypes[]  = "i";
```

**A constant retail ORs, we add.** The record's flag word is `0x20000`, then
`| 8` on one path and `& ~8` on the other. With propagation on, mwcc knows bit
3 is clear and folds both — `addi r0, r5, 0x8` for the first, and the second
vanishes entirely along with its store:

```
  ori    r0, r5, 0x8            |  addi r0, r5, 0x8
  rlwinm r0, r5, 0, 29, 27      |  <missing>
  stw    r0, 0x14(r6)           |  stw  r5, 0x14(r6)
```

`-opt nopropagation` on the unit restores both. `captureCollisionRegister` is
now structurally exact: every instruction in the right place, differing only in
whether the entry pointer lives in r5 or r6.

**`fn_8_9D81C` read the wrong parameter** — the target loads `0x2c(r4)`, so the
function takes two parameters and uses the second. Same shape as #478.

## Measured

`rel/e_capture_collision_stage11` 93.85% -> 94.00% fuzzy.

The roadmap `left` column **rises**, 51 to 63, and that is the honest reading:
21 register differences are now visible in a function that previously had the
wrong instructions to compare at all. Same effect the column's own warning
describes since #477. Unit stays `NonMatching`.

## What is left in the unit

- The r5/r6 swap in `captureCollisionRegister`. Reordering the local
  declarations does not move it — mwcc is not allocating in declaration order
  here.
- `fn_8_9D81C` still folds a `bge`/`b` pair into one `blt`, with
  `-opt nopeephole` already on, so the source shape is doing it rather than the
  peepholer.
- `.data` is 32 of 136 and `.bss` 20 of 56; the record's remaining fields are
  not declared yet.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
