### PR TITLE
decomp: turn data pooling off where retail did not use it

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1294,6 +1294,7 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-pool off",
                 ],
                 data_section_alignment=4,
             ),
@@ -1303,6 +1304,7 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-pool off",
                 ],
             ),
             Object(
@@ -1656,7 +1658,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_strategy_flyer_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 NonMatching,
@@ -1666,12 +1668,12 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_flyer_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_flyer_collision_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -1681,12 +1683,12 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_strategy_magician_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_flyer_path_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 NonMatching,
@@ -1716,12 +1718,12 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_rinoliner_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_rinoliner_collision_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -1741,7 +1743,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_turtle_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -1751,7 +1753,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_wall_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -1761,7 +1763,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_capture.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -2006,12 +2008,12 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_grass2_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_grass_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -2046,7 +2048,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_mask_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -2451,7 +2453,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_s11_flag_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 NonMatching,
@@ -2471,7 +2473,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_s11_key_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -2481,7 +2483,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_spider_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -2796,7 +2798,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_tree_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,

--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -298,6 +298,26 @@ That took the unit from 94.51% to 95.90% and `left` from 54 to 47, with
 materialises a fresh `li r0, 0x0` for the byte store no matter how the field or
 the variable is typed.
 
+**Data pooling is on where retail had it off.** mwcc's `-pool` collects a
+translation unit's static data behind one anchor and addresses every object as
+`base + offset`; retail emits a `lis`/`addi` pair per symbol. Our object gives
+itself away with a symbol named `...bss.0` or `...data.0`, and the register
+function reads
+
+```
+  lis  r3, treeObjectDisplayName@ha    |  <missing>
+  addi r0, r3, treeObjectDisplayName@l |  addi r0, r6, 0x48
+```
+
+Twenty units carry a pool anchor. `-pool off` improves nineteen of them, from
++0.55 to +5.27, and the two it does not are the CRI units `game/cri/svm`
+(-6.02) and `game/cri/axrna` (-0.63), which really were pooled. Check for the
+anchor symbol before assuming either way.
+
+This is also the clearest case of the `left` column misleading: `rel/e_tree_stage11`
+went 84.65% to 87.48% with every register and content difference gone, and its
+`left` **rose** from 32 to 37 because only length gaps remain to be charged.
+
 ## Where to start
 
 The six closest are within sixty instructions:


### PR DESCRIPTION
mwcc's `-pool` collects a translation unit's static data behind one anchor and
addresses every object as `base + offset`. Retail emits a `lis`/`addi` pair per
symbol, so a pooled unit differs from it in every reference to its own data:

```
  lis  r3, treeObjectDisplayName@ha    |  <missing>
  addi r0, r3, treeObjectDisplayName@l |  addi r0, r6, 0x48
  stw  r0, 0x0(r6)                     |  stw  r0, 0x0(r7)
```

Our object names the anchor, so this is detectable without reading a single
instruction: a symbol called `...bss.0` or `...data.0` means the unit is
pooled. Twenty units carry one. `-pool off` improves nineteen.

## Measured

| unit | before | after | delta |
| --- | ---: | ---: | ---: |
| `rel/e_capture` | 80.04 | 85.31 | +5.27 |
| `rel/e_turtle_stage11` | 82.77 | 86.71 | +3.94 |
| `rel/e_mask_stage11` | 90.81 | 94.30 | +3.50 |
| `rel/e_grass2_stage11` | 85.28 | 88.35 | +3.07 |
| `rel/e_flyer_path_stage11` | 74.63 | 77.54 | +2.91 |
| `rel/e_strategy_flyer_stage11` | 87.20 | 90.11 | +2.91 |
| `rel/e_tree_stage11` | 84.65 | 87.48 | +2.83 |
| `rel/e_flyer_stage11` | 77.48 | 80.06 | +2.58 |
| `rel/e_spider_stage11` | 83.40 | 85.73 | +2.33 |
| `rel/e_s11_flag_stage11` | 88.99 | 91.27 | +2.28 |
| `rel/e_rinoliner_collision_stage11` | 77.05 | 78.42 | +1.37 |
| `rel/e_wall_stage11` | 82.52 | 83.60 | +1.08 |
| `rel/e_flyer_collision_stage11` | 76.73 | 77.74 | +1.01 |
| `rel/e_strategy_magician_stage11` | 80.76 | 81.69 | +0.92 |
| `rel/e_rinoliner_stage11` | 83.00 | 83.88 | +0.88 |
| `rel/e_s11_key_stage11` | 83.69 | 84.48 | +0.80 |
| `rel/e_grass_stage11` | 88.69 | 89.48 | +0.79 |
| `rel/sp_dashpanel` | 28.67 | 29.38 | +0.71 |
| `rel/sp_dashring` | 22.40 | 22.95 | +0.55 |

Project measure: 9.30% -> **9.34%** fuzzy, 7.45% -> 7.46% matched. All nineteen
stay `NonMatching`.

## The two that are not touched

`game/cri/svm` (-6.02) and `game/cri/axrna` (-0.63) both regress with the flag,
so they really were compiled pooled. They keep their current flags. That is the
reason this is per-unit and not a global default: the anchor symbol says a unit
is pooled, not that it should not be.

`rel/e_tree_stage11` is also the clearest case of the `left` column misleading
that #477 warned about. It went 84.65% to 87.48% with every register and
content difference gone, and `left` **rose** from 32 to 37, because only length
gaps remain to be charged.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
