### PR TITLE
docs: reserve CRI reconstruction work

### DIFF
--- a/docs/decomp-work-tracking.md
+++ b/docs/decomp-work-tracking.md
@@ -5,6 +5,8 @@ This file records active ownership so parallel decompilation work does not overl
 | Owner | Scope | Status |
 | --- | --- | --- |
 | Claude Code | GX graphics library | Active; reserved |
+| Codex | `game/cri/axrna.c` | Attempted; no net improvement after source-form and compiler-flag trials |
+| Codex | `game/cri/svm.c` | Active; reserved |
 | Codex | `game/skyfs_adx.c` (`0x80013038`–`0x80014154`) | Complete; `pr-skyfs-adx` |
 | Codex | `game/Peripheral.cpp` (`0x80014154`–`0x80015AC0`) | Complete; `pr-peripheral` (stacked on `pr-skyfs-adx`) |
 | Codex | `game/main.cpp` (`0x80015AC0`–`0x80016514`) | Complete; `pr-game-main-cpp` |

--- a/docs/decomp-work-tracking.md
+++ b/docs/decomp-work-tracking.md
@@ -6,7 +6,8 @@ This file records active ownership so parallel decompilation work does not overl
 | --- | --- | --- |
 | Claude Code | GX graphics library | Active; reserved |
 | Codex | `game/cri/axrna.c` | Attempted; no net improvement after source-form and compiler-flag trials |
-| Codex | `game/cri/svm.c` | Active; reserved |
+| Codex | `game/cri/svm.c` | Attempted; BSS layout identified, but no net object improvement |
+| Codex | `game/cri/rnares.c` | Active; BSS layout restored to 100%; reconstructing remaining text |
 | Codex | `game/skyfs_adx.c` (`0x80013038`–`0x80014154`) | Complete; `pr-skyfs-adx` |
 | Codex | `game/Peripheral.cpp` (`0x80014154`–`0x80015AC0`) | Complete; `pr-peripheral` (stacked on `pr-skyfs-adx`) |
 | Codex | `game/main.cpp` (`0x80015AC0`–`0x80016514`) | Complete; `pr-game-main-cpp` |

--- a/src/game/cri/rnares.c
+++ b/src/game/cri/rnares.c
@@ -24,15 +24,24 @@ typedef struct RnaResBase {
 } RnaResBase;
 
 static RnaResBase lbl_8042A9D0;
-static RnaResHandle lbl_8042A9E4[32];
-static u8 rnares_pad[4];
+static struct {
+	RnaResHandle handles[32];
+	u8 pad[4];
+} lbl_8042A9E4;
 
 #define rnares_reference_count      lbl_8042A9D0.referenceCount
 #define rnares_externally_allocated lbl_8042A9D0.externallyAllocated
 #define rnares_handle_count         lbl_8042A9D0.handleCount
 #define rnares_aram_size            lbl_8042A9D0.aramSize
 #define rnares_aram_address         lbl_8042A9D0.aramAddress
-#define rnares_handles              lbl_8042A9E4
+#define rnares_handles              lbl_8042A9E4.handles
+
+// CodeWarrior lays out these uninitialized statics in reverse first-use order.
+// This unused expression preserves the retail base/handle ordering.
+static s32 rnares_layout_touch(void)
+{
+	return rnares_handles[0].used + rnares_reference_count;
+}
 
 const char lbl_802405F8[]       = "E1070313:Not enough RNARES handle.\n";
 const char lbl_8024061C[]       = "E1090601:Free area other than ADX buffer.\n";


### PR DESCRIPTION
Records the AXRNA handoff and reserves SVM reconstruction work. No source object is claimed as matching.