### PR TITLE
match: improve raster native stream locals

### DIFF
--- a/docs/decomp-work-tracking.md
+++ b/docs/decomp-work-tracking.md
@@ -8,7 +8,7 @@ This file records active ownership so parallel decompilation work does not overl
 | Codex | `game/cri/axrna.c` | Attempted; no net improvement after source-form and compiler-flag trials |
 | Codex | `game/cri/svm.c` | Attempted; BSS layout identified, but no net object improvement |
 | Codex | `game/cri/rnares.c` | Attempted; aggregate evidence retained, no text improvement without synthetic layout code |
-| Codex | `game/rw_gcn_raster.c` | Active; `fn_80227300` restored to 100%; continuing |
+| Codex | `game/rw_gcn_raster.c` | Active; `fn_80227300` restored to 100%, `fn_80225BF0` improved; continuing |
 | Codex | `game/skyfs_adx.c` (`0x80013038`–`0x80014154`) | Complete; `pr-skyfs-adx` |
 | Codex | `game/Peripheral.cpp` (`0x80014154`–`0x80015AC0`) | Complete; `pr-peripheral` (stacked on `pr-skyfs-adx`) |
 | Codex | `game/main.cpp` (`0x80015AC0`–`0x80016514`) | Complete; `pr-game-main-cpp` |

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -562,10 +562,10 @@ s32 fn_80225B60(u8* arg0)
 s32* fn_80225BF0(s32* arg0, s32* unused_arg1, s32* arg2)
 {
 	s32 sp8;
+	u8* temp_r31;
 	s32 temp_r30;
 	s32 temp_r6;
 	s32 temp_r7;
-	u8* temp_r31;
 
 	temp_r31 = M2C_FIELD(arg2, u8**, M2C_FIELD(lbl_8029BB30, s32*, 8));
 	if (temp_r31 != NULL) {


### PR DESCRIPTION
Orders the persistent native-stream locals so CodeWarrior assigns the retail registers in fn_80225BF0. Function match improves from 98.87209% to 99.74419%; unit .text rises to 82.03023%.