### PR TITLE
match: recover raster matrix helper types

### DIFF
--- a/docs/decomp-work-tracking.md
+++ b/docs/decomp-work-tracking.md
@@ -8,7 +8,7 @@ This file records active ownership so parallel decompilation work does not overl
 | Codex | `game/cri/axrna.c` | Attempted; no net improvement after source-form and compiler-flag trials |
 | Codex | `game/cri/svm.c` | Attempted; BSS layout identified, but no net object improvement |
 | Codex | `game/cri/rnares.c` | Attempted; aggregate evidence retained, no text improvement without synthetic layout code |
-| Codex | `game/rw_gcn_raster.c` | Active; reserved |
+| Codex | `game/rw_gcn_raster.c` | Active; `fn_80227300` restored to 100%; continuing |
 | Codex | `game/skyfs_adx.c` (`0x80013038`–`0x80014154`) | Complete; `pr-skyfs-adx` |
 | Codex | `game/Peripheral.cpp` (`0x80014154`–`0x80015AC0`) | Complete; `pr-peripheral` (stacked on `pr-skyfs-adx`) |
 | Codex | `game/main.cpp` (`0x80015AC0`–`0x80016514`) | Complete; `pr-game-main-cpp` |

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -1475,14 +1475,14 @@ block_19:
 	return temp_r30;
 }
 
-void fn_80227300(u8* arg0, u32 arg1, s32 arg2)
+void fn_80227300(u8* arg0, s32 arg1, u32 arg2)
 {
 	f32 sp8[12];
+	s32 temp_r31;
 	s32 temp_r30;
-	u32 temp_r31;
 
-	temp_r30 = arg2;
 	temp_r31 = arg1;
+	temp_r30 = arg2;
 	sp8[0]   = -M2C_FIELD(arg0, f32*, 0);
 	sp8[1]   = -M2C_FIELD(arg0, f32*, 0x10);
 	sp8[2]   = -M2C_FIELD(arg0, f32*, 0x20);


### PR DESCRIPTION
Reconstructs the signedness and local ordering for fn_80227300. The compiled function is now a 100% objdiff match; the unit .text rises from 82.005035% to 82.010345%.