### PR TITLE
ci: add non-blocking match-progress check against main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,7 @@ jobs:
 
     - name: Download objdiff-cli
       run: |
+        mkdir -p build/tools
         tag=$(sed -n 's/^config\.objdiff_tag = "\(.*\)"$/\1/p' configure.py)
         python3 tools/download_tool.py objdiff-cli build/tools/objdiff-cli --tag "$tag"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,88 @@ jobs:
         name: ${{ matrix.version }}_report
         path: build/${{ matrix.version }}/report.json
 
+  # Informational for now: not in the required status checks. objdiff-cli's
+  # report/report-changes plumbing (baseline.json, changes_fmt.py) already
+  # existed for local use before this job; this just points it at the last
+  # successful main build instead of a manually-created local snapshot.
+  #
+  # A per-function match percentage moving backward inside a still-NonMatching
+  # unit is invisible to the SHA-1 check below: that unit's compiled source
+  # isn't linked into the compared artifacts yet, so nothing there catches a
+  # claimed improvement that was actually a regression. This job is the check
+  # for that specific gap, not a replacement for the SHA-1 verification.
+  progress_report:
+    name: match progress vs main (G9SE8P)
+    if: github.event_name == 'pull_request' && needs.private_build.result == 'success'
+    needs: private_build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        sparse-checkout: |
+          tools
+          configure.py
+
+    - name: Download this run's report
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: G9SE8P_report
+        path: build/G9SE8P
+
+    - name: Download objdiff-cli
+      run: |
+        tag=$(sed -n 's/^config\.objdiff_tag = "\(.*\)"$/\1/p' configure.py)
+        python3 tools/download_tool.py objdiff-cli build/tools/objdiff-cli --tag "$tag"
+
+    - name: Find the latest successful main-branch build
+      id: baseline
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        run_id=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow build.yml \
+            --branch main --status success --limit 1 --json databaseId \
+            --jq '.[0].databaseId // empty')
+        echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+        if [ -z "$run_id" ]; then
+          echo "::warning::No successful main-branch build found yet (first run, or its report artifact expired); skipping the match regression check."
+        fi
+
+    - name: Download the main-branch baseline report
+      if: steps.baseline.outputs.run_id != ''
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: G9SE8P_report
+        run-id: ${{ steps.baseline.outputs.run_id }}
+        github-token: ${{ github.token }}
+        path: build/G9SE8P/baseline
+
+    - name: Compare match progress against main
+      if: steps.baseline.outputs.run_id != ''
+      run: |
+        mv build/G9SE8P/baseline/report.json build/G9SE8P/baseline.json
+        build/tools/objdiff-cli report changes --format json-pretty \
+            build/G9SE8P/baseline.json build/G9SE8P/report.json \
+            -o build/G9SE8P/report_changes.json
+
+        python3 tools/changes_fmt.py build/G9SE8P/report_changes.json --all \
+            -o build/G9SE8P/changes.md
+        if [ -s build/G9SE8P/changes.md ]; then
+          cat build/G9SE8P/changes.md >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "No match progress changes detected." >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+        regressions=$(python3 tools/changes_fmt.py build/G9SE8P/report_changes.json)
+        if [ -n "$regressions" ]; then
+          echo "::error::Match regressions detected against main:"
+          echo "$regressions"
+          exit 1
+        fi
+
   build_gate:
     name: build (G9SE8P)
     if: always()


### PR DESCRIPTION
## Summary
- The SHA-1 check (`Verify the artifacts match retail`) only covers what's actually linked. A unit still marked `NonMatching` in `configure.py` gets its bytes substituted from the retail extraction at link time, so its compiled source is never part of what that check verifies — meaning a per-function match regression inside it (an inaccurate "this now matches" claim, from me or any other contributor/AI) is currently invisible to CI.
- Adds a `progress_report` job that, on pull requests, downloads the PR's own `report.json` plus the latest successful main-branch build's `report.json`, and runs `objdiff-cli report changes` + the existing `tools/changes_fmt.py` (previously only wired to the local `ninja baseline`/`ninja changes` dev workflow) against that pair.
- Fails the job on any per-function or per-unit match regression; otherwise prints the full diff (regressions and progressions) to the job summary, so genuine progress is visible per PR instead of only in the decomp.dev site after the fact.

## Not done on purpose
- **Not added to `required_status_checks`.** It relies on `gh run list`/`gh run download` reaching across workflow runs and a `sed`-scraped tag from `configure.py`, neither of which I could exercise outside real GitHub Actions before opening this. Recommend watching it succeed on a couple of ordinary PRs first, then promoting it to required once it's proven reliable (e.g. artifact-not-yet-available races, `gh` auth edge cases).
- Gracefully skips (warning, not failure) if no successful main-branch build/artifact is found yet — first run after this merges, or if the last artifact aged out past its retention window.
- Runs in its own job with only `contents: read` + `actions: read`, no `private-build` environment/credentials — it only ever touches already-generated `report.json` files, never `/orig`.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"` — valid YAML, job graph is `private_build` → `progress_report`/`build_gate`
- [x] Verified `objdiff-cli report changes` + `tools/changes_fmt.py` produce the expected regression/progression diff locally (used them to validate PR #495's fix)
- [ ] First live run on this PR — will report back once CI executes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ni9iJDYZ4Um8whMugXb5z