### PR TITLE
decomp: add nopropagation to the five units that measure better with it

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -623,7 +623,9 @@ config.libs = [
             Object(
                 NonMatching,
                 "game/rw_gcn_allinone.c",
-                extra_cflags=["-str reuse,readonly", "-bool off"],
+                extra_cflags=["-str reuse,readonly", "-bool off",
+                    "-opt nopropagation",
+                ],
             ),
             Object(
                 NonMatching,
@@ -1682,7 +1684,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_flyer_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,
@@ -1697,12 +1699,12 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_strategy_magician_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,
                 "rel/e_flyer_path_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,
@@ -1732,7 +1734,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/e_rinoliner_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
+                extra_cflags=["-opt noschedule,nopropagation,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 NonMatching,

--- a/docs/units-returned-to-nonmatching.md
+++ b/docs/units-returned-to-nonmatching.md
@@ -351,6 +351,22 @@ and `rel/light_collision_stage11`, do not compile with it and keep their flags.
 Unlike `-use_lmw_stmw` this one is safe to try everywhere, because a unit that
 does not return a comparison is simply unaffected.
 
+**`-opt nopropagation` is per-unit, not a sweep.** It is the right fix wherever
+retail keeps a constant in a register that this build folds — the record flag
+word, the `mullw` in `game/rw_gcn_render` — but applied to every unit that
+lacked it, five improve and nine regress, `game/cri/axrna` by -4.69 and
+`game/cri/rnares` by -1.32. The CRI units in particular want propagation on.
+Read the folded instruction first, then add the flag to that unit.
+
+So far two flags sweep cleanly and two do not:
+
+| flag | improves | regresses | decidable without building? |
+| --- | ---: | ---: | --- |
+| `-pool off` | 19 | 2 | yes — anchor symbol `...bss.0` |
+| `-bool off` | 11 | 0 | yes — a `clrlwi rX, rY, 24` on a returned comparison |
+| `-opt nopropagation` | 5 | 9 | only from the folded instruction |
+| `-use_lmw_stmw on` | 3 | 17 | no |
+
 **`-use_lmw_stmw on` is not a general answer, unlike `-pool off`.** Swept
 across all 43 open units it improves three — `rel/spboss_throw_object` (+1.05),
 `rel/light_collision_stage11` (+0.07), `rel/e_wall_stage11` (+0.05) — and


### PR DESCRIPTION
`-opt nopropagation` has now been the right answer three times — the record
flag word in #480 and #483, the folded `mullw` in `game/rw_gcn_render` in #487
— so the question is whether it sweeps like `-pool off` did. It does not.

Applied to every open unit that lacked it: five improve, nine regress.

## Kept

| unit | before | after | delta |
| --- | ---: | ---: | ---: |
| `rel/e_flyer_path_stage11` | 77.59 | 77.83 | +0.24 |
| `rel/e_rinoliner_stage11` | 83.99 | 84.09 | +0.10 |
| `game/rw_gcn_allinone` | 49.23 | 49.32 | +0.09 |
| `rel/e_flyer_stage11` | 80.18 | 80.22 | +0.04 |
| `rel/e_strategy_magician_stage11` | 81.78 | 81.82 | +0.04 |

## Not kept

`game/cri/axrna` -4.69, `game/cri/rnares` -1.32, `game/cri/svm` -0.27,
`game/rw_gcn_raster` -0.26, `rel/e_grass_stage11` -0.15,
`rel/e_rinoliner_collision_stage11` -0.13, `rel/e_capture` -0.08,
`game/rw_gcn_core` -0.03, `rel/e_s11_key_stage11` -0.02.

The three CRI units all want propagation **on**, which is worth knowing before
anyone reaches for the flag there — `axrna` is the closest unit in the project
at 97.44% and this would have cost it nearly five points.

## Where the four flags stand

| flag | improves | regresses | decidable without building? |
| --- | ---: | ---: | --- |
| `-pool off` | 19 | 2 | yes — the anchor symbol `...bss.0` |
| `-bool off` | 11 | 0 | yes — a `clrlwi rX, rY, 24` on a returned comparison |
| `-opt nopropagation` | 5 | 9 | only from the folded instruction |
| `-use_lmw_stmw on` | 3 | 17 | no |

Recorded in the doc, because the useful part is not the five units — it is that
two of these four can be decided from the object and two cannot.

## Verification

```
python configure.py
python tools/check_language_policy.py     # 608 managed sources
python tools/check_post_processors.py     # 55 steps checked
ninja                                     # 18 files OK
git diff --check                          # clean
```
