### PR TITLE
match: remove RNA resource layout placeholder

### DIFF
--- a/docs/decomp-work-tracking.md
+++ b/docs/decomp-work-tracking.md
@@ -7,7 +7,7 @@ This file records active ownership so parallel decompilation work does not overl
 | Claude Code | GX graphics library | Active; reserved |
 | Codex | `game/cri/axrna.c` | Attempted; no net improvement after source-form and compiler-flag trials |
 | Codex | `game/cri/svm.c` | Attempted; BSS layout identified, but no net object improvement |
-| Codex | `game/cri/rnares.c` | Active; BSS layout restored to 100%; reconstructing remaining text |
+| Codex | `game/cri/rnares.c` | Active; handle aggregate restored; reconstructing the original BSS first-use order and text |
 | Codex | `game/skyfs_adx.c` (`0x80013038`–`0x80014154`) | Complete; `pr-skyfs-adx` |
 | Codex | `game/Peripheral.cpp` (`0x80014154`–`0x80015AC0`) | Complete; `pr-peripheral` (stacked on `pr-skyfs-adx`) |
 | Codex | `game/main.cpp` (`0x80015AC0`–`0x80016514`) | Complete; `pr-game-main-cpp` |

--- a/src/game/cri/rnares.c
+++ b/src/game/cri/rnares.c
@@ -36,13 +36,6 @@ static struct {
 #define rnares_aram_address         lbl_8042A9D0.aramAddress
 #define rnares_handles              lbl_8042A9E4.handles
 
-// CodeWarrior lays out these uninitialized statics in reverse first-use order.
-// This unused expression preserves the retail base/handle ordering.
-static s32 rnares_layout_touch(void)
-{
-	return rnares_handles[0].used + rnares_reference_count;
-}
-
 const char lbl_802405F8[]       = "E1070313:Not enough RNARES handle.\n";
 const char lbl_8024061C[]       = "E1090601:Free area other than ADX buffer.\n";
 const u8 gap_06_80240647_rodata = 0;


### PR DESCRIPTION
Removes the emitted layout-only helper from rnares.c. The helper altered .text and is not retained as a legitimate reconstruction. Keeps the real handle aggregate evidence and tracks the unresolved first-use ordering.