### PR TITLE
decomp: enable multiple-word moves on the three units that want them

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1329,6 +1329,8 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-use_lmw_stmw on",
+
                 ],
             ),
             Object(
@@ -1753,7 +1755,9 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_wall_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off",
+                    "-use_lmw_stmw on",
+                ],
             ),
             Object(
                 Matching,
@@ -3318,7 +3322,9 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/light_collision_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole",
+                    "-use_lmw_stmw on",
+                ],
             ),
             Object(
                 NonMatching,

--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -307,6 +307,15 @@ That took the unit from 94.51% to 95.90% and `left` from 54 to 47, with
 materialises a fresh `li r0, 0x0` for the byte store no matter how the field or
 the variable is typed.
 
+**`-use_lmw_stmw on` is not a general answer, unlike `-pool off`.** Swept
+across all 43 open units it improves three — `rel/spboss_throw_object` (+1.05),
+`rel/light_collision_stage11` (+0.07), `rel/e_wall_stage11` (+0.05) — and
+regresses seventeen, `rel/e_grass2_stage11` by -2.21 and `game/rw_gcn_core` by
+-2.08. Worth trying per unit, never worth adopting broadly. The contrast with
+`-pool off` below is the useful part: pooling announces itself in our object
+with an anchor symbol, so it can be decided from evidence, while multiple-word
+moves have no such tell and only the report can settle them.
+
 **Data pooling is on where retail had it off.** mwcc's `-pool` collects a
 translation unit's static data behind one anchor and addresses every object as
 `base + offset`; retail emits a `lis`/`addi` pair per symbol. Our object gives


### PR DESCRIPTION
`-pool off` in #482 moved nineteen units, so the obvious next question is
whether another CodeWarrior flag does the same. `-use_lmw_stmw on` does not,
and the sweep is worth recording because it is the cheapest way to stop the
next person repeating it.

Applied to all 43 open units, it improves three and regresses seventeen.

## Kept

| unit | before | after | delta |
| --- | ---: | ---: | ---: |
| `rel/spboss_throw_object` | 29.50 | 30.55 | +1.05 |
| `rel/light_collision_stage11` | 43.24 | 43.31 | +0.07 |
| `rel/e_wall_stage11` | 83.69 | 83.74 | +0.05 |

## Not kept

The worst of the seventeen: `rel/e_grass2_stage11` -2.21, `game/rw_gcn_core`
-2.08, `game/rw_gcn_raster` -1.96, `rel/e_grass_stage11` -1.57,
`game/rw_gcn_allinone` -1.45, `rel/e_tree_stage11` -1.28,
`rel/e_spider_stage11` -1.07. Those units keep their current flags.

The contrast with `-pool off` is the part worth keeping. Pooling announces
itself in our own object — a symbol named `...bss.0` or `...data.0` — so it can
be decided from evidence before building anything. Multiple-word moves have no
such tell, so only the report settles them, one unit at a time. Recorded in the
doc.

Project measure unchanged at 9.34% fuzzy, 7.46% matched. All three stay
`NonMatching`.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
