### PR TITLE
decomp: apply the object record recipe to the stage11 fan unit

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2501,7 +2501,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_fan_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
             ),
             Object(
                 Matching,

--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -43,7 +43,7 @@ decide whether a change helped with `build/G9SE8P/report.json`.
 | `game/cri/axrna` | 48 | 20 | 11 | 17 | 1541 | 48 |
 | `game/cri/svm` | 50 | 0 | 24 | 26 | 1115 | 50 |
 | `rel/e_capture_collision_stage11` | 63 | 21 | 20 | 22 | 401 | 51 |
-| `rel/e_fan_stage11` | 54 | 14 | 18 | 22 | 518 | 54 |
+| `rel/e_fan_stage11` | 47 | 14 | 18 | 15 | 518 | 54 |
 | `game/cri/rnares` | 55 | 0 | 0 | 55 | 251 | 55 |
 | `rel/e_grass2_stage11` | 61 | 15 | 7 | 39 | 1092 | 49 |
 | `rel/e_flyer_path_stage11` | 84 | 0 | 0 | 84 | 2268 | 92 |
@@ -268,6 +268,36 @@ differences are now visible in a function that previously had the wrong
 instructions to compare. It is the same effect the column warning above
 describes.
 
+**The object record is a recipe, and it repeats per unit.** Every stage object
+has a `<name>ObjectRegister` that fills one record and ends with a flag test.
+m2c gets the same three things wrong in each of them, so the second unit costs
+a fraction of the first:
+
+1. *Inline literals instead of named objects.* `"CAPTURE COLLISION"` at the use
+   site becomes an anonymous `@107`; retail has `captureCollisionDisplayName`.
+   objdiff pairs data by symbol name, so the literal has to become a named
+   `static const char[]`.
+2. *Folded flag arithmetic.* The record's flag word is `0x20000`, then `| 8` or
+   `& ~8`. With propagation on, mwcc knows bit 3 is clear, turns the first into
+   `addi` and deletes the second branch entirely. Hoist the constant into a
+   local and put `-opt nopropagation` on the unit.
+3. *A folded-away test.* m2c writes `if (0U != 0U)` when the tested pointer was
+   a constant it could see; that removes the whole branch. Give the value a
+   local and the test comes back. Its **type** decides the compare: retail's
+   `cmplwi` is unsigned, so `u32`, not `s32`.
+
+`rel/e_fan_stage11` also had two more lost arguments of the #478 kind:
+`fn_8015BBF8` takes `(scene, mesh)` and m2c passed only the scene, and
+`fn_80150958()` was called with nothing where the value was already in r3.
+Both are named by the compiler once the extern loses its `(...)`.
+
+That took the unit from 94.51% to 95.90% and `left` from 54 to 47, with
+`fn_8_C37E8` and `s12fanObjectUnload` byte-exact. What is left in
+`s12fanObjectRegister` is a single instruction: retail stores the byte field at
+0x21 from the same register that holds the zero variable, and mwcc always
+materialises a fresh `li r0, 0x0` for the byte store no matter how the field or
+the variable is typed.
+
 ## Where to start
 
 The six closest are within sixty instructions:
@@ -276,7 +306,7 @@ The six closest are within sixty instructions:
 - `game/cri/axrna` (48; 20 registers, 11 other, 17 length)
 - `game/cri/svm` (50; 24 other, 26 length)
 - `rel/e_capture_collision_stage11` (63; 21 registers, 20 other, 22 length — the registers grew because the instructions around them became right, see below)
-- `rel/e_fan_stage11` (54; 14 registers, 18 other, 22 length)
+- `rel/e_fan_stage11` (47; 14 registers, 18 other, 15 length)
 - `game/cri/rnares` (55, all length)
 
 `game/cri/rnares` has three functions and no wrong instruction at all — every

--- a/src/rel/e_fan_stage11.cpp
+++ b/src/rel/e_fan_stage11.cpp
@@ -38,9 +38,9 @@ M2C_UNK fn_800BC9F4(s32, M2C_UNK*);                    /* extern */
 f32 fn_800D7AE4(s32);                                  /* extern */
 f32 fn_800D7B00(s32);                                  /* extern */
 void* fn_80150588(u32);                                /* extern */
-M2C_UNK fn_80150958(...);                              /* extern */
+M2C_UNK fn_80150958(void*);                            /* extern */
 M2C_UNK fn_8015BB08(s32, void*);                       /* extern */
-M2C_UNK fn_8015BBF8(s32);                              /* extern */
+M2C_UNK fn_8015BBF8(s32, void*);                       /* extern */
 M2C_UNK fn_80195790(s32, M2C_UNK*, M2C_UNK, f32, f32); /* extern */
 M2C_UNK fn_8019E880(s32);                              /* extern */
 M2C_UNK fn_8019EB94(s32, f32*, M2C_UNK);               /* extern */
@@ -76,7 +76,7 @@ void fn_8_C37E0(s32 arg0)
 void fn_8_C37E8(void* arg0)
 {
 	if ((void*)M2C_FIELD(arg0, void**, 0x3C) != NULL) {
-		fn_8015BBF8(M2C_FIELD(lbl_8042C1D0, s32*, 0x725C));
+		fn_8015BBF8(M2C_FIELD(lbl_8042C1D0, s32*, 0x725C), M2C_FIELD(arg0, void**, 0x3C));
 		fn_80150958(M2C_FIELD(arg0, void**, 0x3C));
 		M2C_FIELD(arg0, void**, 0x3C) = NULL;
 	}
@@ -143,7 +143,7 @@ TObject* fn_8_C3A98(TObject* arg0, s16 arg1)
 		arg0->unk18 = &lbl_8_data_1823C;
 		arg0->unk2C = &lbl_8_data_1823C + 0x2C;
 		if ((void*)arg0->unk3C != NULL) {
-			fn_8015BBF8(M2C_FIELD(lbl_8042C1D0, s32*, 0x725C));
+			fn_8015BBF8(M2C_FIELD(lbl_8042C1D0, s32*, 0x725C), M2C_FIELD(arg0, void**, 0x3C));
 			fn_80150958(arg0->unk3C);
 			arg0->unk3C = NULL;
 		}
@@ -193,7 +193,7 @@ TObject* fn_8_C3B54(TObject* arg0, TObject* arg1)
 void s12fanObjectUnload(void)
 {
 	if ((u32)lbl_8_bss_1C10 != 0U) {
-		fn_80150958();
+		fn_80150958((void*)lbl_8_bss_1C10);
 		lbl_8_bss_1C10 = 0U;
 	}
 }
@@ -248,26 +248,30 @@ void s12fanObjectCreate(void)
 
 void s12fanObjectRegister(void)
 {
-	M2C_FIELD(&s12fanObjectEntry, s32*, 0x14)       = 0;
-	M2C_FIELD(&s12fanObjectEntry, s32*, 0x18)       = 0;
+	s32 flags;
+	u32 fieldTypes = 0;
+
+	M2C_FIELD(&s12fanObjectEntry, s32*, 0x14)       = fieldTypes;
+	M2C_FIELD(&s12fanObjectEntry, s32*, 0x18)       = fieldTypes;
 	M2C_FIELD(&s12fanObjectEntry, M2C_UNK**, 0)     = &s12fanObjectDisplayName;
 	M2C_FIELD(&s12fanObjectEntry, void (**)(), 4)   = s12fanObjectLoad;
 	M2C_FIELD(&s12fanObjectEntry, void (**)(), 8)   = s12fanObjectUnload;
 	M2C_FIELD(&s12fanObjectEntry, void (**)(), 0xC) = s12fanObjectCreate;
-	M2C_FIELD(&s12fanObjectEntry, s32*, 0x10)       = 0;
-	M2C_FIELD(&s12fanObjectEntry, s32*, 0x14)       = 0x20000;
-	M2C_FIELD(&s12fanObjectEntry, s32*, 0x18)       = 0;
+	M2C_FIELD(&s12fanObjectEntry, s32*, 0x10)       = fieldTypes;
+	flags                                           = 0x20000;
+	M2C_FIELD(&s12fanObjectEntry, s32*, 0x14)       = flags;
+	M2C_FIELD(&s12fanObjectEntry, s32*, 0x18)       = fieldTypes;
 	M2C_FIELD(&s12fanObjectEntry, s8*, 0x20)        = 0x1E;
 	M2C_FIELD(&s12fanObjectEntry, s16*, 0x1C)       = 0x1187;
 	M2C_FIELD(&s12fanObjectEntry, s16*, 0x1E)       = 2;
-	M2C_FIELD(&s12fanObjectEntry, s8*, 0x21)        = 0;
-	M2C_FIELD(&s12fanObjectEntry, s32*, 0x24)       = 0;
-	M2C_FIELD(&s12fanObjectEntry, s32*, 0x28)       = 0;
-	if (0U != 0U) {
-		M2C_FIELD(&s12fanObjectEntry, s32*, 0x14) = 0x20008;
+	M2C_FIELD(&s12fanObjectEntry, s8*, 0x21)        = fieldTypes;
+	M2C_FIELD(&s12fanObjectEntry, s32*, 0x24)       = fieldTypes;
+	M2C_FIELD(&s12fanObjectEntry, s32*, 0x28)       = fieldTypes;
+	if (fieldTypes != 0) {
+		M2C_FIELD(&s12fanObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&s12fanObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&s12fanObjectEntry, s32*, 0x14) = flags & ~8;
 }
 
 __declspec(section ".ctors") void (*const s12fanObjectCtorEntry)(void) = s12fanObjectRegister;


### PR DESCRIPTION
#480 fixed three things in `captureCollisionRegister`. The same three are wrong
in every stage object's register function, so this unit cost a fraction of the
first one.

**1. Inline literals instead of named objects.** m2c writes the literal at the
use site and mwcc emits an anonymous constant; retail has a named symbol.
objdiff pairs data by symbol name, so the literal has to become a named object
before either side can match.

**2. Folded flag arithmetic.** The record's flag word is `0x20000`, then `| 8`
on one path and `& ~8` on the other. With propagation on, mwcc knows bit 3 is
clear, turns the first into `addi` and deletes the second branch outright.
Hoisting the constant into a local plus `-opt nopropagation` on the unit
restores `ori` and `rlwinm`.

**3. A test folded away entirely.** m2c wrote

```c
if (0U != 0U) { ... }
```

because the pointer it tested was a constant it could see, and that removes six
instructions. Giving the value a local brings the test back. Its **type**
decides the compare — retail's is `cmplwi`, unsigned, so `u32` and not `s32`:

```
  cmplwi r5, 0x0        |  cmpwi r6, 0x0      <- s32
  cmplwi r5, 0x0        |  cmplwi r5, 0x0     <- u32
```

**Two more lost arguments**, of the kind #478 and #479 described.
`fn_8015BBF8` takes `(scene, mesh)` and m2c passed only the scene;
`fn_80150958()` was called with nothing at all where the value was already in
r3. Dropping the `(...)` from each extern makes the compiler name both sites.

## Measured

`rel/e_fan_stage11` 94.51% -> **95.90%** fuzzy. `left` 54 -> 47, and
`fn_8_C37E8` and `s12fanObjectUnload` are byte-exact. Unit stays `NonMatching`.

## What is left in the register function

One instruction. Retail stores the byte field at 0x21 from the same register
that holds the zero variable:

```
  stb r5, 0x21(r4)      |  li  r0, 0x0
                        |  stb r0, 0x21(r4)
```

mwcc materialises a fresh zero for the byte store no matter how the field or
the variable is typed — `s8`, `u8`, `s32` and `u32` all produce it. Recorded in
the doc rather than worked around.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
