### PR TITLE
decomp: name the field-type strings in the mask and wall records

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1753,7 +1753,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_wall_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,
@@ -2048,7 +2048,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_mask_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
             ),
             Object(
                 Matching,

--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -268,6 +268,15 @@ differences are now visible in a function that previously had the wrong
 instructions to compare. It is the same effect the column warning above
 describes.
 
+**The object record recipe does not generalise past the flag hoist.** The
+literal-to-named-object half of it changes where the unit's strings live, and
+that moves the whole data section. Applied to the seven units whose register
+function tests an inline literal, it helped `rel/e_wall_stage11` (+0.09) and
+`rel/e_mask_stage11` (+0.05) and *hurt* `rel/e_capture` (-0.07),
+`rel/e_grass_stage11` (-0.11) and `rel/e_rinoliner_collision_stage11` (-0.11).
+Measure each one; the name is right in every case, but the layout it implies is
+not yet right in most.
+
 **The object record is a recipe, and it repeats per unit.** Every stage object
 has a `<name>ObjectRegister` that fills one record and ends with a flag test.
 m2c gets the same three things wrong in each of them, so the second unit costs

--- a/src/rel/e_mask_stage11.cpp
+++ b/src/rel/e_mask_stage11.cpp
@@ -113,18 +113,18 @@ static M2C_UNK lbl_8_data_18D0C;     /* unable to generate initializer: unknown 
 static M2C_UNK lbl_8_data_18D3C;     /* unable to generate initializer: unknown type */
 static M2C_UNK gap_04_00018D45_data; /* unable to generate initializer: unknown type */
 static const char* lbl_8_data_18D48 = "TObjMask";
-static M2C_UNK lbl_8_data_18D4C;      /* unable to generate initializer: unknown type */
-static M2C_UNK lbl_8_data_18D88;      /* unable to generate initializer: unknown type */
-static M2C_UNK gap_04_00018D99_data;  /* unable to generate initializer: unknown type */
-static M2C_UNK lbl_8_data_18D9C;      /* unable to generate initializer: unknown type */
-static M2C_UNK gap_04_00018DAD_data;  /* unable to generate initializer: unknown type */
-static M2C_UNK lbl_8_data_18DB0;      /* unable to generate initializer: unknown type */
-static M2C_UNK gap_04_00018DC1_data;  /* unable to generate initializer: unknown type */
-static M2C_UNK lbl_8_data_18DC4;      /* unable to generate initializer: unknown type */
-static M2C_UNK gap_04_00018DD5_data;  /* unable to generate initializer: unknown type */
-static M2C_UNK maskObjectDisplayName; /* unable to generate initializer: unknown type */
-static M2C_UNK maskObjectFieldTypes;  /* unable to generate initializer: unknown type */
-static M2C_UNK gap_04_00018DEC_data;  /* unable to generate initializer: unknown type */
+static M2C_UNK lbl_8_data_18D4C;     /* unable to generate initializer: unknown type */
+static M2C_UNK lbl_8_data_18D88;     /* unable to generate initializer: unknown type */
+static M2C_UNK gap_04_00018D99_data; /* unable to generate initializer: unknown type */
+static M2C_UNK lbl_8_data_18D9C;     /* unable to generate initializer: unknown type */
+static M2C_UNK gap_04_00018DAD_data; /* unable to generate initializer: unknown type */
+static M2C_UNK lbl_8_data_18DB0;     /* unable to generate initializer: unknown type */
+static M2C_UNK gap_04_00018DC1_data; /* unable to generate initializer: unknown type */
+static M2C_UNK lbl_8_data_18DC4;     /* unable to generate initializer: unknown type */
+static M2C_UNK gap_04_00018DD5_data; /* unable to generate initializer: unknown type */
+static const char maskObjectDisplayName[] = "MASK OBJECT";
+static const char maskObjectFieldTypes[]  = "iFFc";
+static M2C_UNK gap_04_00018DEC_data; /* unable to generate initializer: unknown type */
 static M2C_UNK maskObjectEntry;
 static M2C_UNK lbl_8_bss_1D48;
 static M2C_UNK lbl_8_rodata_20F0; /* unable to generate initializer: unknown type; const */
@@ -624,29 +624,31 @@ void maskObjectCreate(void)
 
 void maskObjectRegister(void)
 {
+	s32 flags;
 	M2C_UNK* temp_r3;
 
 	M2C_FIELD(&maskObjectEntry, s32*, 0x14)       = 0;
 	M2C_FIELD(&maskObjectEntry, s32*, 0x18)       = 0;
-	M2C_FIELD(&maskObjectEntry, M2C_UNK**, 0)     = (M2C_UNK*)"MASK OBJECT";
+	M2C_FIELD(&maskObjectEntry, M2C_UNK**, 0)     = (M2C_UNK*)maskObjectDisplayName;
 	M2C_FIELD(&maskObjectEntry, void (**)(), 4)   = maskObjectLoad;
 	M2C_FIELD(&maskObjectEntry, void (**)(), 8)   = maskObjectUnload;
 	M2C_FIELD(&maskObjectEntry, void (**)(), 0xC) = maskObjectCreate;
 	M2C_FIELD(&maskObjectEntry, s32*, 0x10)       = 0;
-	M2C_FIELD(&maskObjectEntry, s32*, 0x14)       = 0x20000;
+	flags                                         = 0x20000;
+	M2C_FIELD(&maskObjectEntry, s32*, 0x14)       = flags;
 	M2C_FIELD(&maskObjectEntry, s32*, 0x18)       = 0;
 	M2C_FIELD(&maskObjectEntry, s8*, 0x20)        = 0x1E;
 	M2C_FIELD(&maskObjectEntry, s16*, 0x1C)       = 0x118D;
 	M2C_FIELD(&maskObjectEntry, s16*, 0x1E)       = 2;
 	M2C_FIELD(&maskObjectEntry, s8*, 0x21)        = 0;
-	temp_r3                                       = (M2C_UNK*)"iFFc";
+	temp_r3                                       = (M2C_UNK*)maskObjectFieldTypes;
 	M2C_FIELD(&maskObjectEntry, M2C_UNK**, 0x24)  = temp_r3;
 	M2C_FIELD(&maskObjectEntry, M2C_UNK**, 0x28)  = &maskObjectFieldNames;
 	if (temp_r3 != NULL) {
-		M2C_FIELD(&maskObjectEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&maskObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&maskObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&maskObjectEntry, s32*, 0x14) = flags & ~8;
 }
 
 __declspec(section ".ctors") void (*const maskObjectCtorEntry)(void) = maskObjectRegister;

--- a/src/rel/e_wall_stage11.cpp
+++ b/src/rel/e_wall_stage11.cpp
@@ -460,12 +460,12 @@ static M2C_UNK* lbl_8_data_17990 = (M2C_UNK*)"TObjEnemyWall";
 static M2C_UNK lbl_8_data_17994; /* unable to generate initializer: unknown type */
 static M2C_UNK lbl_8_data_179C4; /* unable to generate initializer: unknown type */
 static M2C_UNK* lbl_8_data_179D8 = (M2C_UNK*)"TObjEnemyWallHelmet";
-static M2C_UNK lbl_8_data_179DC;      /* unable to generate initializer: unknown type */
-static M2C_UNK lbl_8_data_17AE0;      /* unable to generate initializer: unknown type */
-static M2C_UNK lbl_8_data_17AEC;      /* unable to generate initializer: unknown type */
-static M2C_UNK wallObjectDisplayName; /* unable to generate initializer: unknown type */
-static M2C_UNK wallObjectFieldTypes;  /* unable to generate initializer: unknown type */
-static M2C_UNK gap_04_00017BAC_data;  /* unable to generate initializer: unknown type */
+static M2C_UNK lbl_8_data_179DC; /* unable to generate initializer: unknown type */
+static M2C_UNK lbl_8_data_17AE0; /* unable to generate initializer: unknown type */
+static M2C_UNK lbl_8_data_17AEC; /* unable to generate initializer: unknown type */
+static const char wallObjectDisplayName[] = "WALL OBJECT";
+static const char wallObjectFieldTypes[]  = "ccccffffiff";
+static M2C_UNK gap_04_00017BAC_data; /* unable to generate initializer: unknown type */
 static M2C_UNK lbl_8_bss_1AC8;
 static u32 lbl_8_bss_1ADC;
 static u32 lbl_8_bss_1AE0[0x11];
@@ -3882,31 +3882,33 @@ void fn_8_BD950(void* arg0, s32 arg1)
 
 void wallObjectRegister(void)
 {
+	s32 flags;
 	M2C_UNK* temp_r3;
 
 	fn_80113C7C(&wallObjectGlobalA);
 	__register_global_object(&fn_80113C2C, &wallObjectGlobalAChain);
 	M2C_FIELD(&wallObjectEntry, s32*, 0x14)       = 0;
 	M2C_FIELD(&wallObjectEntry, s32*, 0x18)       = 0;
-	M2C_FIELD(&wallObjectEntry, M2C_UNK**, 0)     = (M2C_UNK*)"WALL OBJECT";
+	M2C_FIELD(&wallObjectEntry, M2C_UNK**, 0)     = (M2C_UNK*)wallObjectDisplayName;
 	M2C_FIELD(&wallObjectEntry, void (**)(), 4)   = wallObjectLoad;
 	M2C_FIELD(&wallObjectEntry, void (**)(), 8)   = wallObjectUnload;
 	M2C_FIELD(&wallObjectEntry, void (**)(), 0xC) = wallObjectCreate;
 	M2C_FIELD(&wallObjectEntry, s32*, 0x10)       = 0;
-	M2C_FIELD(&wallObjectEntry, s32*, 0x14)       = 0x20000;
+	flags                                         = 0x20000;
+	M2C_FIELD(&wallObjectEntry, s32*, 0x14)       = flags;
 	M2C_FIELD(&wallObjectEntry, s32*, 0x18)       = 0;
 	M2C_FIELD(&wallObjectEntry, s8*, 0x20)        = 0x1E;
 	M2C_FIELD(&wallObjectEntry, s16*, 0x1C)       = 0x1540;
 	M2C_FIELD(&wallObjectEntry, s16*, 0x1E)       = 4;
 	M2C_FIELD(&wallObjectEntry, s8*, 0x21)        = 0;
-	temp_r3                                       = (M2C_UNK*)"ccccffffiff";
+	temp_r3                                       = (M2C_UNK*)wallObjectFieldTypes;
 	M2C_FIELD(&wallObjectEntry, M2C_UNK**, 0x24)  = temp_r3;
 	M2C_FIELD(&wallObjectEntry, M2C_UNK**, 0x28)  = &wallObjectFieldNames;
 	if (temp_r3 != NULL) {
-		M2C_FIELD(&wallObjectEntry, s32*, 0x14) = 0x20008;
+		M2C_FIELD(&wallObjectEntry, s32*, 0x14) = flags | 8;
 		return;
 	}
-	M2C_FIELD(&wallObjectEntry, s32*, 0x14) = 0x20000;
+	M2C_FIELD(&wallObjectEntry, s32*, 0x14) = flags & ~8;
 }
 
 __declspec(section ".ctors") void (*const wallObjectCtorEntry)(void) = wallObjectRegister;


### PR DESCRIPTION
The other half of the object-record recipe from #480: the register function
tests a local holding an inline string literal, so mwcc emits an anonymous
constant where retail has a named object.

```c
	temp_r3 = (M2C_UNK*)"iFFc";
	M2C_FIELD(&maskObjectEntry, M2C_UNK**, 0x24) = temp_r3;
	if (temp_r3 != NULL) { ... }
```

Both `maskObjectDisplayName` and `maskObjectFieldTypes` already exist in the
file as `static M2C_UNK` placeholders m2c could not initialise. Filling them in
from the literals at the use sites gives the strings the names the target uses,
which is what objdiff pairs data by.

## Measured

| unit | before | after | delta |
| --- | ---: | ---: | ---: |
| `rel/e_wall_stage11` | 83.60 | 83.69 | +0.09 |
| `rel/e_mask_stage11` | 94.30 | 94.35 | +0.05 |

Both stay `NonMatching`.

## Why only two of seven

The same transform on `rel/e_capture` (-0.07), `rel/e_grass_stage11` (-0.11)
and `rel/e_rinoliner_collision_stage11` (-0.11) measures worse, and
`rel/e_strategy_flyer_stage11` and `rel/e_s11_key_stage11` have a different
tail shape again.

Naming the string moves it out of the anonymous constant pool and into the
unit's own data, which shifts the whole section. The name is right in every
case — it is the layout the name implies that is not yet right in most, and
that will not be settled until each unit's remaining data is declared. Recorded
in the doc so the next attempt does not read the regression as the name being
wrong.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
