### PR TITLE
decomp: restore the parameter m2c named arg1 without declaring arg0

### DIFF
--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -222,6 +222,24 @@ knowing why before someone tries. Two obstacles came up:
   has to be settled against the target's register setup at the call site rather
   than by majority.
 
+**m2c names a dropped parameter for you.** When it decides a function takes
+one argument but the target reads r4, it still calls that parameter `arg1` —
+the number is the register position it came from, not the position in the list
+it wrote. So a function whose *first* declared parameter is named `arg1` is
+missing `arg0`:
+
+```c
+void fn_8_B9548(s32 arg1)      /* target: mr r3, r4; bl fn_8_90B10 */
+{
+	fn_8_90B10(arg1);
+}
+```
+
+Sixty-seven functions across twenty files have that shape, and it is a one-line
+grep: the first parameter's name. Prepending `void* arg0` moved nine units,
+`game/rw_gcn_render` by +1.22. Three files have to be left out because a call
+site inside the file then needs the argument too, and one measures worse.
+
 **A `(...)` extern can hide a lost argument.** m2c cannot see an argument that
 was already in the right register. `fn_8_C4B58` in `rel/e_tree_stage11` calls
 `fn_8013F484` right after `mr r30, r3`, so r3 still holds the function's own

--- a/src/game/rw_gcn_render.c
+++ b/src/game/rw_gcn_render.c
@@ -2221,7 +2221,7 @@ u8* fn_8022E09C(u8* arg0, u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_8022E46C(u8* arg1)
+u8* fn_8022E46C(void* arg0, u8* arg1)
 {
 	f32 temp_f1;
 	f32 temp_f4;
@@ -2277,7 +2277,7 @@ u8* fn_8022E46C(u8* arg1)
 	return arg1;
 }
 
-u8* fn_8022E5D4(u8* arg1, u8* arg2)
+u8* fn_8022E5D4(void* arg0, u8* arg1, u8* arg2)
 {
 	s32 temp_r31;
 	s32 temp_r3;
@@ -2295,7 +2295,7 @@ u8* fn_8022E5D4(u8* arg1, u8* arg2)
 	return arg2;
 }
 
-u8* fn_8022E674(u8* arg1, s32* arg2)
+u8* fn_8022E674(void* arg0, u8* arg1, s32* arg2)
 {
 	s32 var_r0;
 	u32* temp_r6;
@@ -2309,7 +2309,7 @@ u8* fn_8022E674(u8* arg1, s32* arg2)
 	return arg1;
 }
 
-u8* fn_8022E6D4(u8* arg1, s32 arg2)
+u8* fn_8022E6D4(void* arg0, u8* arg1, s32 arg2)
 {
 	s32 temp_r3;
 	u8* temp_r30;
@@ -2325,7 +2325,7 @@ u8* fn_8022E6D4(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_8022E774(u8* arg1, s32 arg2)
+u8* fn_8022E774(void* arg0, u8* arg1, s32 arg2)
 {
 	s32 temp_r3;
 	u8* temp_r30;
@@ -2461,7 +2461,7 @@ u8* fn_8022E814(u8* arg0, u8* arg1, f32* arg2)
 	return arg1;
 }
 
-u8* fn_8022EB2C(u8* arg1)
+u8* fn_8022EB2C(void* arg0, u8* arg1)
 {
 	s32 spB8;
 	s32 spB4;
@@ -3160,7 +3160,7 @@ u8* fn_8022EB2C(u8* arg1)
 	return var_r15;
 }
 
-u8* fn_8022FA00(u8* arg1, u8* arg2)
+u8* fn_8022FA00(void* arg0, u8* arg1, u8* arg2)
 {
 	s32* temp_r4;
 	s32* temp_r4_2;
@@ -3212,7 +3212,7 @@ u8* fn_8022FA00(u8* arg1, u8* arg2)
 	return arg2;
 }
 
-u8* fn_8022FB60(u8* arg1, s32* arg2)
+u8* fn_8022FB60(void* arg0, u8* arg1, s32* arg2)
 {
 	s32 temp_r3;
 	s32 temp_r3_2;
@@ -3240,7 +3240,7 @@ u8* fn_8022FB60(u8* arg1, s32* arg2)
 	return arg1;
 }
 
-u8* fn_8022FC2C(u8* arg1, s32 arg2)
+u8* fn_8022FC2C(void* arg0, u8* arg1, s32 arg2)
 {
 	s32 temp_r3;
 	s32 temp_r3_2;
@@ -3309,7 +3309,7 @@ u8* fn_8022FC2C(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_8022FE30(u8* arg1, s32 arg2)
+u8* fn_8022FE30(void* arg0, u8* arg1, s32 arg2)
 {
 	s32 temp_r3;
 	s32 temp_r3_2;
@@ -3353,7 +3353,7 @@ u8* fn_8022FE30(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_8022FF58(u8* arg1)
+u8* fn_8022FF58(void* arg0, u8* arg1)
 {
 	u8* sp8;
 	s32 temp_r3;
@@ -3474,7 +3474,7 @@ u8* fn_802301CC(u8* arg0, u8* arg1, f32* arg2)
 	return arg1;
 }
 
-u8* fn_8023031C(u8* arg1, M2C_UNK arg_sp0)
+u8* fn_8023031C(void* arg0, u8* arg1, M2C_UNK arg_sp0)
 {
 	f32 sp24;
 	f32 sp20;
@@ -3662,7 +3662,7 @@ u8* fn_8023031C(u8* arg1, M2C_UNK arg_sp0)
 	return var_r19;
 }
 
-u8* fn_80230794(u8* arg1, u8* arg2)
+u8* fn_80230794(void* arg0, u8* arg1, u8* arg2)
 {
 	s32* temp_r4;
 	s32 temp_r31;
@@ -3682,7 +3682,7 @@ u8* fn_80230794(u8* arg1, u8* arg2)
 	return arg2;
 }
 
-u8* fn_80230834(u8* arg1, s32* arg2)
+u8* fn_80230834(void* arg0, u8* arg1, s32* arg2)
 {
 	s32 temp_r3;
 	s32 var_r31;
@@ -3698,7 +3698,7 @@ u8* fn_80230834(u8* arg1, s32* arg2)
 	return arg1;
 }
 
-u8* fn_802308A4(u8* arg1, s32 arg2)
+u8* fn_802308A4(void* arg0, u8* arg1, s32 arg2)
 {
 	s32 temp_r3;
 	u32* temp_r30;
@@ -3723,7 +3723,7 @@ u8* fn_802308A4(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_8023096C(u8* arg1, s32 arg2)
+u8* fn_8023096C(void* arg0, u8* arg1, s32 arg2)
 {
 	s32 temp_r3;
 	u32* temp_r30;
@@ -3741,7 +3741,7 @@ u8* fn_8023096C(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_802309F8(u8* arg1)
+u8* fn_802309F8(void* arg0, u8* arg1)
 {
 	u8* sp8;
 	s32 temp_r3;
@@ -3770,7 +3770,7 @@ u8* fn_802309F8(u8* arg1)
 	return arg1;
 }
 
-u8* fn_80230AF0(u8* arg1)
+u8* fn_80230AF0(void* arg0, u8* arg1)
 {
 	f32 sp1C;
 	f32 sp18;
@@ -3933,7 +3933,7 @@ u8* fn_80230AF0(u8* arg1)
 	return arg1;
 }
 
-u8* fn_80230F78(u8* arg1, u8* arg2)
+u8* fn_80230F78(void* arg0, u8* arg1, u8* arg2)
 {
 	s32 temp_r31;
 	s32 temp_r3;
@@ -3948,7 +3948,7 @@ u8* fn_80230F78(u8* arg1, u8* arg2)
 	return arg2;
 }
 
-u8* fn_80231004(u8* arg1, s32* arg2)
+u8* fn_80231004(void* arg0, u8* arg1, s32* arg2)
 {
 	s32 var_r0;
 	u32* temp_r6;
@@ -3962,7 +3962,7 @@ u8* fn_80231004(u8* arg1, s32* arg2)
 	return arg1;
 }
 
-u8* fn_80231064(u8* arg1, s32 arg2)
+u8* fn_80231064(void* arg0, u8* arg1, s32 arg2)
 {
 	u32 sp8;
 	s32 temp_r3;
@@ -3988,7 +3988,7 @@ u8* fn_80231064(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_8023113C(u8* arg1, s32 arg2)
+u8* fn_8023113C(void* arg0, u8* arg1, s32 arg2)
 {
 	u32 sp8;
 	s32 temp_r3;
@@ -4012,7 +4012,7 @@ u8* fn_8023113C(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_80231208(u8* arg1)
+u8* fn_80231208(void* arg0, u8* arg1)
 {
 	f32 sp1C;
 	f32 sp18;
@@ -4162,7 +4162,7 @@ u8* fn_80231208(u8* arg1)
 	return arg1;
 }
 
-u8* fn_802315DC(u8* arg1, u8* arg2)
+u8* fn_802315DC(void* arg0, u8* arg1, u8* arg2)
 {
 	s32 temp_r31;
 	s32 temp_r3;
@@ -4177,7 +4177,7 @@ u8* fn_802315DC(u8* arg1, u8* arg2)
 	return arg2;
 }
 
-u8* fn_80231668(u8* arg1, s32* arg2)
+u8* fn_80231668(void* arg0, u8* arg1, s32* arg2)
 {
 	s32 var_r0;
 	u32* temp_r6;
@@ -4191,7 +4191,7 @@ u8* fn_80231668(u8* arg1, s32* arg2)
 	return arg1;
 }
 
-u8* fn_802316C8(u8* arg1, s32 arg2)
+u8* fn_802316C8(void* arg0, u8* arg1, s32 arg2)
 {
 	u32 sp8;
 	s32 temp_r3;
@@ -4215,7 +4215,7 @@ u8* fn_802316C8(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_80231780(u8* arg1, s32 arg2)
+u8* fn_80231780(void* arg0, u8* arg1, s32 arg2)
 {
 	u32 sp8;
 	s32 temp_r3;
@@ -4237,7 +4237,7 @@ u8* fn_80231780(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_8023182C(u8* arg1, u8* arg_sp0)
+u8* fn_8023182C(void* arg0, u8* arg1, u8* arg_sp0)
 {
 	f32 sp1C;
 	f32 sp18;
@@ -4409,7 +4409,7 @@ u8* fn_8023182C(u8* arg1, u8* arg_sp0)
 	return arg1;
 }
 
-u8* fn_80231CE8(u8* arg1, u8* arg2)
+u8* fn_80231CE8(void* arg0, u8* arg1, u8* arg2)
 {
 	s32 temp_r31;
 	s32 temp_r3;
@@ -4436,7 +4436,7 @@ u8* fn_80231CE8(u8* arg1, u8* arg2)
 	return arg2;
 }
 
-u8* fn_80231DB8(u8* arg1, s32* arg2)
+u8* fn_80231DB8(void* arg0, u8* arg1, s32* arg2)
 {
 	s32 temp_r3;
 	s32 var_r4;
@@ -4464,7 +4464,7 @@ u8* fn_80231DB8(u8* arg1, s32* arg2)
 	return arg1;
 }
 
-u8* fn_80231E5C(u8* arg1, s32 arg2)
+u8* fn_80231E5C(void* arg0, u8* arg1, s32 arg2)
 {
 	u32 sp8;
 	s32 temp_r3;
@@ -4505,7 +4505,7 @@ u8* fn_80231E5C(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_80231FAC(u8* arg1, s32 arg2)
+u8* fn_80231FAC(void* arg0, u8* arg1, s32 arg2)
 {
 	u32 sp8;
 	s32 temp_r3;
@@ -4544,7 +4544,7 @@ u8* fn_80231FAC(u8* arg1, s32 arg2)
 	return arg1;
 }
 
-u8* fn_80232114(u8* arg1)
+u8* fn_80232114(void* arg0, u8* arg1)
 {
 	u8* sp8;
 	u32* temp_r5;

--- a/src/rel/e_capture.cpp
+++ b/src/rel/e_capture.cpp
@@ -409,7 +409,7 @@ void fn_8_98060(void* arg0)
 	}
 }
 
-void fn_8_980F8(s32 arg1)
+void fn_8_980F8(void* arg0, s32 arg1)
 {
 	fn_8_90B10(arg1);
 }
@@ -516,7 +516,7 @@ s32 fn_8_9832C(void* arg0)
 	return var_r0;
 }
 
-s32 fn_8_983D8(void* arg1, s32 arg2, u8 arg3)
+s32 fn_8_983D8(void* arg0, void* arg1, s32 arg2, u8 arg3)
 {
 	s32* temp_r6;
 	void* temp_r0;
@@ -2930,7 +2930,7 @@ TObject* fn_8_9CA9C(void)
 	return var_r0;
 }
 
-void fn_8_9CAF0(void* arg1)
+void fn_8_9CAF0(void* arg0, void* arg1)
 {
 	f32* var_r4_3;
 	f32* var_r4_4;

--- a/src/rel/e_flyer_collision_stage11.cpp
+++ b/src/rel/e_flyer_collision_stage11.cpp
@@ -1075,7 +1075,7 @@ TObject* fn_8_A7E24(void)
 	return temp_r3;
 }
 
-void fn_8_A7FA4(void* arg1)
+void fn_8_A7FA4(void* arg0, void* arg1)
 {
 	s32* var_r5_2;
 	s32 temp_r6;

--- a/src/rel/e_flyer_path_stage11.cpp
+++ b/src/rel/e_flyer_path_stage11.cpp
@@ -1508,7 +1508,7 @@ s32 fn_8_AABC8(void* arg0)
 	return ((lbl_8_rodata_1ACC * (f32)fn_801C28D8()) < lbl_8_rodata_1AD0) == 0;
 }
 
-void fn_8_AAC6C(s32 arg1)
+void fn_8_AAC6C(void* arg0, s32 arg1)
 {
 	fn_8_90B10(arg1);
 }

--- a/src/rel/e_flyer_stage11.cpp
+++ b/src/rel/e_flyer_stage11.cpp
@@ -714,7 +714,7 @@ void fn_8_A325C(void* arg0)
 	}
 }
 
-void fn_8_A3420(s32 arg1)
+void fn_8_A3420(void* arg0, s32 arg1)
 {
 	fn_8_90B10(arg1);
 }
@@ -1472,7 +1472,7 @@ void fn_8_A4830(void* arg0, void* arg1, void* arg2)
 	}
 }
 
-void fn_8_A4AC0(void* arg1, void* arg2)
+void fn_8_A4AC0(void* arg0, void* arg1, void* arg2)
 {
 	f32 temp_f1;
 
@@ -2430,7 +2430,7 @@ M2C_UNK* fn_8_A66D4(void)
 	return var_r0;
 }
 
-void fn_8_A6728(void* arg1)
+void fn_8_A6728(void* arg0, void* arg1)
 {
 	f32* var_r4_3;
 	f32 temp_f1;

--- a/src/rel/e_grass2_stage11.cpp
+++ b/src/rel/e_grass2_stage11.cpp
@@ -638,7 +638,7 @@ s32 fn_8_C5BB8(s32 arg0, void** arg1)
 	return 0;
 }
 
-void fn_8_C5C1C(void* arg1)
+void fn_8_C5C1C(void* arg0, void* arg1)
 {
 	void* temp_r5;
 

--- a/src/rel/e_grass_stage11.cpp
+++ b/src/rel/e_grass_stage11.cpp
@@ -800,7 +800,7 @@ s32 fn_8_C70C4(s32 arg0, void** arg1)
 	return 0;
 }
 
-void fn_8_C7128(void* arg1)
+void fn_8_C7128(void* arg0, void* arg1)
 {
 	void* temp_r5;
 

--- a/src/rel/e_magician_stage11.cpp
+++ b/src/rel/e_magician_stage11.cpp
@@ -1146,7 +1146,7 @@ TEnemyParalysis* fn_8_AF390(void)
 	return var_r0;
 }
 
-void fn_8_AF3E8(void* arg1)
+void fn_8_AF3E8(void* arg0, void* arg1)
 {
 	f32* var_r4_2;
 	f32* var_r4_3;

--- a/src/rel/e_mask_stage11.cpp
+++ b/src/rel/e_mask_stage11.cpp
@@ -550,7 +550,7 @@ s32 fn_8_C9E7C(s32 arg0, void** arg1)
 	return 0;
 }
 
-void fn_8_C9EE0(void* arg1)
+void fn_8_C9EE0(void* arg0, void* arg1)
 {
 	void* temp_r3;
 

--- a/src/rel/e_rinoliner_collision_stage11.cpp
+++ b/src/rel/e_rinoliner_collision_stage11.cpp
@@ -1892,7 +1892,7 @@ TObject* fn_8_B6DC0(void)
 	return temp_r3;
 }
 
-void fn_8_B6F14(void* arg1)
+void fn_8_B6F14(void* arg0, void* arg1)
 {
 	u8* temp_r3;
 	u8* var_r5;

--- a/src/rel/e_rinoliner_stage11.cpp
+++ b/src/rel/e_rinoliner_stage11.cpp
@@ -1076,7 +1076,7 @@ TEnemyParalysis* fn_8_B4394(void)
 	return var_r0;
 }
 
-void fn_8_B43E8(void* arg1)
+void fn_8_B43E8(void* arg0, void* arg1)
 {
 	f32* var_r4_4;
 	f32* var_r4_6;

--- a/src/rel/e_s11_flag_stage11.cpp
+++ b/src/rel/e_s11_flag_stage11.cpp
@@ -850,7 +850,7 @@ TObject* fn_8_C8688(TObject* arg0, TObject* arg1)
 	return arg0;
 }
 
-void fn_8_C8C34(void* arg1)
+void fn_8_C8C34(void* arg0, void* arg1)
 {
 	void* temp_r5;
 

--- a/src/rel/e_spider_stage11.cpp
+++ b/src/rel/e_spider_stage11.cpp
@@ -488,7 +488,7 @@ TObject* fn_8_C31F0(TObject* arg0, TObject* arg1)
 	return arg0;
 }
 
-void fn_8_C33D0(void* arg1)
+void fn_8_C33D0(void* arg0, void* arg1)
 {
 	s32* temp_r3;
 

--- a/src/rel/e_strategy_magician_stage11.cpp
+++ b/src/rel/e_strategy_magician_stage11.cpp
@@ -209,7 +209,7 @@ s32 fn_8_AABC8(void* arg0)
 	return ((lbl_8_rodata_1ACC * (f32)fn_801C28D8()) < lbl_8_rodata_1AD0) == 0;
 }
 
-void fn_8_AAC6C(s32 arg1)
+void fn_8_AAC6C(void* arg0, s32 arg1)
 {
 	fn_8_90B10(arg1);
 }

--- a/src/rel/e_turtle_stage11.cpp
+++ b/src/rel/e_turtle_stage11.cpp
@@ -865,7 +865,7 @@ void fn_8_BE5AC(void* arg0, void* arg1)
 	}
 }
 
-void fn_8_BE644(s32 arg1)
+void fn_8_BE644(void* arg0, s32 arg1)
 {
 	fn_8_90B10(arg1);
 }
@@ -2843,7 +2843,7 @@ TEnemyParalysis* fn_8_C2344(void)
 	return var_r0;
 }
 
-void fn_8_C2398(void* arg1)
+void fn_8_C2398(void* arg0, void* arg1)
 {
 	f32* var_r4_3;
 	f32* var_r4_4;

--- a/src/rel/e_wall_stage11.cpp
+++ b/src/rel/e_wall_stage11.cpp
@@ -1576,7 +1576,7 @@ void fn_8_B93A4(void* arg0)
 	}
 }
 
-void fn_8_B9548(s32 arg1)
+void fn_8_B9548(void* arg0, s32 arg1)
 {
 	fn_8_90B10(arg1);
 }
@@ -3694,7 +3694,7 @@ TObject* fn_8_BD32C(void)
 	return var_r0;
 }
 
-void fn_8_BD380(void* arg1)
+void fn_8_BD380(void* arg0, void* arg1)
 {
 	f32* var_r4_3;
 	f32* var_r4_4;

--- a/src/rel/o_s11_door.cpp
+++ b/src/rel/o_s11_door.cpp
@@ -595,7 +595,7 @@ TObject* fn_8_96018(TObject* arg0, TObject* arg1)
 	return arg0;
 }
 
-void fn_8_964DC(void* arg1)
+void fn_8_964DC(void* arg0, void* arg1)
 {
 	u8* temp_r3;
 


### PR DESCRIPTION
m2c names a dropped parameter for you, and nobody had noticed.

When it decides a function takes one argument but the target reads r4, it still
calls that parameter `arg1` — the number is the register position the value
came from, not its position in the list m2c wrote. So a function whose *first*
declared parameter is named `arg1` is missing `arg0`:

```c
void fn_8_B9548(s32 arg1)      /* target: mr r3, r4 ; bl fn_8_90B10 */
{
	fn_8_90B10(arg1);
}
```

Ours skips the `mr` because the value it passes is already in r3. Five units
have that exact three-line function, and the shape generalises: sixty-seven
functions across twenty files declare a first parameter named `arg1`. It is a
one-line grep, no disassembly needed.

## Measured

| unit | before | after | delta |
| --- | ---: | ---: | ---: |
| `game/rw_gcn_render` | 66.63 | 67.85 | +1.22 |
| `rel/e_flyer_stage11` | 80.06 | 80.11 | +0.05 |
| `rel/e_strategy_magician_stage11` | 81.69 | 81.73 | +0.05 |
| `rel/e_flyer_collision_stage11` | 77.92 | 77.97 | +0.04 |
| `rel/e_rinoliner_collision_stage11` | 78.42 | 78.45 | +0.03 |
| `rel/e_capture` | 85.31 | 85.34 | +0.03 |
| `rel/e_turtle_stage11` | 86.73 | 86.75 | +0.02 |
| `rel/e_wall_stage11` | 83.74 | 83.75 | +0.02 |
| `rel/e_spider_stage11` | 85.75 | 85.75 | +0.01 |

Project `matched_code` 7.46% -> **7.47%**. All units stay `NonMatching`.

## Left out

`rel/o_s12_celestial_sphere` and `game/rw_gcn_core` do not compile after the
change, because a call site inside the file then needs the extra argument and
its value has to come from the target. `rel/o_colli_communication_stage11`
compiles and measures -0.02, so it is reverted too. The other seventeen files
are in.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
