### PR TITLE
decomp: hoist the record flag constant in eight stage11 units

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1673,7 +1673,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_flyer_collision_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -1698,7 +1698,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_magician_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
             ),
             Object(
                 NonMatching,
@@ -1743,7 +1743,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_turtle_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -2008,7 +2008,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_grass2_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
             ),
             Object(
                 NonMatching,
@@ -2458,7 +2458,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/o_s11_door.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
             ),
             Object(
                 Matching,
@@ -2483,7 +2483,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_spider_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -2498,7 +2498,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/o_s12_celestial_sphere.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
             ),
             Object(
                 NonMatching,
@@ -2798,7 +2798,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_tree_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,

--- a/src/rel/e_flyer_collision_stage11.cpp
+++ b/src/rel/e_flyer_collision_stage11.cpp
@@ -1169,6 +1169,8 @@ void flyerColObjectCreate(void)
 
 void flyerColObjectRegister(void)
 {
+	s32 flags;
+
 	M2C_FIELD(&flyerColObjectEntry, s32*, 0x14)       = 0;
 	M2C_FIELD(&flyerColObjectEntry, s32*, 0x18)       = 0;
 	M2C_FIELD(&flyerColObjectEntry, M2C_UNK**, 0)     = &flyerColObjectDisplayName;
@@ -1176,7 +1178,8 @@ void flyerColObjectRegister(void)
 	M2C_FIELD(&flyerColObjectEntry, void (**)(), 8)   = flyerColObjectUnload;
 	M2C_FIELD(&flyerColObjectEntry, void (**)(), 0xC) = flyerColObjectCreate;
 	M2C_FIELD(&flyerColObjectEntry, s32*, 0x10)       = 0;
-	M2C_FIELD(&flyerColObjectEntry, s32*, 0x14)       = 0x20000;
+	flags                                             = 0x20000;
+	M2C_FIELD(&flyerColObjectEntry, s32*, 0x14)       = flags;
 	M2C_FIELD(&flyerColObjectEntry, s32*, 0x18)       = 0;
 	M2C_FIELD(&flyerColObjectEntry, s8*, 0x20)        = 0x1E;
 	M2C_FIELD(&flyerColObjectEntry, s16*, 0x1C)       = 0x63;
@@ -1185,9 +1188,9 @@ void flyerColObjectRegister(void)
 	M2C_FIELD(&flyerColObjectEntry, M2C_UNK**, 0x24)  = &flyerColObjectFieldTypes;
 	M2C_FIELD(&flyerColObjectEntry, M2C_UNK***, 0x28) = flyerColObjectFieldNames;
 	if (&flyerColObjectFieldTypes != NULL) {
-		M2C_FIELD(&flyerColObjectEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&flyerColObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&flyerColObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&flyerColObjectEntry, s32*, 0x14) = flags & ~8;
 }
 }

--- a/src/rel/e_grass2_stage11.cpp
+++ b/src/rel/e_grass2_stage11.cpp
@@ -772,6 +772,8 @@ void grass2ObjectCreate(void)
 
 void grass2ObjectRegister(void)
 {
+	s32 flags;
+
 	M2C_FIELD(&grass2ObjectEntry, s32*, 0x14)            = 0;
 	M2C_FIELD(&grass2ObjectEntry, s32*, 0x18)            = 0;
 	M2C_FIELD(&grass2ObjectEntry, M2C_UNK**, 0)          = &grass2ObjectDisplayName;
@@ -779,7 +781,8 @@ void grass2ObjectRegister(void)
 	M2C_FIELD(&grass2ObjectEntry, void (**)(M2C_UNK), 8) = grass2ObjectUnload;
 	M2C_FIELD(&grass2ObjectEntry, void (**)(), 0xC)      = grass2ObjectCreate;
 	M2C_FIELD(&grass2ObjectEntry, s32*, 0x10)            = 0;
-	M2C_FIELD(&grass2ObjectEntry, s32*, 0x14)            = 0x20000;
+	flags                                                = 0x20000;
+	M2C_FIELD(&grass2ObjectEntry, s32*, 0x14)            = flags;
 	M2C_FIELD(&grass2ObjectEntry, s32*, 0x18)            = 0;
 	M2C_FIELD(&grass2ObjectEntry, s8*, 0x20)             = 0x1E;
 	M2C_FIELD(&grass2ObjectEntry, s16*, 0x1C)            = 0x118C;
@@ -788,10 +791,10 @@ void grass2ObjectRegister(void)
 	M2C_FIELD(&grass2ObjectEntry, M2C_UNK**, 0x24)       = &grass2ObjectFieldTypes;
 	M2C_FIELD(&grass2ObjectEntry, M2C_UNK**, 0x28)       = &grass2ObjectFieldNames;
 	if (&grass2ObjectFieldTypes != NULL) {
-		M2C_FIELD(&grass2ObjectEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&grass2ObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&grass2ObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&grass2ObjectEntry, s32*, 0x14) = flags & ~8;
 }
 
 __declspec(section ".ctors") void (*const grass2ObjectCtorEntry)(void) = grass2ObjectRegister;

--- a/src/rel/e_magician_stage11.cpp
+++ b/src/rel/e_magician_stage11.cpp
@@ -1307,6 +1307,8 @@ void fn_8_AF86C(void* arg0, s32 arg1)
 
 void magicianObjectRegister(void)
 {
+	s32 flags;
+
 	M2C_FIELD(&magicianObjectEntry, s32*, 0x14)       = 0;
 	M2C_FIELD(&magicianObjectEntry, s32*, 0x18)       = 0;
 	M2C_FIELD(&magicianObjectEntry, M2C_UNK**, 0)     = &magicianObjectDisplayName;
@@ -1314,7 +1316,8 @@ void magicianObjectRegister(void)
 	M2C_FIELD(&magicianObjectEntry, void (**)(), 8)   = magicianObjectUnload;
 	M2C_FIELD(&magicianObjectEntry, void (**)(), 0xC) = magicianObjectCreate;
 	M2C_FIELD(&magicianObjectEntry, s32*, 0x10)       = 0;
-	M2C_FIELD(&magicianObjectEntry, s32*, 0x14)       = 0x20000;
+	flags                                             = 0x20000;
+	M2C_FIELD(&magicianObjectEntry, s32*, 0x14)       = flags;
 	M2C_FIELD(&magicianObjectEntry, s32*, 0x18)       = 0;
 	M2C_FIELD(&magicianObjectEntry, s8*, 0x20)        = 0x1E;
 	M2C_FIELD(&magicianObjectEntry, s16*, 0x1C)       = 0x15C0;
@@ -1323,9 +1326,9 @@ void magicianObjectRegister(void)
 	M2C_FIELD(&magicianObjectEntry, M2C_UNK**, 0x24)  = &magicianObjectFieldTypes;
 	M2C_FIELD(&magicianObjectEntry, s32**, 0x28)      = &magicianObjectFieldNames;
 	if (&magicianObjectFieldTypes != NULL) {
-		M2C_FIELD(&magicianObjectEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&magicianObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&magicianObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&magicianObjectEntry, s32*, 0x14) = flags & ~8;
 }
 }

--- a/src/rel/e_spider_stage11.cpp
+++ b/src/rel/e_spider_stage11.cpp
@@ -614,6 +614,8 @@ void s11spiderObjectCreate(void)
 
 void s11spiderObjectRegister(void)
 {
+	s32 flags;
+
 	M2C_FIELD(&s11spiderObjectEntry, s32*, 0x14)            = 0;
 	M2C_FIELD(&s11spiderObjectEntry, s32*, 0x18)            = 0;
 	M2C_FIELD(&s11spiderObjectEntry, M2C_UNK**, 0)          = &s11spiderObjectDisplayName;
@@ -621,7 +623,8 @@ void s11spiderObjectRegister(void)
 	M2C_FIELD(&s11spiderObjectEntry, void (**)(), 8)        = s11spiderObjectUnload;
 	M2C_FIELD(&s11spiderObjectEntry, void (**)(), 0xC)      = s11spiderObjectCreate;
 	M2C_FIELD(&s11spiderObjectEntry, s32*, 0x10)            = 0;
-	M2C_FIELD(&s11spiderObjectEntry, s32*, 0x14)            = 0x20000;
+	flags                                                   = 0x20000;
+	M2C_FIELD(&s11spiderObjectEntry, s32*, 0x14)            = flags;
 	M2C_FIELD(&s11spiderObjectEntry, s32*, 0x18)            = 0;
 	M2C_FIELD(&s11spiderObjectEntry, s8*, 0x20)             = 0x1E;
 	M2C_FIELD(&s11spiderObjectEntry, s16*, 0x1C)            = 0x1189;
@@ -630,10 +633,10 @@ void s11spiderObjectRegister(void)
 	M2C_FIELD(&s11spiderObjectEntry, M2C_UNK**, 0x24)       = &s11spiderObjectFieldTypes;
 	M2C_FIELD(&s11spiderObjectEntry, M2C_UNK**, 0x28)       = &s11spiderObjectFieldNames;
 	if (&s11spiderObjectFieldTypes != NULL) {
-		M2C_FIELD(&s11spiderObjectEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&s11spiderObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&s11spiderObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&s11spiderObjectEntry, s32*, 0x14) = flags & ~8;
 }
 
 __declspec(section ".ctors") void (*const s11spiderObjectCtorEntry)(void) = s11spiderObjectRegister;

--- a/src/rel/e_tree_stage11.cpp
+++ b/src/rel/e_tree_stage11.cpp
@@ -555,6 +555,8 @@ void treeObjectCreate(void)
 
 void treeObjectRegister(void)
 {
+	s32 flags;
+
 	M2C_FIELD(&treeObjectEntry, s32*, 0x14)       = 0;
 	M2C_FIELD(&treeObjectEntry, s32*, 0x18)       = 0;
 	M2C_FIELD(&treeObjectEntry, M2C_UNK**, 0)     = &treeObjectDisplayName;
@@ -562,7 +564,8 @@ void treeObjectRegister(void)
 	M2C_FIELD(&treeObjectEntry, void (**)(), 8)   = treeObjectUnload;
 	M2C_FIELD(&treeObjectEntry, void (**)(), 0xC) = treeObjectCreate;
 	M2C_FIELD(&treeObjectEntry, s32*, 0x10)       = 0;
-	M2C_FIELD(&treeObjectEntry, s32*, 0x14)       = 0x20000;
+	flags                                         = 0x20000;
+	M2C_FIELD(&treeObjectEntry, s32*, 0x14)       = flags;
 	M2C_FIELD(&treeObjectEntry, s32*, 0x18)       = 0;
 	M2C_FIELD(&treeObjectEntry, s8*, 0x20)        = 0x1E;
 	M2C_FIELD(&treeObjectEntry, s16*, 0x1C)       = 0x118A;
@@ -571,10 +574,10 @@ void treeObjectRegister(void)
 	M2C_FIELD(&treeObjectEntry, M2C_UNK**, 0x24)  = &treeObjectFieldTypes;
 	M2C_FIELD(&treeObjectEntry, M2C_UNK**, 0x28)  = &treeObjectFieldNames;
 	if (&treeObjectFieldTypes != NULL) {
-		M2C_FIELD(&treeObjectEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&treeObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&treeObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&treeObjectEntry, s32*, 0x14) = flags & ~8;
 }
 
 __declspec(section ".ctors") void (*const treeObjectCtorEntry)(void) = treeObjectRegister;

--- a/src/rel/e_turtle_stage11.cpp
+++ b/src/rel/e_turtle_stage11.cpp
@@ -2994,6 +2994,8 @@ void turtleObjectCreate(void)
 
 void turtleObjectRegister(void)
 {
+	s32 flags;
+
 	fn_80113C7C(&turtleObjectGlobalA);
 	__register_global_object(&fn_80113C2C, &turtleObjectGlobalAChain);
 	M2C_FIELD(&turtleObjectEntry, s32*, 0x14)       = 0;
@@ -3003,7 +3005,8 @@ void turtleObjectRegister(void)
 	M2C_FIELD(&turtleObjectEntry, void (**)(), 8)   = turtleObjectUnload;
 	M2C_FIELD(&turtleObjectEntry, void (**)(), 0xC) = turtleObjectCreate;
 	M2C_FIELD(&turtleObjectEntry, s32*, 0x10)       = 0;
-	M2C_FIELD(&turtleObjectEntry, s32*, 0x14)       = 0x20000;
+	flags                                           = 0x20000;
+	M2C_FIELD(&turtleObjectEntry, s32*, 0x14)       = flags;
 	M2C_FIELD(&turtleObjectEntry, s32*, 0x18)       = 0;
 	M2C_FIELD(&turtleObjectEntry, s8*, 0x20)        = 0x1E;
 	M2C_FIELD(&turtleObjectEntry, s16*, 0x1C)       = 0x1570;
@@ -3012,10 +3015,10 @@ void turtleObjectRegister(void)
 	M2C_FIELD(&turtleObjectEntry, M2C_UNK**, 0x24)  = &turtleObjectFieldTypes;
 	M2C_FIELD(&turtleObjectEntry, M2C_UNK**, 0x28)  = &turtleObjectFieldNames;
 	if (&turtleObjectFieldTypes != NULL) {
-		M2C_FIELD(&turtleObjectEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&turtleObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&turtleObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&turtleObjectEntry, s32*, 0x14) = flags & ~8;
 }
 
 __declspec(section ".ctors") void (*const turtleObjectCtorEntry)(void) = turtleObjectRegister;

--- a/src/rel/o_s11_door.cpp
+++ b/src/rel/o_s11_door.cpp
@@ -658,6 +658,8 @@ void s11doorObjectCreate(void)
 
 void s11doorObjectRegister(void)
 {
+	s32 flags;
+
 	M2C_FIELD(&s11doorObjectEntry, s32*, 0x14)            = 0;
 	M2C_FIELD(&s11doorObjectEntry, s32*, 0x18)            = 0;
 	M2C_FIELD(&s11doorObjectEntry, M2C_UNK**, 0)          = &s11doorObjectDisplayName;
@@ -665,7 +667,8 @@ void s11doorObjectRegister(void)
 	M2C_FIELD(&s11doorObjectEntry, void (**)(), 8)        = s11doorObjectUnload;
 	M2C_FIELD(&s11doorObjectEntry, void (**)(), 0xC)      = s11doorObjectCreate;
 	M2C_FIELD(&s11doorObjectEntry, s32*, 0x10)            = 0;
-	M2C_FIELD(&s11doorObjectEntry, s32*, 0x14)            = 0x20000;
+	flags                                                 = 0x20000;
+	M2C_FIELD(&s11doorObjectEntry, s32*, 0x14)            = flags;
 	M2C_FIELD(&s11doorObjectEntry, s32*, 0x18)            = 0;
 	M2C_FIELD(&s11doorObjectEntry, s8*, 0x20)             = 0x1E;
 	M2C_FIELD(&s11doorObjectEntry, s16*, 0x1C)            = 0x1101;
@@ -674,9 +677,9 @@ void s11doorObjectRegister(void)
 	M2C_FIELD(&s11doorObjectEntry, M2C_UNK**, 0x24)       = &s11doorObjectFieldTypes;
 	M2C_FIELD(&s11doorObjectEntry, s32**, 0x28)           = &s11doorObjectFieldNames;
 	if (&s11doorObjectFieldTypes != NULL) {
-		M2C_FIELD(&s11doorObjectEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&s11doorObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&s11doorObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&s11doorObjectEntry, s32*, 0x14) = flags & ~8;
 }
 }

--- a/src/rel/o_s12_celestial_sphere.cpp
+++ b/src/rel/o_s12_celestial_sphere.cpp
@@ -391,6 +391,8 @@ void s12celestialObjectCreate(void)
 
 void s12celestialObjectRegister(void)
 {
+	s32 flags;
+
 	M2C_FIELD(&s12celestialObjectEntry, s32*, 0x14)            = 0;
 	M2C_FIELD(&s12celestialObjectEntry, s32*, 0x18)            = 0;
 	M2C_FIELD(&s12celestialObjectEntry, M2C_UNK**, 0)          = &s12celestialObjectDisplayName;
@@ -398,7 +400,8 @@ void s12celestialObjectRegister(void)
 	M2C_FIELD(&s12celestialObjectEntry, void (**)(), 8)        = s12celestialObjectUnload;
 	M2C_FIELD(&s12celestialObjectEntry, void (**)(), 0xC)      = s12celestialObjectCreate;
 	M2C_FIELD(&s12celestialObjectEntry, s32*, 0x10)            = 0;
-	M2C_FIELD(&s12celestialObjectEntry, s32*, 0x14)            = 0x20000;
+	flags                                                      = 0x20000;
+	M2C_FIELD(&s12celestialObjectEntry, s32*, 0x14)            = flags;
 	M2C_FIELD(&s12celestialObjectEntry, s32*, 0x18)            = 0;
 	M2C_FIELD(&s12celestialObjectEntry, s8*, 0x20)             = 0x1E;
 	M2C_FIELD(&s12celestialObjectEntry, s16*, 0x1C)            = 0x1181;
@@ -407,10 +410,10 @@ void s12celestialObjectRegister(void)
 	M2C_FIELD(&s12celestialObjectEntry, M2C_UNK**, 0x24)       = &s12celestialObjectFieldTypes;
 	M2C_FIELD(&s12celestialObjectEntry, M2C_UNK**, 0x28)       = &s12celestialObjectFieldNames;
 	if (&s12celestialObjectFieldTypes != NULL) {
-		M2C_FIELD(&s12celestialObjectEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&s12celestialObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&s12celestialObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&s12celestialObjectEntry, s32*, 0x14) = flags & ~8;
 }
 
 void fn_8_973D4(s32 arg0)


### PR DESCRIPTION
#480 and #481 fixed the record flag fold one unit at a time. Fifteen units
carry the same signature — a `0x20008` in the register function's tail — and
eight of them have the shape that transforms without judgement:

```c
	M2C_FIELD(&treeObjectEntry, s32*, 0x14) = 0x20000;
	...
	if (&treeObjectFieldTypes != NULL) {
		M2C_FIELD(&treeObjectEntry, s32*, 0x14) = 0x20008;
		return;
	}
	M2C_FIELD(&treeObjectEntry, s32*, 0x14) = 0x20000;
```

The record's flag word is `0x20000`, then `| 8` on one path and `& ~8` on the
other. Written as literals, mwcc's propagation knows bit 3 is clear, turns the
first into `addi` and deletes the second branch outright:

```
  ori    r0, r5, 0x8            |  addi r0, r4, 0x8
  rlwinm r0, r5, 0, 29, 27      |  <missing>
  stw    r0, 0x14(r6)           |  stw  r4, 0x14(r7)
```

Hoisting the constant into a local and adding `-opt nopropagation` to each unit
restores both instructions.

## Measured

Eight units, no regressions:

| unit | before | after | delta |
| --- | ---: | ---: | ---: |
| `rel/e_tree_stage11` | 87.48 | 87.75 | +0.27 |
| `rel/e_flyer_collision_stage11` | 77.74 | 77.92 | +0.19 |
| `rel/o_s12_celestial_sphere` | 92.66 | 92.72 | +0.07 |
| `rel/o_s11_door` | 87.47 | 87.53 | +0.06 |
| `rel/e_grass2_stage11` | 88.35 | 88.40 | +0.05 |
| `rel/e_turtle_stage11` | 86.71 | 86.73 | +0.03 |
| `rel/e_spider_stage11` | 85.73 | 85.75 | +0.02 |
| `rel/e_magician_stage11` | 59.44 | 59.45 | +0.01 |

Small, because it is two instructions per unit — but they are two instructions
that no amount of work on the surrounding code would ever have reached. All
stay `NonMatching`.

## The seven left out

`e_mask_stage11`, `e_wall_stage11`, `e_strategy_flyer_stage11`,
`e_rinoliner_collision_stage11`, `e_s11_key_stage11`, `e_grass_stage11` and
`e_capture` test a local holding an inline string literal instead of the
address of a static:

```c
	temp_r3 = (M2C_UNK*)"iFFc";
	M2C_FIELD(&maskObjectEntry, M2C_UNK**, 0x24) = temp_r3;
	if (temp_r3 != NULL) { ... }
```

Those need the literal turned into a named object first — the fix #480 applied
to `captureCollisionFieldTypes` — because mwcc emits an anonymous constant for
an inline literal and objdiff pairs data by symbol name. Two changes in one
function, so they are left for a pass that can check each name against the
target rather than being folded into a mechanical sweep.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
