### PR TITLE
decomp: make bool an int and fix a narrow struct and a folded multiply

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -583,27 +583,27 @@ config.libs = [
             Object(
                 NonMatching,
                 "game/cri/svm.c",
-                extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
+                extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "game/cri/axrna.c",
-                extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
+                extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "game/cri/rnares.c",
-                extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on"],
+                extra_cflags=["-sdata 0", "-sdata2 0", "-str reuse,readonly", "-use_lmw_stmw on", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "game/rw_gcn_core.c",
-                extra_cflags=["-str reuse,readonly"],
+                extra_cflags=["-str reuse,readonly", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "game/rw_gcn_render.c",
-                extra_cflags=["-str reuse,readonly"],
+                extra_cflags=["-str reuse,readonly", "-opt nopropagation", "-bool off"],
             ),
             Object(
                 Matching,
@@ -623,12 +623,12 @@ config.libs = [
             Object(
                 NonMatching,
                 "game/rw_gcn_allinone.c",
-                extra_cflags=["-str reuse,readonly"],
+                extra_cflags=["-str reuse,readonly", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "game/rw_gcn_raster.c",
-                extra_cflags=["-str reuse,readonly"],
+                extra_cflags=["-str reuse,readonly", "-bool off"],
             ),
             Object(
                 Matching,
@@ -1286,6 +1286,7 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-bool off",
                 ],
             ),
             Object(
@@ -1295,6 +1296,7 @@ config.libs = [
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
                     "-pool off",
+                    "-bool off",
                 ],
                 data_section_alignment=4,
             ),
@@ -1305,6 +1307,7 @@ config.libs = [
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
                     "-pool off",
+                    "-bool off",
                 ],
             ),
             Object(
@@ -1313,6 +1316,7 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-bool off",
                 ],
             ),
             Object(
@@ -1331,6 +1335,8 @@ config.libs = [
                     "-opt noschedule,nopropagation,nopeephole",
                     "-use_lmw_stmw on",
 
+                    "-bool off",
+
                 ],
             ),
             Object(
@@ -1339,6 +1345,7 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-bool off",
                 ],
             ),
             Object(
@@ -1347,6 +1354,7 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-bool off",
                 ],
             ),
             Object(
@@ -1355,6 +1363,7 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-bool off",
                 ],
             ),
             Object(
@@ -1363,6 +1372,7 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-bool off",
                 ],
             ),
             Object(
@@ -1371,6 +1381,7 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-bool off",
                 ],
             ),
             Object(
@@ -1379,6 +1390,7 @@ config.libs = [
                 extra_cflags=[
                     "-inline noauto",
                     "-opt noschedule,nopropagation,nopeephole",
+                    "-bool off",
                 ],
             ),
             Object(
@@ -1660,22 +1672,22 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_strategy_flyer_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_capture_collision_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_flyer_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_flyer_collision_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 Matching,
@@ -1685,27 +1697,27 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_strategy_magician_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_flyer_path_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_strategy_rinoliner_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_magician_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/o_colli_communication_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole"],
+                extra_cflags=["-opt noschedule,nopeephole", "-bool off"],
             ),
             Object(
                 Matching,
@@ -1720,12 +1732,12 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_rinoliner_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_rinoliner_collision_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 Matching,
@@ -1745,7 +1757,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_turtle_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 Matching,
@@ -1757,6 +1769,7 @@ config.libs = [
                 "rel/e_wall_stage11.cpp",
                 extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off",
                     "-use_lmw_stmw on",
+                    "-bool off",
                 ],
             ),
             Object(
@@ -1767,7 +1780,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_capture.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 Matching,
@@ -2012,12 +2025,12 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_grass2_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_grass_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 Matching,
@@ -2052,7 +2065,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_mask_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 Matching,
@@ -2457,12 +2470,12 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_s11_flag_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/o_s11_door.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-bool off"],
             ),
             Object(
                 Matching,
@@ -2477,7 +2490,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_s11_key_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 Matching,
@@ -2487,7 +2500,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_spider_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 Matching,
@@ -2502,12 +2515,12 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/o_s12_celestial_sphere.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_fan_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-bool off"],
             ),
             Object(
                 Matching,
@@ -2802,7 +2815,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_tree_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 Matching,
@@ -3317,19 +3330,20 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/object_effects_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/light_collision_stage11.cpp",
                 extra_cflags=["-opt noschedule,nopropagation,nopeephole",
                     "-use_lmw_stmw on",
+                    
                 ],
             ),
             Object(
                 NonMatching,
                 "rel/goal_ring_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopropagation,nopeephole"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-bool off"],
             ),
             Object(
                 Matching,

--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -222,6 +222,17 @@ knowing why before someone tries. Two obstacles came up:
   has to be settled against the target's register setup at the call site rather
   than by majority.
 
+**A constant multiply that retail keeps in a register.** `fn_8022C300` in
+`game/rw_gcn_render` is `li r3, 0x16` then `mullw r3, r3, r0`, where this build
+folds it to one `mulli`. Same cause as the record flag fold — propagation sees
+the literal — and the same fix, `-opt nopropagation` on the unit.
+
+**A struct four bytes too narrow shifts every field after it.**
+`rel/particle_test` stored to 0x2c and 0x34 where the target uses 0x30 and
+0x38: its `motion` member is a two-word structure, not one pointer. The give-away
+is that *both* offsets are wrong by the same amount, so the fix is one padding
+member rather than two field edits.
+
 **m2c names a dropped parameter for you.** When it decides a function takes
 one argument but the target reads r4, it still calls that parameter `arg1` —
 the number is the register position it came from, not the position in the list
@@ -324,6 +335,21 @@ That took the unit from 94.51% to 95.90% and `left` from 54 to 47, with
 0x21 from the same register that holds the zero variable, and mwcc always
 materialises a fresh `li r0, 0x0` for the byte store no matter how the field or
 the variable is typed.
+
+**`bool` is a byte in C++ and an int in retail.** A float comparison returned
+as `s32` costs one extra instruction, because mwcc normalises the `bool` before
+widening it:
+
+```
+  xori r3, r0, 0x1      |  xori   r0, r0, 0x1
+                        |  clrlwi r3, r0, 24
+```
+
+`-bool off` makes `bool` an `int` and the mask disappears. Swept across the
+open units it improves eleven and regresses none; two units, `rel/propeller_stage11`
+and `rel/light_collision_stage11`, do not compile with it and keep their flags.
+Unlike `-use_lmw_stmw` this one is safe to try everywhere, because a unit that
+does not return a comparison is simply unaffected.
 
 **`-use_lmw_stmw on` is not a general answer, unlike `-pool off`.** Swept
 across all 43 open units it improves three — `rel/spboss_throw_object` (+1.05),

--- a/src/rel/particle_test.cpp
+++ b/src/rel/particle_test.cpp
@@ -13,6 +13,7 @@ struct Params {
 struct Object {
 	u8 base[0x28];
 	void* motion;
+	u8 unk2C[4];
 	void* particle;
 	u8 effect, family, pad[2];
 	s32 timer;


### PR DESCRIPTION
Three unrelated shapes found in the functions now within two instructions of
exact. One of them turned out to be a flag worth sweeping.

**`bool` is a byte in C++ and an int in retail.** `fn_8_98464` in
`rel/e_capture` returns a float comparison as `s32`, and mwcc normalises the
`bool` before widening it:

```
  xori r3, r0, 0x1      |  xori   r0, r0, 0x1
                        |  clrlwi r3, r0, 24
```

`-bool off` makes `bool` an `int` and the mask disappears. Swept across the
open units it improves eleven and regresses **none** — unlike `-use_lmw_stmw`
in #485, because a unit that never returns a comparison is simply unaffected.
`rel/propeller_stage11` and `rel/light_collision_stage11` do not compile with
it and keep their flags.

**A constant multiply retail keeps in a register.** `fn_8022C300` in
`game/rw_gcn_render`:

```
  li    r3, 0x16        |  mulli r3, r0, 0x16
  mullw r3, r3, r0      |
```

Same cause as the record flag fold in #480 — propagation sees the literal — and
the same fix, `-opt nopropagation` on the unit.

**A struct four bytes too narrow.** `fn_16_817B0` in `rel/particle_test` stores
to 0x2c and 0x34 where the target uses 0x30 and 0x38. Its `motion` member is a
two-word structure, not one pointer. Both offsets being wrong by the same
amount is the give-away, so it is one padding member rather than two field
edits.

## Measured

| unit | before | after | delta |
| --- | ---: | ---: | ---: |
| `game/rw_gcn_render` | 67.85 | 68.07 | +0.22 |
| `rel/e_capture` | 85.34 | 85.50 | +0.16 |
| `rel/e_rinoliner_stage11` | 83.88 | 83.99 | +0.10 |
| `rel/e_strategy_rinoliner_stage11` | 81.48 | 81.58 | +0.10 |
| `rel/e_turtle_stage11` | 86.75 | 86.83 | +0.08 |
| `rel/e_rinoliner_collision_stage11` | 78.45 | 78.53 | +0.08 |
| `rel/e_flyer_stage11` | 80.11 | 80.18 | +0.07 |
| `rel/e_strategy_flyer_stage11` | 90.11 | 90.17 | +0.06 |
| `rel/e_wall_stage11` | 83.75 | 83.81 | +0.06 |
| `rel/e_strategy_magician_stage11` | 81.73 | 81.78 | +0.05 |
| `rel/e_flyer_path_stage11` | 77.54 | 77.59 | +0.04 |
| `rel/e_magician_stage11` | 59.45 | 59.49 | +0.04 |
| `rel/particle_test` | 49.48 | 49.50 | +0.02 |

No regressions. All stay `NonMatching`.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
