### PR TITLE
match: rebuild rw_gcn_raster around retail's control flow

### DIFF
--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -1072,6 +1072,7 @@ void fn_80226B2C(s32 arg0, u8* arg1, M2C_UNK* arg2, u8* arg3)
 	M2C_UNK sp8[16];
 	M2C_UNK* var_r29;
 	M2C_UNK* var_r6;
+	s32 temp_r0x;
 	s32 temp_r23;
 	s32 temp_r29;
 	s32 temp_r3;
@@ -1103,36 +1104,27 @@ void fn_80226B2C(s32 arg0, u8* arg1, M2C_UNK* arg2, u8* arg3)
 			temp_r24 = M2C_FIELD(arg1, u32*, 4);
 			var_r25  = var_r31;
 			var_r27  = var_r31;
-		loop_8:
-			if (var_r30 < temp_r24) {
-				sp88[3] = 0;
-				temp_r4 = M2C_FIELD(arg3, u8**, 0x10);
+			for (var_r30 = 0U; var_r30 < temp_r24;
+			    var_r30 += 1, var_r27 += 1, var_r25 += 1, var_r31 += 1) {
+				sp88[3]  = 0;
+				temp_r4  = M2C_FIELD(arg3, u8**, 0x10);
+				temp_r0x = (*var_r31 * 0x10) + 0xC;
 				fn_80195674(sp88, (M2C_UNK*)(temp_r23 + (*var_r25 << 6)),
-				    fn_8019E8EC(M2C_FIELD(temp_r4, s32*, (*var_r31 * 0x10) + 0xC)));
+				    fn_8019E8EC(M2C_FIELD(temp_r4, s32*, temp_r0x)));
 				fn_80195674((M2C_UNK*)(arg0 + (*var_r27 << 6)), sp88, (M2C_UNK*)var_r29);
-				var_r30 += 1;
-				var_r27 += 1;
-				var_r25 += 1;
-				var_r31 += 1;
-				goto loop_8;
 			}
 			return;
 		}
 		if (temp_r3 & 0x4000) {
 			if (((u32)M2C_FIELD(arg1, u32*, 0x10) > 1U)
 			    || ((u32)M2C_FIELD(arg1, u32*, 0x2C) == 3U)) {
-				var_r23   = 0U;
+				var_r27_2 = M2C_FIELD(arg1, u8**, 8);
 				temp_r29  = M2C_FIELD(arg1, s32*, 0xC);
 				temp_r25  = M2C_FIELD(arg1, u32*, 4);
-				var_r27_2 = M2C_FIELD(arg1, u8**, 8);
-			loop_15:
-				if (var_r23 < temp_r25) {
+				for (var_r23 = 0U; var_r23 < temp_r25; var_r23 += 1, var_r27_2 += 1) {
 					temp_r5 = *var_r27_2 << 6;
 					fn_80195674((M2C_UNK*)(arg0 + temp_r5), (M2C_UNK*)(temp_r29 + temp_r5),
 					    (M2C_UNK*)(M2C_FIELD(arg3, s32*, 8) + temp_r5));
-					var_r23 += 1;
-					var_r27_2 += 1;
-					goto loop_15;
 				}
 				return;
 			}

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -573,8 +573,8 @@ s32* fn_80225BF0(s32* arg0, s32* unused_arg1, s32* arg2)
 			temp_r6  = M2C_FIELD(temp_r31, s32*, 0x10);
 			temp_r7  = M2C_FIELD(temp_r31, s32*, 0);
 			temp_r30 = M2C_FIELD(arg2, s32*, 0x14);
-			sp8      = ((((M2C_FIELD(temp_r31, s32*, 4) << 8) & 0xFF00 & ~0xFF0000)
-			                | ((temp_r6 << 0x10) & 0xFF0000))
+			sp8      = ((((temp_r6 << 0x10) & 0xFF0000 & ~0xFF00)
+			                | ((M2C_FIELD(temp_r31, s32*, 4) << 8) & 0xFF00))
 			               & ~0xFF)
 			    | (temp_r7 & 0xFF);
 			if (fn_80193474(arg0, &sp8, 4) == 0U) {

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -509,8 +509,10 @@ s32 fn_80225B60(u8* arg0)
 			temp_r6   = M2C_FIELD(arg0, s32*, 0x14);
 			temp_r5_2 = temp_r6 * 4;
 			temp_r4   = temp_r6 * 0x10;
-			var_r31   = (s32)((u8*)M2C_FIELD(temp_r5, s32*, 4) + 4 + temp_r5_2 + temp_r4
-			    + (M2C_FIELD(temp_r5, s32*, 0) << 6));
+			var_r31   = (s32)((u8*)M2C_FIELD(temp_r5, s32*, 4) + 4);
+			var_r31 += temp_r5_2;
+			var_r31 += temp_r4;
+			var_r31 += M2C_FIELD(temp_r5, s32*, 0) << 6;
 			var_r31 += fn_80225400(temp_r5);
 		} else {
 			var_r31 = fn_80227F48(arg0);

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -40,7 +40,7 @@ M2C_UNK (*fn_8015ECF4(u32, s32, s32, s32))(u8*, u8*, u8*, f32); /* extern */
 s32 fn_8015F3FC(u8*, u8*, s32, s32, s32);                       /* extern */
 u8* fn_8015F5EC(s32*, s32, s32);                                /* extern */
 u8* fn_8015F8A4(s32*, s32, s32);                                /* extern */
-s32 fn_801659DC(u32*);                                          /* extern */
+s32 fn_801659DC(u32*, u8*, u8*);                                /* extern */
 u32 fn_80192ED8(s32*, M2C_UNK, s32, M2C_UNK, M2C_UNK);          /* extern */
 s32 fn_80192F38(M2C_UNK, u32*, u32*);                           /* extern */
 u32 fn_8019336C(s32*, s32, s32);                                /* extern */
@@ -80,8 +80,8 @@ s32 fn_80227DF0(s32 arg0);                                      /* static */
 s32 fn_80227F48(u8* arg0);                                      /* static */
 s32* fn_80228014(s32* arg0, u8* arg1);                          /* static */
 u32* fn_8022824C(u32* arg0, u32* arg1);                         /* static */
-s32 fn_802290F0(u32*);                                          /* static */
-s32 fn_8022A028(u32*);                                          /* static */
+s32 fn_802290F0(u32*, u8*, u8*);                                /* static */
+s32 fn_8022A028(u32*, u8*, u8*);                                /* static */
 M2C_UNK fn_8022A454(s32, s32, s32, M2C_UNK*, u8*, u32);         /* static */
 M2C_UNK fn_8022A650(u8*, s32, u32, s32, u8, u8, s32);           /* static */
 M2C_UNK fn_8022A87C(u8*, s32, u32, s32, u8, u8, s32);           /* static */
@@ -1380,37 +1380,45 @@ void fn_80226D3C(u8* arg0, s32 arg1, u32 arg2, s32 arg3, u8* arg4, s32 arg5)
 	    arg2, (((arg5 * (var_r31 * 3)) + 0x1F) & 0xFFFFFFE0) + (arg5 * (var_r29 + (var_r30 * 3))));
 }
 
+#pragma dont_inline on
 u8* fn_80227018(u8* arg0, s32* arg1)
 {
 	u32* temp_r30;
 	u8* temp_r3;
-
+	u8* var_r4;
+	u8* var_r5;
 	temp_r30 = M2C_FIELD(arg0, u32**, 0x18);
 	temp_r3  = fn_80226468(temp_r30);
 	if ((s32)M2C_FIELD(temp_r30, s32*, 0x18) != 1) {
+		var_r4 = arg0;
+		var_r5 = arg0 + 0x14;
+	} else {
+		var_r4 = (u8*)temp_r30;
+		var_r5 = (u8*)temp_r30 + 0x58;
 	}
 	if (((u32)M2C_FIELD(temp_r3, u32*, 0x10) > 1U) || ((u32)M2C_FIELD(temp_r3, u32*, 0x2C) == 3U)) {
 		if (M2C_FIELD(temp_r30, s32*, 8) & 0x02000000) {
 			if ((s32)lbl_8042BD28 == 1) {
-				*arg1 = fn_802290F0(temp_r30);
+				*arg1 = fn_802290F0(temp_r30, var_r4, var_r5);
 			} else {
-				*arg1 = fn_801659DC(temp_r30);
+				*arg1 = fn_801659DC(temp_r30, var_r4, var_r5);
 			}
 		} else {
-			*arg1 = fn_801659DC(temp_r30);
+			*arg1 = fn_801659DC(temp_r30, var_r4, var_r5);
 		}
 	} else if (M2C_FIELD(temp_r30, s32*, 8) & 0x02000000) {
 		if ((s32)lbl_8042BD28 == 1) {
-			*arg1 = fn_802290F0(temp_r30);
+			*arg1 = fn_802290F0(temp_r30, var_r4, var_r5);
 		} else {
-			*arg1 = fn_8022A028(temp_r30);
+			*arg1 = fn_8022A028(temp_r30, var_r4, var_r5);
 		}
 	} else {
-		*arg1 = fn_8022A028(temp_r30);
+		*arg1 = fn_8022A028(temp_r30, var_r4, var_r5);
 	}
 	M2C_FIELD(temp_r30, s16*, 0xC) = 0;
 	return arg0;
 }
+#pragma dont_inline reset
 
 u8* fn_80227130(u8* arg0, u8** arg1, M2C_UNK arg_sp0)
 {

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -2106,7 +2106,7 @@ s32* fn_80228014(s32* arg0, u8* arg1)
 	temp_r31   = M2C_FIELD(arg1, u8**, M2C_FIELD(lbl_8029BB30, s32*, 8));
 	temp_r0_3  = M2C_FIELD(temp_r31, u32*, 4);
 	temp_r29   = M2C_FIELD(temp_r31, u32*, 0x10);
-	sp8        = ((temp_r0_3 & 0xFF) << 8) | ((temp_r29 & 0xFF) << 16)
+	sp8        = ((temp_r29 & 0xFF) << 16) | ((temp_r0_3 & 0xFF) << 8)
 	    | (M2C_FIELD(temp_r31, u32*, 0) & 0xFF);
 	if (fn_80193474(arg0, &sp8, 4) == 0U) {
 		return NULL;

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -1843,10 +1843,10 @@ u8* fn_80227E68(s32 arg0, u32 arg1, u32 arg2, u32 arg3, M2C_UNK arg_sp0)
 
 s32 fn_80227F48(u8* arg0)
 {
-	s32 temp_r31;
 	s32 var_r5;
 	s32 var_r31;
 	u32 temp_r0;
+	u32 temp_r0_2;
 	u8* temp_r6;
 	u8* temp_r7;
 
@@ -1856,21 +1856,22 @@ s32 fn_80227F48(u8* arg0)
 	if (temp_r0 > 1U) {
 		var_r31 += M2C_FIELD(arg0, s32*, 0x14) * (temp_r0 * 2);
 	}
-	temp_r31 = var_r31 + (M2C_FIELD(temp_r7, s32*, 0) << 6);
+	var_r31 += M2C_FIELD(temp_r7, s32*, 0) << 6;
 	if ((u8*)M2C_FIELD(temp_r7, u8**, 0x1C) != NULL) {
-		var_r5  = 0;
-		temp_r6 = M2C_FIELD(arg0, u8**, 0x58);
+		var_r5    = 0;
+		temp_r6   = M2C_FIELD(arg0, u8**, 0x58);
+		temp_r0_2 = M2C_FIELD(arg0, u32*, 8);
 		M2C_FIELD(M2C_FIELD(M2C_FIELD(temp_r6, u8**, 0x24), u8**, -4), s32*, 0x10) = var_r5;
 		M2C_FIELD(temp_r6, u8**, 0x24) = (u8*)M2C_FIELD(temp_r7, u8**, 0x1C);
-		if (M2C_FIELD(arg0, s32*, 8) & 0x10) {
+		if (temp_r0_2 & 0x10) {
 			M2C_FIELD(temp_r6, s32*, 0x2C) = (s32)M2C_FIELD(temp_r7, s32*, 0x20);
 		}
 		M2C_FIELD(M2C_FIELD(arg0, u8**, 0x58), void (**)(), 0x14) = fn_8015C004;
 		M2C_FIELD(temp_r7, s32*, 0x1C)                            = var_r5;
 		M2C_FIELD(temp_r7, s32*, 0x20)                            = var_r5;
 	}
-	temp_r31 += fn_80225400(temp_r7);
-	return temp_r31;
+	var_r31 += fn_80225400(temp_r7);
+	return var_r31;
 }
 
 s32* fn_80228014(s32* arg0, u8* arg1)

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -22,11 +22,11 @@ s32 RwEngineRegisterPlugin(M2C_UNK, M2C_UNK, u8* (*)(u8*), u8* (*)(u8*));       
 M2C_UNK RwFreeListDestroy(s32);                                                      /* extern */
 s32 fn_801520D0(M2C_UNK, M2C_UNK, void (*)(u8*), void (*)(u8*), void (*)(u8*, u8*)); /* extern */
 M2C_UNK fn_80152150(
-    M2C_UNK, u32* (*)(u32*, u8*, s32, M2C_UNK), void (*)(), s32 (*)(), M2C_UNK*); /* extern */
-M2C_UNK fn_8015218C(M2C_UNK, s32 (*)(u8*));                                       /* extern */
-M2C_UNK fn_801521C0(M2C_UNK, s32 (*)(u8*, s32, s32, s32));                        /* extern */
-s32 fn_801521F4(M2C_UNK);                                                         /* extern */
-s32 fn_80152FDC(M2C_UNK, M2C_UNK, void (*)(u8*), u8* (*)(u8*), void (*)());       /* extern */
+    M2C_UNK, u32* (*)(u32*, s32, u8*, s32, s32), void (*)(), s32 (*)(), M2C_UNK*); /* extern */
+M2C_UNK fn_8015218C(M2C_UNK, s32 (*)(u8*));                                        /* extern */
+M2C_UNK fn_801521C0(M2C_UNK, s32 (*)(u8*, s32, s32, s32));                         /* extern */
+s32 fn_801521F4(M2C_UNK);                                                          /* extern */
+s32 fn_80152FDC(M2C_UNK, M2C_UNK, void (*)(u8*), u8* (*)(u8*), void (*)());        /* extern */
 M2C_UNK fn_8015301C(M2C_UNK, u32* (*)(u32*, u32*, M2C_UNK), s32* (*)(s32*, s32*, s32*),
     s32 (*)(u8*), M2C_UNK*);                                    /* extern */
 M2C_UNK fn_8015C358(s32, u32);                                  /* extern */
@@ -234,8 +234,7 @@ s32 fn_80225400(u8* arg0)
 }
 #pragma dont_inline reset
 
-u8* fn_80225434(
-    u32 arg0, u32 arg1, u32 arg2, u32 arg3, u32* arg4, u32* arg5, u8* arg6, M2C_UNK arg_sp0)
+u8* fn_80225434(u32 arg0, u32 arg1, u32 arg2, u32 arg3, u32* arg4, u32* arg5, u8* arg6)
 {
 	u8 sp8[0xF0];
 	s32 temp_cr0_eq;
@@ -630,10 +629,10 @@ u32* fn_80225D48(u32* arg0, u32* arg2, M2C_UNK arg_sp0)
 	u32 var_r7_2;
 	u32 var_r8;
 	u8* temp_r9;
-	u8* var_r3;
 	u8 temp_r26;
 	u8 temp_r27;
 	u8* var_r29;
+	u8* var_r3;
 
 	if (!(M2C_FIELD(arg2, s32*, 8) & 0x01000000)) {
 		if (fn_80193884(arg0, (s32*)&sp8, 4) == 0U) {
@@ -643,13 +642,13 @@ u32* fn_80225D48(u32* arg0, u32* arg2, M2C_UNK arg_sp0)
 		temp_r26 = (u8)(sp8 >> 0x10U);
 		temp_r27 = (u8)(sp8 >> 8U);
 		if (temp_r26 == 0) {
-			var_r29 = fn_80225434(temp_r30, (u32)(u8)sp8, 4U, 0U, NULL, NULL, NULL, 0);
+			var_r29 = fn_80225434(temp_r30, (u32)(u8)sp8, 4U, 0U, NULL, NULL, NULL);
 			if (var_r29 == NULL) {
 				return NULL;
 			}
 			goto block_10;
 		}
-		var_r29 = fn_80225434(temp_r30, (u32)temp_r27, (u32)temp_r26, 0U, NULL, NULL, NULL, 0);
+		var_r29 = fn_80225434(temp_r30, (u32)temp_r27, (u32)temp_r26, 0U, NULL, NULL, NULL);
 		if (var_r29 == NULL) {
 			return NULL;
 		}
@@ -776,14 +775,13 @@ block_50:
 	return arg0;
 }
 
-u32* fn_80226080(u32* arg0, u8* arg2, s32 arg4, M2C_UNK arg_sp0)
+u32* fn_80226080(u32* arg0, s32 arg1, u8* arg2, s32 arg3, s32 arg4)
 {
 	s32 sp8;
-	s32* var_r27_2;
-	s32 var_ctr;
 	s32 var_r11;
 	s32 var_r27;
 	s32 var_r4;
+	s32* var_r27_2;
 	u32* temp_r30;
 	u32* var_r10;
 	u32* var_r12;
@@ -793,14 +791,14 @@ u32* fn_80226080(u32* arg0, u8* arg2, s32 arg4, M2C_UNK arg_sp0)
 	u32 temp_r26;
 	u32 temp_r29;
 	u32 temp_r4;
-	u32 var_ctr_2;
+	u32 var_i;
+	u32 var_j;
 	u32 var_r26;
 	u32 var_r5;
 	u32 var_r7_2;
 	u32 var_r8;
-	u8* temp_r9;
-	u8* var_r3;
 	u8* temp_r31;
+	u8* temp_r9;
 
 	temp_r30 = M2C_FIELD(arg2, u32**, 0x18);
 	if (fn_80226468(temp_r30) == NULL) {
@@ -808,7 +806,7 @@ u32* fn_80226080(u32* arg0, u8* arg2, s32 arg4, M2C_UNK arg_sp0)
 			return NULL;
 		}
 		temp_r29 = M2C_FIELD(temp_r30, u32*, 0x14);
-		temp_r31 = fn_80225434(temp_r29, (u32)sp8, (u32)sp8, 4U, NULL, NULL, NULL, 0);
+		temp_r31 = fn_80225434(temp_r29, (u32)sp8, (u32)sp8, 4U, NULL, NULL, NULL);
 		if (fn_80197D70(arg0, 4) == 0U) {
 			return NULL;
 		}
@@ -818,98 +816,62 @@ u32* fn_80226080(u32* arg0, u8* arg2, s32 arg4, M2C_UNK arg_sp0)
 		if (fn_801937A0(arg0, M2C_FIELD(temp_r31, u32**, 0x18), temp_r29 * 0x10) == 0U) {
 			return NULL;
 		}
-		var_r26 = 0U;
-		var_r27 = 0;
-	loop_15:
-		if (var_r26 >= (u32)M2C_FIELD(temp_r31, u32*, 0)) {
-			var_r7                          = M2C_FIELD(temp_r31, u32**, 0x18);
-			var_r5                          = 0U;
-			M2C_FIELD(temp_r31, u32*, 0x10) = 1U;
-		loop_22:
-			if (var_r5 < temp_r29) {
-				temp_r4 = M2C_FIELD(temp_r31, u32*, 0x10);
-				var_r6  = &var_r7[temp_r4];
-				var_ctr = 4 - temp_r4;
-				if (temp_r4 < 4U) {
-				loop_18:
-					if ((u32)*var_r6 != 0U) {
-						M2C_FIELD(temp_r31, u32*, 0x10)
-						    = (u32)(M2C_FIELD(temp_r31, u32*, 0x10) + 1);
-						if ((u32)M2C_FIELD(temp_r31, u32*, 0x10) != 4) {
-							var_r6 += 4;
-							var_ctr -= 1;
-							if (var_ctr == 0) {
-								goto block_21;
-							}
-							goto loop_18;
-						}
-					} else {
-						goto block_21;
-					}
-				} else {
-				block_21:
-					var_r7 += 0x10;
-					var_r5 += 1;
-					goto loop_22;
+		for (var_r26 = 0U, var_r27 = 0; var_r26 < (u32)M2C_FIELD(temp_r31, u32*, 0);
+		    var_r27 += 0x40, var_r26 += 1) {
+			if (fn_80197D70(arg0, 0xC) == 0U) {
+				return NULL;
+			}
+			if (fn_801937A0(arg0, (u32*)(M2C_FIELD(temp_r31, s32*, 0xC) + var_r27), 0x40) == 0U) {
+				return NULL;
+			}
+		}
+		var_r7                          = M2C_FIELD(temp_r31, u32**, 0x18);
+		var_r5                          = 0U;
+		M2C_FIELD(temp_r31, u32*, 0x10) = 1U;
+		for (; var_r5 < temp_r29; var_r5 += 1, var_r7 += 4) {
+			temp_r4 = M2C_FIELD(temp_r31, u32*, 0x10);
+			var_r6  = &var_r7[temp_r4];
+			for (var_i = temp_r4; var_i < 4U; var_i += 1, var_r6 += 1) {
+				if ((u32)*var_r6 == 0U) {
+					break;
+				}
+				M2C_FIELD(temp_r31, u32*, 0x10) = (u32)(M2C_FIELD(temp_r31, u32*, 0x10) + 1);
+				if ((u32)M2C_FIELD(temp_r31, u32*, 0x10) == 4U) {
+					goto block_36;
 				}
 			}
-			var_r12                      = M2C_FIELD(temp_r31, u32**, 0x18);
-			var_r8                       = 0U;
-			var_r27_2                    = M2C_FIELD(temp_r31, s32**, 0x14);
-			temp_r9                      = M2C_FIELD(temp_r31, u8**, 8);
-			M2C_FIELD(temp_r31, u32*, 4) = 0U;
-		loop_35:
-			if (var_r8 < temp_r29) {
-				var_r7_2 = 0U;
-				var_r10  = var_r12;
-				var_r11  = 0;
-			loop_33:
-				if (var_r7_2 < (u32)M2C_FIELD(temp_r31, u32*, 0x10)) {
-					if ((u32)*var_r10 != 0U) {
-						var_r3    = temp_r9;
-						temp_r26  = M2C_FIELD(temp_r31, u32*, 4);
-						var_r4    = 1;
-						temp_r0   = (u32)*var_r27_2 >> var_r11;
-						var_ctr_2 = temp_r26;
-						if (temp_r26 > 0U) {
-						loop_27:
-							if ((u8)temp_r0 == (u8)*var_r3) {
-								var_r4 = 0;
-							} else {
-								var_r3 += 1;
-								var_ctr_2 -= 1;
-								if (var_ctr_2 != 0U) {
-									goto loop_27;
-								}
-							}
-						}
-						if (var_r4 != 0) {
-							*(temp_r9 + temp_r26)        = (u8)temp_r0;
-							M2C_FIELD(temp_r31, u32*, 4) = (u32)(M2C_FIELD(temp_r31, u32*, 4) + 1);
-						}
-					}
-					var_r10 += 4;
-					var_r11 += 8;
-					var_r7_2 += 1;
-					goto loop_33;
+		}
+	block_36:
+		var_r12                      = M2C_FIELD(temp_r31, u32**, 0x18);
+		var_r8                       = 0U;
+		var_r27_2                    = M2C_FIELD(temp_r31, s32**, 0x14);
+		temp_r9                      = M2C_FIELD(temp_r31, u8**, 8);
+		M2C_FIELD(temp_r31, u32*, 4) = 0U;
+		for (; var_r8 < temp_r29; var_r8 += 1, var_r12 += 4, var_r27_2 += 1) {
+			var_r10 = var_r12;
+			var_r11 = 0;
+			for (var_r7_2 = 0U; var_r7_2 < (u32)M2C_FIELD(temp_r31, u32*, 0x10);
+			    var_r7_2 += 1, var_r10 += 1, var_r11 += 8) {
+				if ((u32)*var_r10 == 0U) {
+					continue;
 				}
-				var_r12 += 0x10;
-				var_r27_2 += 4;
-				var_r8 += 1;
-				goto loop_35;
+				temp_r0  = (u32)*var_r27_2 >> var_r11;
+				temp_r26 = M2C_FIELD(temp_r31, u32*, 4);
+				var_r4   = 1;
+				for (var_j = 0U; var_j < temp_r26; var_j += 1) {
+					if ((u8)temp_r0 == (u8)temp_r9[var_j]) {
+						var_r4 = 0;
+						break;
+					}
+				}
+				if (var_r4 != 0) {
+					temp_r9[temp_r26]            = (u8)temp_r0;
+					M2C_FIELD(temp_r31, u32*, 4) = (u32)(M2C_FIELD(temp_r31, u32*, 4) + 1);
+				}
 			}
-			fn_8022647C(temp_r30, temp_r31);
-			goto block_39;
 		}
-		if (fn_80197D70(arg0, 0xC) == 0U) {
-			return NULL;
-		}
-		if (fn_801937A0(arg0, (u32*)(M2C_FIELD(temp_r31, s32*, 0xC) + var_r27), 0x40) == 0U) {
-			return NULL;
-		}
-		var_r27 += 0x40;
-		var_r26 += 1;
-		goto loop_15;
+		fn_8022647C(temp_r30, temp_r31);
+		goto block_39;
 	}
 	if (fn_80197D70(arg0, arg4) == 0U) {
 		return NULL;

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -168,6 +168,7 @@ u32* fn_80225248(u32* arg0, u8* arg1)
 	s32 temp_r25;
 	s32 temp_r26;
 	s32 temp_r27;
+	s32 temp_r5x;
 	s32 temp_r6;
 	u32 temp_r28;
 	u8* temp_r31;
@@ -193,7 +194,8 @@ u32* fn_80225248(u32* arg0, u8* arg1)
 		}
 		M2C_FIELD(arg1, u32*, 0x30) = 0U;
 		M2C_FIELD(arg1, s32*, 0x34) = 0;
-		temp_r24                    = temp_r27 + ((u32)temp_r25 * 2 + (temp_r26 * 2));
+		temp_r24                    = (u32)temp_r25 * 2 + (temp_r26 * 2);
+		temp_r24                    = temp_r27 + temp_r24;
 		M2C_FIELD(arg1, s32*, 0x38) = 0;
 		M2C_FIELD(arg1, u32*, 0x3C) = 0U;
 		M2C_FIELD(arg1, s32*, 0x40) = 0;
@@ -214,11 +216,9 @@ u32* fn_80225248(u32* arg0, u8* arg1)
 		if (var_r4 == NULL) {
 			return NULL;
 		}
-		temp_r6 = M2C_FIELD(arg1, s32*, 0);
-		if (fn_801979AC(arg0, M2C_FIELD(temp_r31, s32*, 0xC),
-		        temp_r6
-		            + ((u32)M2C_FIELD(temp_r31, u32*, 4) * 2 + (M2C_FIELD(temp_r31, s32*, 8) * 2)))
-		    == 0U) {
+		temp_r6  = M2C_FIELD(arg1, s32*, 0);
+		temp_r5x = (u32)M2C_FIELD(temp_r31, u32*, 4) * 2 + (M2C_FIELD(temp_r31, s32*, 8) * 2);
+		if (fn_801979AC(arg0, M2C_FIELD(temp_r31, s32*, 0xC), temp_r6 + temp_r5x) == 0U) {
 			M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(temp_r31, lbl_8042C9A4);
 			return NULL;
 		}
@@ -333,7 +333,8 @@ block_8:
 		}
 	}
 	temp_r4_2 = (arg1 << 6) + var_r26;
-	temp_r23  = (arg0 * 0x14) + (temp_r4_2 + 0xF);
+	temp_r23  = temp_r4_2 + 0xF;
+	temp_r23  = (arg0 * 0x14) + temp_r23;
 	M2C_FIELD(temp_r30, u32*, 0x48)
 	    = M2C_FIELD(lbl_8042C9A4, u32(**)(), 0x134)(temp_r23, temp_r4_2);
 	if ((u32)M2C_FIELD(temp_r30, u32*, 0x48) == 0U) {

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -54,7 +54,7 @@ M2C_UNK fn_80195B5C(M2C_UNK*, M2C_UNK*);                        /* extern */
 s32 fn_801966CC(M2C_UNK, s32, M2C_UNK, s32, M2C_UNK*);          /* extern */
 M2C_UNK fn_80197384(s32);                                       /* extern */
 u8** fn_801974E0(u8*, u8*, s32, void (*)(u8*));                 /* extern */
-u32 fn_801979AC(u32*, s32, u8);                                 /* extern */
+u32 fn_801979AC(u32*, s32, s32);                                /* extern */
 u32 fn_80197B48(s32*, s32, s32);                                /* extern */
 u32 fn_80197D70(u32*, s32);                                     /* extern */
 M2C_UNK fn_8019941C(u32, s32, M2C_UNK, s32);                    /* extern */
@@ -162,8 +162,11 @@ u32* fn_80225248(u32* arg0, u8* arg1)
 	s32 spC;
 	u32 sp8;
 	s32 temp_r24;
+	s32 temp_r25;
+	s32 temp_r26;
 	s32 temp_r27;
 	s32 temp_r6;
+	u32 temp_r28;
 	u8* temp_r31;
 	u8* var_r4;
 
@@ -177,14 +180,17 @@ u32* fn_80225248(u32* arg0, u8* arg1)
 	if (fn_80193884(arg0, &spC, 4) == 0U) {
 		return NULL;
 	}
-	if (sp10 > 0) {
+	temp_r25 = sp10;
+	if (temp_r25 > 0) {
+		temp_r26 = spC;
 		temp_r27 = M2C_FIELD(arg1, s32*, 0);
+		temp_r28 = sp8;
 		if ((u32)M2C_FIELD(arg1, u32*, 0x3C) != 0U) {
 			M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(lbl_8042C9A4);
 		}
 		M2C_FIELD(arg1, u32*, 0x30) = 0U;
 		M2C_FIELD(arg1, s32*, 0x34) = 0;
-		temp_r24                    = temp_r27 + ((sp10 * 2) + (spC * 2));
+		temp_r24                    = temp_r27 + ((u32)temp_r25 * 2 + (temp_r26 * 2));
 		M2C_FIELD(arg1, s32*, 0x38) = 0;
 		M2C_FIELD(arg1, u32*, 0x3C) = 0U;
 		M2C_FIELD(arg1, s32*, 0x40) = 0;
@@ -195,19 +201,20 @@ u32* fn_80225248(u32* arg0, u8* arg1)
 			var_r4 = NULL;
 		} else {
 			memset(M2C_FIELD(arg1, void**, 0x3C), 0, temp_r24);
-			M2C_FIELD(arg1, u32*, 0x30) = sp8;
+			M2C_FIELD(arg1, u32*, 0x30) = temp_r28;
 			var_r4                      = arg1;
-			M2C_FIELD(arg1, s32*, 0x34) = sp10;
-			M2C_FIELD(arg1, s32*, 0x38) = spC;
+			M2C_FIELD(arg1, s32*, 0x34) = temp_r25;
+			M2C_FIELD(arg1, s32*, 0x38) = temp_r26;
 			M2C_FIELD(arg1, s32*, 0x40) = (s32)(M2C_FIELD(arg1, u32*, 0x3C) + temp_r27);
-			M2C_FIELD(arg1, s32*, 0x44) = (s32)(M2C_FIELD(arg1, s32*, 0x40) + (sp10 * 2));
+			M2C_FIELD(arg1, s32*, 0x44) = (s32)(M2C_FIELD(arg1, s32*, 0x40) + (temp_r25 * 2));
 		}
 		if (var_r4 == NULL) {
 			return NULL;
 		}
 		temp_r6 = M2C_FIELD(arg1, s32*, 0);
 		if (fn_801979AC(arg0, M2C_FIELD(temp_r31, s32*, 0xC),
-		        temp_r6 + ((M2C_FIELD(temp_r31, s32*, 4) * 2) + (M2C_FIELD(temp_r31, s32*, 8) * 2)))
+		        temp_r6
+		            + ((u32)M2C_FIELD(temp_r31, u32*, 4) * 2 + (M2C_FIELD(temp_r31, s32*, 8) * 2)))
 		    == 0U) {
 			M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(temp_r31, lbl_8042C9A4);
 			return NULL;

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -1214,36 +1214,23 @@ void fn_80226D3C(u8* arg0, s32 arg1, u32 arg2, s32 arg3, u8* arg4, s32 arg5)
 				var_r21 = arg2;
 				var_r22 = 0;
 				var_r20 = arg3;
-				var_r28 = 0;
-			loop_15:
-				if (var_r28 < arg5) {
+				for (var_r28 = 0; var_r28 < arg5;
+				    var_r23 += 4, var_r22 += 0xC, var_r21 += 0xC, var_r20 += 0xC, var_r28 += 1) {
 					temp_r19 = arg1
 					    + ((M2C_FIELD(M2C_FIELD(arg0, u32**, 0x14), u32*, var_r23) << 6) & 0x3FC0);
 					fn_8019941C(var_r21, M2C_FIELD(arg0, u32*, 0x1C) + var_r22, 1, temp_r19);
 					fn_8019947C(var_r20, M2C_FIELD(arg0, u32*, 0x20) + var_r22, 1, temp_r19);
-					var_r23 += 4;
-					var_r22 += 0xC;
-					var_r21 += 0xC;
-					var_r20 += 0xC;
-					var_r28 += 1;
-					goto loop_15;
 				}
 			} else {
 				var_r20_2 = 0;
 				var_r22_2 = arg2;
 				var_r21_2 = 0;
-				var_r19   = 0;
-			loop_19:
-				if (var_r19 < arg5) {
+				for (var_r19 = 0; var_r19 < arg5;
+				    var_r20_2 += 4, var_r21_2 += 0xC, var_r22_2 += 0xC, var_r19 += 1) {
 					fn_8019941C(var_r22_2, M2C_FIELD(arg0, u32*, 0x1C) + var_r21_2, 1,
 					    arg1
 					        + ((M2C_FIELD(M2C_FIELD(arg0, u32**, 0x14), u32*, var_r20_2) << 6)
 					            & 0x3FC0));
-					var_r20_2 += 4;
-					var_r21_2 += 0xC;
-					var_r22_2 += 0xC;
-					var_r19 += 1;
-					goto loop_19;
 				}
 			}
 			break;

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -27,7 +27,7 @@ M2C_UNK fn_8015218C(M2C_UNK, s32 (*)(u8*));                                     
 M2C_UNK fn_801521C0(M2C_UNK, s32 (*)(u8*, s32, s32, s32));                         /* extern */
 s32 fn_801521F4(M2C_UNK);                                                          /* extern */
 s32 fn_80152FDC(M2C_UNK, M2C_UNK, void (*)(u8*), u8* (*)(u8*), void (*)());        /* extern */
-M2C_UNK fn_8015301C(M2C_UNK, u32* (*)(u32*, u32*, M2C_UNK), s32* (*)(s32*, s32*, s32*),
+M2C_UNK fn_8015301C(M2C_UNK, u32* (*)(u32*, s32, u32*, s32, s32), s32* (*)(s32*, s32*, s32*),
     s32 (*)(u8*), M2C_UNK*);                                    /* extern */
 M2C_UNK fn_8015C358(s32, u32);                                  /* extern */
 M2C_UNK fn_8015C370(s32, u32);                                  /* extern */
@@ -607,14 +607,13 @@ block_16:
 	return arg0;
 }
 
-u32* fn_80225D48(u32* arg0, u32* arg2, M2C_UNK arg_sp0)
+u32* fn_80225D48(u32* arg0, s32 arg1, u32* arg2, s32 arg3, s32 arg4)
 {
 	u32 sp8;
-	s32* var_r27_2;
-	s32 var_ctr;
 	s32 var_r11;
 	s32 var_r27;
 	s32 var_r4;
+	s32* var_r27_2;
 	u32* var_r10;
 	u32* var_r12;
 	u32* var_r6;
@@ -623,39 +622,41 @@ u32* fn_80225D48(u32* arg0, u32* arg2, M2C_UNK arg_sp0)
 	u32 temp_r26_2;
 	u32 temp_r30;
 	u32 temp_r4;
-	u32 var_ctr_2;
+	u32 var_i;
+	u32 var_j;
 	u32 var_r26;
 	u32 var_r5;
 	u32 var_r7_2;
 	u32 var_r8;
 	u8* temp_r9;
 	u8 temp_r26;
+	u8 temp_r4_2;
 	u8 temp_r27;
 	u8* var_r29;
-	u8* var_r3;
 
 	if (!(M2C_FIELD(arg2, s32*, 8) & 0x01000000)) {
 		if (fn_80193884(arg0, (s32*)&sp8, 4) == 0U) {
 			return NULL;
 		}
-		temp_r30 = M2C_FIELD(arg2, u32*, 0x14);
-		temp_r26 = (u8)(sp8 >> 0x10U);
-		temp_r27 = (u8)(sp8 >> 8U);
+		temp_r30  = M2C_FIELD(arg2, u32*, 0x14);
+		temp_r26  = (u8)(sp8 >> 0x10U);
+		temp_r4_2 = (u8)sp8;
+		temp_r27  = (u8)(sp8 >> 8U);
 		if (temp_r26 == 0) {
-			var_r29 = fn_80225434(temp_r30, (u32)(u8)sp8, 4U, 0U, NULL, NULL, NULL);
+			var_r29 = fn_80225434(temp_r30, (u32)temp_r4_2, (u32)temp_r4_2, 4U, NULL, NULL, NULL);
 			if (var_r29 == NULL) {
 				return NULL;
 			}
-			goto block_10;
+		} else {
+			var_r29 = fn_80225434(
+			    temp_r30, (u32)temp_r4_2, (u32)temp_r27, (u32)temp_r26, NULL, NULL, NULL);
+			if (var_r29 == NULL) {
+				return NULL;
+			}
+			if (temp_r27 != fn_801979AC(arg0, M2C_FIELD(var_r29, s32*, 8), temp_r27)) {
+				return NULL;
+			}
 		}
-		var_r29 = fn_80225434(temp_r30, (u32)temp_r27, (u32)temp_r26, 0U, NULL, NULL, NULL);
-		if (var_r29 == NULL) {
-			return NULL;
-		}
-		if (temp_r27 != fn_801979AC(arg0, M2C_FIELD(var_r29, s32*, 8), temp_r27)) {
-			return NULL;
-		}
-	block_10:
 		if (fn_80193884(arg0, M2C_FIELD(var_r29, s32**, 0x14), temp_r30 * 4) == 0U) {
 			return NULL;
 		}
@@ -663,98 +664,62 @@ u32* fn_80225D48(u32* arg0, u32* arg2, M2C_UNK arg_sp0)
 			return NULL;
 		}
 		if (temp_r26 == 0) {
-			var_r26 = 0U;
-			var_r27 = 0;
-		loop_21:
-			if (var_r26 >= (u32)M2C_FIELD(var_r29, u32*, 0)) {
-				var_r7                         = M2C_FIELD(var_r29, u32**, 0x18);
-				var_r5                         = 0U;
-				M2C_FIELD(var_r29, u32*, 0x10) = 1U;
-			loop_28:
-				if (var_r5 < temp_r30) {
-					temp_r4 = M2C_FIELD(var_r29, u32*, 0x10);
-					var_r6  = &var_r7[temp_r4];
-					var_ctr = 4 - temp_r4;
-					if (temp_r4 < 4U) {
-					loop_24:
-						if ((u32)*var_r6 != 0U) {
-							M2C_FIELD(var_r29, u32*, 0x10)
-							    = (u32)(M2C_FIELD(var_r29, u32*, 0x10) + 1);
-							if ((u32)M2C_FIELD(var_r29, u32*, 0x10) != 4) {
-								var_r6 += 4;
-								var_ctr -= 1;
-								if (var_ctr == 0) {
-									goto block_27;
-								}
-								goto loop_24;
-							}
-						} else {
-							goto block_27;
-						}
-					} else {
-					block_27:
-						var_r7 += 0x10;
-						var_r5 += 1;
-						goto loop_28;
+			for (var_r26 = 0U, var_r27 = 0; var_r26 < (u32)M2C_FIELD(var_r29, u32*, 0);
+			    var_r27 += 0x40, var_r26 += 1) {
+				if (fn_80197D70(arg0, 4) == 0U) {
+					return NULL;
+				}
+				if (fn_801937A0(arg0, (u32*)(M2C_FIELD(var_r29, s32*, 0xC) + var_r27), 0x40)
+				    == 0U) {
+					return NULL;
+				}
+			}
+			var_r7                         = M2C_FIELD(var_r29, u32**, 0x18);
+			var_r5                         = 0U;
+			M2C_FIELD(var_r29, u32*, 0x10) = 1U;
+			for (; var_r5 < temp_r30; var_r5 += 1, var_r7 += 4) {
+				temp_r4 = M2C_FIELD(var_r29, u32*, 0x10);
+				var_r6  = &var_r7[temp_r4];
+				for (var_i = temp_r4; var_i < 4U; var_i += 1, var_r6 += 1) {
+					if ((u32)*var_r6 == 0U) {
+						break;
+					}
+					M2C_FIELD(var_r29, u32*, 0x10) = (u32)(M2C_FIELD(var_r29, u32*, 0x10) + 1);
+					if ((u32)M2C_FIELD(var_r29, u32*, 0x10) == 4U) {
+						goto block_42;
 					}
 				}
-				var_r12                     = M2C_FIELD(var_r29, u32**, 0x18);
-				var_r8                      = 0U;
-				var_r27_2                   = M2C_FIELD(var_r29, s32**, 0x14);
-				temp_r9                     = M2C_FIELD(var_r29, u8**, 8);
-				M2C_FIELD(var_r29, u32*, 4) = 0U;
-			loop_41:
-				if (var_r8 < temp_r30) {
-					var_r7_2 = 0U;
-					var_r10  = var_r12;
-					var_r11  = 0;
-				loop_39:
-					if (var_r7_2 < (u32)M2C_FIELD(var_r29, u32*, 0x10)) {
-						if ((u32)*var_r10 != 0U) {
-							var_r3     = temp_r9;
-							temp_r26_2 = M2C_FIELD(var_r29, u32*, 4);
-							var_r4     = 1;
-							temp_r0    = (u32)*var_r27_2 >> var_r11;
-							var_ctr_2  = temp_r26_2;
-							if (temp_r26_2 > 0U) {
-							loop_33:
-								if ((u8)temp_r0 == (u8)*var_r3) {
-									var_r4 = 0;
-								} else {
-									var_r3 += 1;
-									var_ctr_2 -= 1;
-									if (var_ctr_2 != 0U) {
-										goto loop_33;
-									}
-								}
-							}
-							if (var_r4 != 0) {
-								*(temp_r9 + temp_r26_2) = (u8)temp_r0;
-								M2C_FIELD(var_r29, u32*, 4)
-								    = (u32)(M2C_FIELD(var_r29, u32*, 4) + 1);
-							}
-						}
-						var_r10 += 4;
-						var_r11 += 8;
-						var_r7_2 += 1;
-						goto loop_39;
+			}
+		block_42:
+			var_r12                     = M2C_FIELD(var_r29, u32**, 0x18);
+			var_r8                      = 0U;
+			var_r27_2                   = M2C_FIELD(var_r29, s32**, 0x14);
+			temp_r9                     = M2C_FIELD(var_r29, u8**, 8);
+			M2C_FIELD(var_r29, u32*, 4) = 0U;
+			for (; var_r8 < temp_r30; var_r8 += 1, var_r12 += 4, var_r27_2 += 1) {
+				var_r10 = var_r12;
+				var_r11 = 0;
+				for (var_r7_2 = 0U; var_r7_2 < (u32)M2C_FIELD(var_r29, u32*, 0x10);
+				    var_r7_2 += 1, var_r10 += 1, var_r11 += 8) {
+					if ((u32)*var_r10 == 0U) {
+						continue;
 					}
-					var_r12 += 0x10;
-					var_r27_2 += 4;
-					var_r8 += 1;
-					goto loop_41;
+					temp_r0    = (u32)*var_r27_2 >> var_r11;
+					temp_r26_2 = M2C_FIELD(var_r29, u32*, 4);
+					var_r4     = 1;
+					for (var_j = 0U; var_j < temp_r26_2; var_j += 1) {
+						if ((u8)temp_r0 == (u8)temp_r9[var_j]) {
+							var_r4 = 0;
+							break;
+						}
+					}
+					if (var_r4 != 0) {
+						temp_r9[temp_r26_2]         = (u8)temp_r0;
+						M2C_FIELD(var_r29, u32*, 4) = (u32)(M2C_FIELD(var_r29, u32*, 4) + 1);
+					}
 				}
-				goto block_47;
 			}
-			if (fn_80197D70(arg0, 4) == 0U) {
-				return NULL;
-			}
-			if (fn_801937A0(arg0, M2C_FIELD(var_r29, u32**, 0xC) + var_r27, 0x40) == 0U) {
-				return NULL;
-			}
-			var_r27 += 0x40;
-			var_r26 += 1;
-			goto loop_21;
+			goto block_47;
 		}
 		M2C_FIELD(var_r29, u32*, 0x10) = (u32)temp_r26;
 		if (fn_801937A0(arg0, M2C_FIELD(var_r29, u32**, 0xC), M2C_FIELD(var_r29, u32*, 0) << 6)
@@ -1481,6 +1446,7 @@ void fn_802273D0(u8* arg0, s32 arg1, s32 arg2, M2C_UNK arg_sp0)
 	u32 var_r21;
 	u8 temp_r23;
 	u8 temp_r26;
+	u8 temp_r4_2;
 	u8 var_r22;
 	u8 var_r25;
 	u8* temp_r3;

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -1696,120 +1696,90 @@ u8* fn_80227AA8(u8* arg0, u32 arg1)
 	M2C_FIELD(arg0, s32*, 0x20) = 0;
 	M2C_FIELD(arg0, s8**, 0x24) = NULL;
 	M2C_FIELD(arg0, s8**, 0x28) = NULL;
-loop_8:
-	if (var_r8 < arg1) {
+	for (; var_r8 < arg1; var_r6 += 0x10, var_r7 += 4, var_r8 += 1) {
 		var_r4 = var_r6;
 		var_r9 = 0U;
 		var_r5 = 0;
 		do {
 			temp_r12 = 4 - var_r9;
 			temp_r0  = 0xFF << var_r5;
-			var_r10  = 1;
-			var_r3   = 4;
-			var_ctr  = temp_r12 - 1;
-			if (temp_r12 > 1U) {
-				do {
-					temp_r11 = (f32*)(var_r4 + M2C_FIELD(arg0, s32*, 0x18));
-					temp_f1  = M2C_FIELD(temp_r11, f32*, var_r3);
-					temp_f0  = *temp_r11;
-					if (temp_f1 > temp_f0) {
-						*temp_r11  = temp_f1;
-						temp_r26   = (var_r9 + var_r10) * 8;
-						temp_r11_2 = 0xFF << temp_r26;
-						M2C_FIELD(M2C_FIELD(arg0, u8**, 0x18), f32*, var_r4 + var_r3) = temp_f0;
-						temp_r28 = M2C_FIELD(arg0, s32*, 0x14);
-						temp_r29 = M2C_FIELD((u8*)temp_r28, u32*, var_r7);
-						M2C_FIELD((u8*)temp_r28, u32*, var_r7) = temp_r29 & ~(temp_r0 | temp_r0);
-						temp_r27                               = M2C_FIELD(arg0, s32*, 0x14);
-						M2C_FIELD((u8*)temp_r27, u32*, var_r7)
-						    = M2C_FIELD((u8*)temp_r27, u32*, var_r7)
-						    | ((u8)(temp_r29 >> temp_r26) << var_r5);
-						temp_r28_2 = M2C_FIELD(arg0, s32*, 0x14);
-						M2C_FIELD((u8*)temp_r28_2, u32*, var_r7)
-						    = M2C_FIELD((u8*)temp_r28_2, u32*, var_r7) & ~(temp_r11_2 | temp_r11_2);
-						temp_r29_2 = M2C_FIELD(arg0, s32*, 0x14);
-						M2C_FIELD((u8*)temp_r29_2, u32*, var_r7)
-						    = M2C_FIELD((u8*)temp_r29_2, u32*, var_r7)
-						    | ((u8)(temp_r29 >> var_r5) << temp_r26);
-					}
-					var_r3 += 4;
-					var_r10 += 1;
-					var_ctr -= 1;
-				} while (var_ctr != 0);
+			for (var_r10 = 1, var_r3 = 4; var_r10 < temp_r12; var_r3 += 4, var_r10 += 1) {
+				temp_r11 = (f32*)(var_r4 + M2C_FIELD(arg0, s32*, 0x18));
+				temp_f1  = M2C_FIELD(temp_r11, f32*, var_r3);
+				temp_f0  = *temp_r11;
+				if (temp_f1 > temp_f0) {
+					*temp_r11  = temp_f1;
+					temp_r26   = (var_r9 + var_r10) * 8;
+					temp_r11_2 = 0xFF << temp_r26;
+					M2C_FIELD(M2C_FIELD(arg0, u8**, 0x18), f32*, var_r4 + var_r3) = temp_f0;
+					temp_r28                               = M2C_FIELD(arg0, s32*, 0x14);
+					temp_r29                               = M2C_FIELD((u8*)temp_r28, u32*, var_r7);
+					M2C_FIELD((u8*)temp_r28, u32*, var_r7) = temp_r29 & ~(temp_r0 | temp_r0);
+					temp_r27                               = M2C_FIELD(arg0, s32*, 0x14);
+					M2C_FIELD((u8*)temp_r27, u32*, var_r7) = M2C_FIELD((u8*)temp_r27, u32*, var_r7)
+					    | ((u8)(temp_r29 >> temp_r26) << var_r5);
+					temp_r28_2 = M2C_FIELD(arg0, s32*, 0x14);
+					M2C_FIELD((u8*)temp_r28_2, u32*, var_r7)
+					    = M2C_FIELD((u8*)temp_r28_2, u32*, var_r7) & ~(temp_r11_2 | temp_r11_2);
+					temp_r29_2 = M2C_FIELD(arg0, s32*, 0x14);
+					M2C_FIELD((u8*)temp_r29_2, u32*, var_r7)
+					    = M2C_FIELD((u8*)temp_r29_2, u32*, var_r7)
+					    | ((u8)(temp_r29 >> var_r5) << temp_r26);
+				}
 			}
 			var_r9 += 1;
 			var_r5 += 8;
 			var_r4 += 4;
 		} while (var_r9 < 3U);
-		var_r6 += 0x10;
-		var_r7 += 4;
-		var_r8 += 1;
-		goto loop_8;
 	}
 	temp_r0_2 = M2C_FIELD(arg0, u32*, 0x10);
 	if (temp_r0_2 > 1U) {
 		temp_r4 = arg1 * (temp_r0_2 * 2);
 		M2C_FIELD(arg0, s8**, 0x24)
 		    = M2C_FIELD(lbl_8042C9A4, s8 * (**)(), 0x134)(temp_r4 + 3, temp_r4);
-		var_r5_2  = 0;
-		var_r7_2  = M2C_FIELD(arg0, s8**, 0x24);
-		var_ctr_2 = arg1;
-		if (arg1 > 0U) {
-			do {
-				var_r8_2 = 0;
-				var_r4_2 = 0U;
-				var_r3_2 = 0;
-			loop_13:
-				if (var_r4_2 < (u32)M2C_FIELD(arg0, u32*, 0x10)) {
-					var_r4_2 += 1;
-					temp_r0_3 = M2C_FIELD(arg0, s32*, 0x18) + var_r3_2;
-					var_r3_2 += 4;
-					*var_r7_2 = (s8)(lbl_80430110 * M2C_FIELD((u8*)temp_r0_3, f32*, var_r5_2));
-					temp_r0_4 = (u8)*var_r7_2;
-					var_r7_2 += 1;
-					var_r8_2 += temp_r0_4;
-					goto loop_13;
-				}
-				if (var_r8_2 < 0x80U) {
-					var_r6_2 = 0U;
-				loop_18:
-					temp_r0_5 = M2C_FIELD(arg0, u32*, 0x10);
-					if (var_r6_2 < temp_r0_5) {
-						var_r8_2 += 1;
-						temp_r4_2 = var_r7_2 - (temp_r0_5 - var_r6_2);
-						*temp_r4_2 += 1;
-						if (var_r8_2 != 0x80) {
-							var_r6_2 += 1;
-							goto loop_18;
-						}
+		var_r5_2 = 0;
+		var_r7_2 = M2C_FIELD(arg0, s8**, 0x24);
+		for (var_ctr_2 = 0U; var_ctr_2 < arg1; var_r5_2 += 0x10, var_ctr_2 += 1) {
+			var_r8_2 = 0;
+			var_r4_2 = 0U;
+			var_r3_2 = 0;
+			while (var_r4_2 < (u32)M2C_FIELD(arg0, u32*, 0x10)) {
+				var_r4_2 += 1;
+				temp_r0_3 = M2C_FIELD(arg0, s32*, 0x18) + var_r3_2;
+				var_r3_2 += 4;
+				*var_r7_2 = (s8)(lbl_80430110 * M2C_FIELD((u8*)temp_r0_3, f32*, var_r5_2));
+				temp_r0_4 = (u8)*var_r7_2;
+				var_r7_2 += 1;
+				var_r8_2 += temp_r0_4;
+			}
+			if (var_r8_2 < 0x80U) {
+				var_r6_2 = 0U;
+				while (temp_r0_5 = M2C_FIELD(arg0, u32*, 0x10), var_r6_2 < temp_r0_5) {
+					var_r8_2 += 1;
+					temp_r4_2 = var_r7_2 - (temp_r0_5 - var_r6_2);
+					*temp_r4_2 += 1;
+					if (var_r8_2 == 0x80) {
+						break;
 					}
+					var_r6_2 += 1;
 				}
-				var_r5_2 += 0x10;
-				var_ctr_2 -= 1;
-			} while (var_ctr_2 != 0);
+			}
 		}
 		var_r4_3 = 0;
 		M2C_FIELD(arg0, s8**, 0x28)
 		    = (s8*)(M2C_FIELD(arg0, s8**, 0x24) + (M2C_FIELD(arg0, u32*, 0x10) * arg1));
 		M2C_FIELD(arg0, s8**, 0x28) = (s8*)((s32)(M2C_FIELD(arg0, s8**, 0x28) + 3) & 0xFFFFFFFC);
 		var_r5_3                    = M2C_FIELD(arg0, s8**, 0x28);
-		var_ctr_3                   = arg1;
-		if (arg1 > 0U) {
-			do {
-				var_r6_3 = 0U;
-				var_r3_3 = 0;
-			loop_23:
-				if (var_r6_3 < (u32)M2C_FIELD(arg0, u32*, 0x10)) {
-					var_r6_3 += 1;
-					temp_r0_6 = M2C_FIELD(M2C_FIELD(arg0, u8**, 0x14), u32*, var_r4_3) >> var_r3_3;
-					var_r3_3 += 8;
-					*var_r5_3 = (s8)temp_r0_6;
-					var_r5_3 += 1;
-					goto loop_23;
-				}
-				var_r4_3 += 4;
-				var_ctr_3 -= 1;
-			} while (var_ctr_3 != 0);
+		for (var_ctr_3 = 0U; var_ctr_3 < arg1; var_r4_3 += 4, var_ctr_3 += 1) {
+			var_r6_3 = 0U;
+			var_r3_3 = 0;
+			while (var_r6_3 < (u32)M2C_FIELD(arg0, u32*, 0x10)) {
+				var_r6_3 += 1;
+				temp_r0_6 = M2C_FIELD(M2C_FIELD(arg0, u8**, 0x14), u32*, var_r4_3) >> var_r3_3;
+				var_r3_3 += 8;
+				*var_r5_3 = (s8)temp_r0_6;
+				var_r5_3 += 1;
+			}
 		}
 	}
 	return arg0;

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -9,6 +9,10 @@ typedef s32 M2C_UNK;
 typedef struct {
 	s32 words[16];
 } M2C_BLOCK64;
+typedef struct {
+	s32 unk0;
+	s32 unk4;
+} M2C_PAIR;
 #define M2C_FIELD(base, type, offset)   (*(type)((u8*)(base) + (offset)))
 #define M2C_STRUCT_COPY(dst, src, size) memcpy((void*)(dst), (const void*)(src), (size))
 #define M2C_ERROR(...)                  0
@@ -45,13 +49,13 @@ u8* fn_8015F5EC(s32*, s32, s32);                                /* extern */
 u8* fn_8015F8A4(s32*, s32, s32);                                /* extern */
 s32 fn_801659DC(u32*, u8*, u8*);                                /* extern */
 u32 fn_80192ED8(s32*, M2C_UNK, s32, M2C_UNK, M2C_UNK);          /* extern */
-s32 fn_80192F38(M2C_UNK, u32*, u32*);                           /* extern */
+s32 fn_80192F38(u32*, s32, u32*, u32*);                         /* extern */
 u32 fn_8019336C(s32*, s32, s32);                                /* extern */
 u32 fn_80193474(s32*, s32*, s32);                               /* extern */
 u32 fn_801937A0(u32*, u32*, s32);                               /* extern */
 u32 fn_80193884(u32*, s32*, s32);                               /* extern */
 M2C_UNK fn_80193FE8(s32*);                                      /* extern */
-s32 fn_8019408C(M2C_UNK);                                       /* extern */
+s32 fn_8019408C(s32, ...);                                      /* extern */
 M2C_UNK fn_80195674(M2C_UNK*, M2C_UNK*, M2C_UNK*);              /* extern */
 M2C_UNK fn_80195B5C(M2C_UNK*, M2C_UNK*);                        /* extern */
 s32 fn_801966CC(M2C_UNK, s32, M2C_UNK, s32, M2C_UNK*);          /* extern */
@@ -1956,10 +1960,8 @@ block_19:
 
 u32* fn_8022824C(u32* arg0, u32* arg1)
 {
-	s32 sp24;
-	s32 sp20;
-	s32 sp1C;
-	s32 sp18;
+	M2C_PAIR sp20;
+	M2C_PAIR sp18;
 	u32 sp14;
 	u32 sp10;
 	s32 spC;
@@ -1974,19 +1976,19 @@ u32* fn_8022824C(u32* arg0, u32* arg1)
 	u32 temp_r5_6;
 	u8* temp_r30;
 
-	if (fn_80192F38(1, &sp10, &sp14) == 0) {
+	if (fn_80192F38(arg0, 1, &sp10, &sp14) == 0) {
 		return NULL;
 	}
 	if ((sp14 < 0x31000U) || (sp14 > 0x35000U)) {
-		sp20 = 0x116;
-		sp24 = fn_8019408C(0x80000004);
-		fn_80193FE8(&sp20);
+		sp20.unk0 = 0x116;
+		sp20.unk4 = fn_8019408C(0x80000004);
+		fn_80193FE8((s32*)&sp20);
 		return NULL;
 	}
 	if (sp14 < 0x34002U) {
-		sp18 = 0x116;
-		sp1C = fn_8019408C(0x80000004);
-		fn_80193FE8(&sp18);
+		sp18.unk0 = 0x116;
+		sp18.unk4 = fn_8019408C(0x80000004);
+		fn_80193FE8((s32*)&sp18);
 		return NULL;
 	}
 	if (fn_80193884(arg0, &sp8, 4) == 0U) {
@@ -2020,22 +2022,22 @@ u32* fn_8022824C(u32* arg0, u32* arg1)
 		    = (s32)(M2C_FIELD(temp_r30, s32*, 0xC) + (M2C_FIELD(temp_r30, s32*, 0) << 6));
 		temp_r5 = M2C_FIELD(temp_r30, u32*, 4);
 		sp10    = temp_r5;
-		if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 8), (u8)temp_r5)) {
+		if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 8), temp_r5)) {
 			return NULL;
 		}
 		temp_r5_2 = M2C_FIELD(temp_r30, u32*, 0x10) * temp_r31;
 		sp10      = temp_r5_2;
-		if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 0x28), (u8)temp_r5_2)) {
+		if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 0x28), temp_r5_2)) {
 			return NULL;
 		}
 		temp_r5_3 = M2C_FIELD(temp_r30, u32*, 0x10) * temp_r31;
 		sp10      = temp_r5_3;
-		if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 0x24), (u8)temp_r5_3)) {
+		if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 0x24), temp_r5_3)) {
 			return NULL;
 		}
 		temp_r5_4 = M2C_FIELD(temp_r30, s32*, 0) << 6;
 		sp10      = temp_r5_4;
-		if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 0xC), (u8)temp_r5_4)) {
+		if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 0xC), temp_r5_4)) {
 			return NULL;
 		}
 		goto block_26;
@@ -2048,12 +2050,12 @@ u32* fn_8022824C(u32* arg0, u32* arg1)
 	    = (s32)(M2C_FIELD(temp_r30, s32*, 0xC) + (M2C_FIELD(temp_r30, s32*, 0) << 6));
 	temp_r5_5 = M2C_FIELD(temp_r30, u32*, 4);
 	sp10      = temp_r5_5;
-	if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 8), (u8)temp_r5_5)) {
+	if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 8), temp_r5_5)) {
 		return NULL;
 	}
 	temp_r5_6 = M2C_FIELD(temp_r30, s32*, 0) << 6;
 	sp10      = temp_r5_6;
-	if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 0xC), (u8)temp_r5_6)) {
+	if (sp10 != fn_801979AC(arg0, M2C_FIELD(temp_r30, s32*, 0xC), temp_r5_6)) {
 		return NULL;
 	}
 block_26:

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -6,6 +6,9 @@
 // the first user of the independent BSS object at 0x8042AB90.
 
 typedef s32 M2C_UNK;
+typedef struct {
+	s32 words[16];
+} M2C_BLOCK64;
 #define M2C_FIELD(base, type, offset)   (*(type)((u8*)(base) + (offset)))
 #define M2C_STRUCT_COPY(dst, src, size) memcpy((void*)(dst), (const void*)(src), (size))
 #define M2C_ERROR(...)                  0
@@ -252,6 +255,8 @@ u8* fn_80225434(u32 arg0, u32 arg1, u32 arg2, u32 arg3, u32* arg4, u32* arg5, u8
 	s32 var_r3;
 	s32 var_r6_3;
 	s32 var_r9;
+	u32 var_i;
+	u32 var_j;
 	u8* var_r10;
 	u32* var_r11;
 	u8* var_r12;
@@ -279,82 +284,52 @@ u8* fn_80225434(u32 arg0, u32 arg1, u32 arg2, u32 arg3, u32* arg4, u32* arg5, u8
 	if (arg3 == 0U) {
 		var_r7                          = arg4;
 		M2C_FIELD(temp_r30, u32*, 0x10) = 1U;
-		var_r5                          = 0U;
-	loop_7:
-		if (var_r5 < arg0) {
+		for (var_r5 = 0U; var_r5 < arg0; var_r5 += 1, var_r7 += 4) {
 			temp_r4 = M2C_FIELD(temp_r30, u32*, 0x10);
-			var_r6  = var_r7 + (temp_r4 * 4);
-			var_ctr = 4 - temp_r4;
-			if (temp_r4 < 4U) {
-			loop_3:
-				if ((u32)*var_r6 != 0U) {
-					M2C_FIELD(temp_r30, u32*, 0x10) = (u32)(M2C_FIELD(temp_r30, u32*, 0x10) + 1);
-					if ((u32)M2C_FIELD(temp_r30, u32*, 0x10) != 4) {
-						var_r6 += 4;
-						var_ctr -= 1;
-						if (var_ctr == 0) {
-							goto block_6;
-						}
-						goto loop_3;
-					}
-				} else {
-					goto block_6;
+			var_r6  = &var_r7[temp_r4];
+			for (var_i = temp_r4; var_i < 4U; var_i += 1, var_r6 += 1) {
+				if ((u32)*var_r6 == 0U) {
+					break;
 				}
-			} else {
-			block_6:
-				var_r7 += 0x10;
-				var_r5 += 1;
-				goto loop_7;
+				M2C_FIELD(temp_r30, u32*, 0x10) = (u32)(M2C_FIELD(temp_r30, u32*, 0x10) + 1);
+				if ((u32)M2C_FIELD(temp_r30, u32*, 0x10) == 4U) {
+					goto block_8;
+				}
 			}
 		}
 	}
+block_8:
 	if (var_r26 == 0) {
-		var_r11  = arg4;
-		var_r12  = sp8;
-		var_r23  = arg5;
-		var_r26  = 0;
-		var_r6_2 = 0U;
-	loop_21:
-		if (var_r6_2 < arg0) {
+		var_r11 = arg4;
+		var_r12 = sp8;
+		var_r23 = arg5;
+		var_r26 = 0;
+		for (var_r6_2 = 0U; var_r6_2 < arg0; var_r6_2 += 1, var_r11 += 4, var_r23 += 1) {
 			var_r5_2 = 0U;
 			var_r8   = var_r11;
-			var_r9   = 0;
+			var_r9   = var_r5_2;
 			var_r10  = var_r12;
-		loop_19:
-			if (var_r5_2 < (u32)M2C_FIELD(temp_r30, u32*, 0x10)) {
-				if ((u32)*var_r8 != 0) {
-					var_r7_2  = sp8;
-					var_r3    = 1;
-					temp_r0   = (u32)*var_r23 >> var_r9;
-					var_ctr_2 = var_r26;
-					if (var_r26 > 0U) {
-					loop_13:
-						if ((u8)temp_r0 == (u8)*var_r7_2) {
-							var_r3 = 0;
-						} else {
-							var_r7_2 += 1;
-							var_ctr_2 -= 1;
-							if (var_ctr_2 != 0) {
-								goto loop_13;
-							}
-						}
-					}
-					if (var_r3 != 0) {
-						*var_r10 = (u8)temp_r0;
-						var_r10 += 1;
-						var_r12 += 1;
-						var_r26 += 1;
+			for (; var_r5_2 < (u32)M2C_FIELD(temp_r30, u32*, 0x10);
+			    var_r5_2 += 1, var_r8 += 1, var_r9 += 8) {
+				if ((u32)*var_r8 == 0U) {
+					continue;
+				}
+				var_r7_2 = sp8;
+				var_r3   = 1;
+				temp_r0  = (u32)*var_r23 >> var_r9;
+				for (var_j = 0U; var_j < var_r26; var_j += 1, var_r7_2 += 1) {
+					if ((u8)temp_r0 == (u8)*var_r7_2) {
+						var_r3 = 0;
+						break;
 					}
 				}
-				var_r8 += 4;
-				var_r9 += 8;
-				var_r5_2 += 1;
-				goto loop_19;
+				if (var_r3 != 0) {
+					*var_r10 = (u8)temp_r0;
+					var_r10 += 1;
+					var_r12 += 1;
+					var_r26 += 1;
+				}
 			}
-			var_r11 += 0x10;
-			var_r23 += 4;
-			var_r6_2 += 1;
-			goto loop_21;
 		}
 	}
 	temp_r4_2 = (arg1 << 6) + var_r26;
@@ -379,30 +354,9 @@ u8* fn_80225434(u32 arg0, u32 arg1, u32 arg2, u32 arg3, u32* arg4, u32* arg5, u8
 			var_r7_3 = M2C_FIELD(temp_r30, u32*, 0);
 			var_r6_3 = var_r7_3 << 6;
 			var_r5_3 = arg6 + var_r6_3;
-		loop_30:
-			temp_cr0_eq = var_r7_3 == 0;
-			var_r7_3 -= 1;
-			var_r5_3 -= 0x40;
-			var_r6_3 -= 0x40;
-			if (temp_cr0_eq == 0) {
-				temp_r4_3                        = (u8*)(M2C_FIELD(temp_r30, s32*, 0xC) + var_r6_3);
-				M2C_FIELD(temp_r4_3, s32*, 0x00) = M2C_FIELD(var_r5_3, s32*, 0x00);
-				M2C_FIELD(temp_r4_3, s32*, 0x04) = M2C_FIELD(var_r5_3, s32*, 0x04);
-				M2C_FIELD(temp_r4_3, s32*, 0x08) = M2C_FIELD(var_r5_3, s32*, 0x08);
-				M2C_FIELD(temp_r4_3, s32*, 0x0C) = M2C_FIELD(var_r5_3, s32*, 0x0C);
-				M2C_FIELD(temp_r4_3, s32*, 0x10) = M2C_FIELD(var_r5_3, s32*, 0x10);
-				M2C_FIELD(temp_r4_3, s32*, 0x14) = M2C_FIELD(var_r5_3, s32*, 0x14);
-				M2C_FIELD(temp_r4_3, s32*, 0x18) = M2C_FIELD(var_r5_3, s32*, 0x18);
-				M2C_FIELD(temp_r4_3, s32*, 0x1C) = M2C_FIELD(var_r5_3, s32*, 0x1C);
-				M2C_FIELD(temp_r4_3, s32*, 0x20) = M2C_FIELD(var_r5_3, s32*, 0x20);
-				M2C_FIELD(temp_r4_3, s32*, 0x24) = M2C_FIELD(var_r5_3, s32*, 0x24);
-				M2C_FIELD(temp_r4_3, s32*, 0x28) = M2C_FIELD(var_r5_3, s32*, 0x28);
-				M2C_FIELD(temp_r4_3, s32*, 0x2C) = M2C_FIELD(var_r5_3, s32*, 0x2C);
-				M2C_FIELD(temp_r4_3, s32*, 0x30) = M2C_FIELD(var_r5_3, s32*, 0x30);
-				M2C_FIELD(temp_r4_3, s32*, 0x34) = M2C_FIELD(var_r5_3, s32*, 0x34);
-				M2C_FIELD(temp_r4_3, s32*, 0x38) = M2C_FIELD(var_r5_3, s32*, 0x38);
-				M2C_FIELD(temp_r4_3, s32*, 0x3C) = M2C_FIELD(var_r5_3, s32*, 0x3C);
-				goto loop_30;
+			while (var_r5_3 -= 0x40, var_r6_3 -= 0x40, var_r7_3-- != 0U) {
+				temp_r4_3                = (u8*)(M2C_FIELD(temp_r30, s32*, 0xC) + var_r6_3);
+				*(M2C_BLOCK64*)temp_r4_3 = *(M2C_BLOCK64*)var_r5_3;
 			}
 		}
 		if (arg5 != NULL) {

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -37,7 +37,7 @@ M2C_UNK fn_8015C3A4(s32, u8*, u32*);                            /* extern */
 M2C_UNK fn_8015C590();                                          /* extern */
 s32* fn_8015D4B8();                                             /* extern */
 M2C_UNK (*fn_8015ECF4(u32, s32, s32, s32))(u8*, u8*, u8*, f32); /* extern */
-s32 fn_8015F3FC(u8*, u8*, s32, s32, s32);                       /* extern */
+s32 fn_8015F3FC(u8*, u8*, s32, s32);                            /* extern */
 u8* fn_8015F5EC(s32*, s32, s32);                                /* extern */
 u8* fn_8015F8A4(s32*, s32, s32);                                /* extern */
 s32 fn_801659DC(u32*, u8*, u8*);                                /* extern */
@@ -2188,6 +2188,7 @@ block_26:
 	return arg0;
 }
 
+#pragma dont_inline on
 s32 fn_802285D8(u32* arg0, u8** arg1, u8** arg2, M2C_UNK arg_sp0)
 {
 	u8 sp8[0x180];
@@ -2213,7 +2214,6 @@ s32 fn_802285D8(u32* arg0, u8** arg1, u8** arg2, M2C_UNK arg_sp0)
 	s32 var_r19;
 	s32 var_r26;
 	s32 var_r31;
-	s32 var_r31_2;
 	s32 var_r4;
 	s32 var_r6_2;
 	s32 var_r7;
@@ -2248,7 +2248,7 @@ s32 fn_802285D8(u32* arg0, u8** arg1, u8** arg2, M2C_UNK arg_sp0)
 	M2C_FIELD(sp8, s32*, 4) = 8;
 	M2C_FIELD(sp8, s8*, 8)  = -1;
 	if (M2C_FIELD(arg0, s32*, 8) & 0x10) {
-		temp_r6                           = 1 * 0x18;
+		temp_r6                           = var_r31 * 0x18;
 		var_r31                           = 2;
 		M2C_FIELD(sp8, s32*, temp_r6)     = M2C_FIELD(temp_r3, s32*, 0x18);
 		M2C_FIELD(sp8, s32*, temp_r6 + 4) = 8;
@@ -2263,19 +2263,12 @@ s32 fn_802285D8(u32* arg0, u8** arg1, u8** arg2, M2C_UNK arg_sp0)
 	}
 	if (M2C_FIELD(arg0, s32*, 8) & 0x84) {
 		var_r5 = arg0;
-		var_r7 = 0;
 		var_r6 = sp8 + (var_r31 * 0x18);
-	loop_9:
-		if (var_r7 < (s32)M2C_FIELD(arg0, s32*, 0x1C)) {
-			temp_r0 = M2C_FIELD(var_r5, s32*, 0x34);
-			var_r31 += 1;
-			var_r5 += 4;
-			var_r7 += 1;
-			M2C_FIELD(var_r6, s32*, 0) = temp_r0;
+		for (var_r7 = 0; var_r7 < (s32)M2C_FIELD(arg0, s32*, 0x1C);
+		    var_r31 += 1, var_r5 += 1, var_r7 += 1, var_r6 += 0x18) {
+			M2C_FIELD(var_r6, s32*, 0) = M2C_FIELD(var_r5, s32*, 0x34);
 			M2C_FIELD(var_r6, s32*, 4) = 7;
 			M2C_FIELD(var_r6, s8*, 8)  = -1;
-			var_r6 += 0x18;
-			goto loop_9;
 		}
 	}
 	temp_r3_2 = fn_80226468(arg0);
@@ -2304,23 +2297,23 @@ s32 fn_802285D8(u32* arg0, u8** arg1, u8** arg2, M2C_UNK arg_sp0)
 	}
 	M2C_FIELD(sp8, s8*, (var_r31 * 0x18) + 8) = -1;
 	if ((u32)M2C_FIELD(temp_r3_2, u32*, 0x10) > 1U) {
-		temp_r7                           = (var_r31 + 1) * 0x18;
-		var_r31_2                         = var_r31 + 2;
+		temp_r7 = (var_r31 + 1) * 0x18;
+		var_r31 += 2;
 		M2C_FIELD(sp8, s32*, temp_r7)     = M2C_FIELD(temp_r3_2, s32*, 0x24);
-		M2C_FIELD(sp8, s32*, temp_r7 + 4) = M2C_FIELD(sp8, s8*, temp_r7 - 0xC);
+		M2C_FIELD(sp8, s32*, temp_r7 + 4) = M2C_FIELD(sp8, s32*, temp_r7 - 0x14);
 		M2C_FIELD(sp8, s8*, temp_r7 + 8)  = -1;
 	} else {
-		temp_r5_3                           = (var_r31 + 1) * 0x18;
-		var_r31_2                           = var_r31 + 2;
+		temp_r5_3 = (var_r31 + 1) * 0x18;
+		var_r31 += 2;
 		M2C_FIELD(sp8, s32*, temp_r5_3)     = M2C_FIELD(temp_r3_2, s32*, 0x18);
 		M2C_FIELD(sp8, s32*, temp_r5_3 + 4) = 9;
 		M2C_FIELD(sp8, s8*, temp_r5_3 + 8)  = -1;
 	}
 	if (M2C_FIELD(arg0, s32*, 8) & 0x10) {
-		temp_r18                             = var_r31_2 - 2;
-		temp_r12                             = var_r31_2 - 1;
+		temp_r18                             = var_r31 - 2;
+		temp_r12                             = var_r31 - 1;
 		M2C_FIELD(sp8, s8*, 8)               = 1;
-		temp_r20                             = var_r31_2 * 0x18;
+		temp_r20                             = var_r31 * 0x18;
 		M2C_FIELD(sp8, s8*, 9)               = temp_r18;
 		M2C_FIELD(sp8, s8*, 10)              = temp_r12;
 		M2C_FIELD(sp8, s8*, 11)              = -1;
@@ -2328,33 +2321,33 @@ s32 fn_802285D8(u32* arg0, u8** arg1, u8** arg2, M2C_UNK arg_sp0)
 		M2C_FIELD(sp8, s8*, 0x21)            = temp_r18;
 		M2C_FIELD(sp8, s8*, 0x22)            = temp_r12;
 		M2C_FIELD(sp8, s8*, 0x23)            = -1;
-		M2C_FIELD(sp8, s8*, temp_r20 - 0x20) = 0;
-		M2C_FIELD(sp8, s8*, temp_r20 - 0x1F) = 1;
-		M2C_FIELD(sp8, s8*, temp_r20 - 0x1E) = temp_r12;
-		M2C_FIELD(sp8, s8*, temp_r20 - 0x1D) = -1;
-		M2C_FIELD(sp8, s8*, temp_r20 - 8)    = 0;
-		M2C_FIELD(sp8, s8*, temp_r20 - 7)    = 1;
-		M2C_FIELD(sp8, s8*, temp_r20 - 6)    = temp_r18;
-		M2C_FIELD(sp8, s8*, temp_r20 - 5)    = -1;
+		M2C_FIELD(sp8, s8*, temp_r20 - 0x28) = 0;
+		M2C_FIELD(sp8, s8*, temp_r20 - 0x27) = 1;
+		M2C_FIELD(sp8, s8*, temp_r20 - 0x26) = temp_r12;
+		M2C_FIELD(sp8, s8*, temp_r20 - 0x25) = -1;
+		M2C_FIELD(sp8, s8*, temp_r20 - 0x10) = 0;
+		M2C_FIELD(sp8, s8*, temp_r20 - 0xF)  = 1;
+		M2C_FIELD(sp8, s8*, temp_r20 - 0xE)  = temp_r18;
+		M2C_FIELD(sp8, s8*, temp_r20 - 0xD)  = -1;
 	} else {
-		temp_r10                             = var_r31_2 - 2;
-		temp_r9                              = var_r31_2 - 1;
+		temp_r10                             = var_r31 - 2;
+		temp_r9                              = var_r31 - 1;
 		M2C_FIELD(sp8, s8*, 8)               = temp_r10;
-		temp_r11                             = var_r31_2 * 0x18;
+		temp_r11                             = var_r31 * 0x18;
 		M2C_FIELD(sp8, s8*, 9)               = temp_r9;
 		M2C_FIELD(sp8, s8*, 10)              = -1;
-		M2C_FIELD(sp8, s8*, temp_r11 - 0x20) = 0;
-		M2C_FIELD(sp8, s8*, temp_r11 - 0x1F) = temp_r9;
-		M2C_FIELD(sp8, s8*, temp_r11 - 0x1E) = -1;
-		M2C_FIELD(sp8, s8*, temp_r11 - 8)    = 0;
-		M2C_FIELD(sp8, s8*, temp_r11 - 7)    = temp_r10;
-		M2C_FIELD(sp8, s8*, temp_r11 - 6)    = -1;
+		M2C_FIELD(sp8, s8*, temp_r11 - 0x28) = 0;
+		M2C_FIELD(sp8, s8*, temp_r11 - 0x27) = temp_r9;
+		M2C_FIELD(sp8, s8*, temp_r11 - 0x26) = -1;
+		M2C_FIELD(sp8, s8*, temp_r11 - 0x10) = 0;
+		M2C_FIELD(sp8, s8*, temp_r11 - 0xF)  = temp_r10;
+		M2C_FIELD(sp8, s8*, temp_r11 - 0xE)  = -1;
 	}
-	temp_r3_3 = fn_8015F8A4((s32*)sp8, var_r31_2, M2C_FIELD(arg0, s32*, 0x14));
+	temp_r3_3 = fn_8015F8A4((s32*)sp8, var_r31, M2C_FIELD(arg0, s32*, 0x14));
 	if (temp_r3_3 == NULL) {
 		return 0;
 	}
-	*arg1 = fn_8015F5EC((s32*)sp8, var_r31_2, M2C_FIELD(arg0, s32*, 0x14));
+	*arg1 = fn_8015F5EC((s32*)sp8, var_r31, M2C_FIELD(arg0, s32*, 0x14));
 	if ((u8*)*arg1 == NULL) {
 		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(temp_r3_3, lbl_8042C9A4);
 		return 0;
@@ -2362,7 +2355,7 @@ s32 fn_802285D8(u32* arg0, u8** arg1, u8** arg2, M2C_UNK arg_sp0)
 	temp_r4    = M2C_FIELD(arg0, u8**, 0x54);
 	temp_r24   = M2C_FIELD(temp_r4, u16*, 4);
 	temp_r26   = temp_r24 * 4;
-	temp_r18_2 = (var_r31_2 - 2) * temp_r26;
+	temp_r18_2 = (var_r31 - 2) * temp_r26;
 	temp_r3_4  = M2C_FIELD(lbl_8042C9A4, u8 * (**)(), 0x134)(temp_r18_2, temp_r4);
 	if (temp_r3_4 == NULL) {
 		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(*arg1, lbl_8042C9A4);
@@ -2370,50 +2363,13 @@ s32 fn_802285D8(u32* arg0, u8** arg1, u8** arg2, M2C_UNK arg_sp0)
 		return 0;
 	}
 	memset(temp_r3_4, 0, temp_r18_2);
-	var_r7_2  = 0;
-	temp_r0_3 = var_r31_2 - 2;
-	var_r4    = 0;
-	temp_r5_4 = var_r31_2 - 0xA;
-loop_43:
-	if (var_r7_2 < (s32)temp_r24) {
-		var_r9  = 0U;
+	temp_r0_3 = var_r31 - 2;
+	for (var_r7_2 = 0, var_r4 = 0; var_r7_2 < (s32)temp_r24; var_r4 += 0xC, var_r7_2 += 1) {
 		temp_r8 = M2C_FIELD(arg0, u8**, 0x54) + var_r4;
-		if (temp_r0_3 > 0U) {
-			if (temp_r0_3 > 8U) {
-				temp_r6_3 = var_r7_2 * temp_r0_3;
-				var_r11   = temp_r6_3 * 4;
-				var_ctr   = (u32)(temp_r5_4 + 7) >> 3U;
-				if (temp_r5_4 > 0U) {
-					do {
-						temp_r19                            = var_r9 + temp_r6_3;
-						*(temp_r3_4 + var_r11)              = M2C_FIELD(temp_r8, s32*, 0x10);
-						*(temp_r3_4 + ((temp_r19 + 1) * 4)) = M2C_FIELD(temp_r8, s32*, 0x10);
-						*(temp_r3_4 + ((temp_r19 + 2) * 4)) = M2C_FIELD(temp_r8, s32*, 0x10);
-						var_r11 += 0x20;
-						var_r9 += 8;
-						*(temp_r3_4 + ((temp_r19 + 3) * 4)) = M2C_FIELD(temp_r8, s32*, 0x10);
-						*(temp_r3_4 + ((temp_r19 + 4) * 4)) = M2C_FIELD(temp_r8, s32*, 0x10);
-						*(temp_r3_4 + ((temp_r19 + 5) * 4)) = M2C_FIELD(temp_r8, s32*, 0x10);
-						*(temp_r3_4 + ((temp_r19 + 6) * 4)) = M2C_FIELD(temp_r8, s32*, 0x10);
-						*(temp_r3_4 + ((temp_r19 + 7) * 4)) = M2C_FIELD(temp_r8, s32*, 0x10);
-						var_ctr -= 1;
-					} while (var_ctr != 0);
-				}
-			}
-			temp_r10_2 = var_r31_2 - 2;
-			var_r6_2   = (var_r9 + (var_r7_2 * temp_r10_2)) * 4;
-			var_ctr_2  = temp_r10_2 - var_r9;
-			if (var_r9 < temp_r10_2) {
-				do {
-					*(temp_r3_4 + var_r6_2) = M2C_FIELD(temp_r8, s32*, 0x10);
-					var_r6_2 += 4;
-					var_ctr_2 -= 1;
-				} while (var_ctr_2 != 0);
-			}
+		for (var_r9 = 0U; var_r9 < temp_r0_3; var_r9 += 1) {
+			M2C_FIELD(temp_r3_4, s32*, ((var_r7_2 * temp_r0_3) + var_r9) * 4)
+			    = M2C_FIELD(temp_r8, s32*, 0x10);
 		}
-		var_r4 += 0xC;
-		var_r7_2 += 1;
-		goto loop_43;
 	}
 	*arg2 = M2C_FIELD(lbl_8042C9A4, u8 * (**)(), 0x134)(temp_r26, lbl_8042C9A4);
 	if ((u8*)*arg2 == NULL) {
@@ -2422,33 +2378,24 @@ loop_43:
 		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(temp_r3_3, lbl_8042C9A4);
 		return 0;
 	}
-	var_r26  = 0;
-	temp_r29 = var_r31_2 - 2;
-	var_r18  = 0;
-	var_r19  = 0;
-loop_53:
-	if (var_r26 >= (s32)temp_r24) {
-		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(temp_r3_4, lbl_8042C9A4);
-		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(temp_r3_3, lbl_8042C9A4);
-		return 1;
-	}
-	temp_r7_2          = var_r26 * temp_r29;
-	*(*arg2 + var_r19) = fn_8015F3FC(temp_r3_3, temp_r3_4 + (temp_r7_2 * 4), temp_r29,
-	    M2C_FIELD((M2C_FIELD(arg0, u8**, 0x54) + var_r18), s32*, 0x14), temp_r7_2);
-	if ((u32) * (*arg2 + var_r19) == 0U) {
-		var_r18_2 = var_r26 * 4;
-	loop_50:
-		var_r26 -= 1;
-		var_r18_2 -= 4;
-		if (var_r26 > 0) {
-			temp_r4_2 = *arg2;
-			M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(*(temp_r4_2 + var_r18_2), temp_r4_2);
-			goto loop_50;
+	temp_r29 = var_r31 - 2;
+	for (var_r26 = 0, var_r18 = 0, var_r19 = 0; var_r26 < (s32)temp_r24;
+	    var_r18 += 0xC, var_r19 += 4, var_r26 += 1) {
+		temp_r7_2                       = var_r26 * temp_r29;
+		M2C_FIELD(*arg2, s32*, var_r19) = fn_8015F3FC(temp_r3_3, temp_r3_4 + (temp_r7_2 * 4),
+		    temp_r29, M2C_FIELD((M2C_FIELD(arg0, u8**, 0x54) + var_r18), s32*, 0x14));
+		if ((u32)M2C_FIELD(*arg2, u32*, var_r19) == 0U) {
+			var_r18_2 = var_r26 * 4;
+			while (var_r26 -= 1, var_r18_2 -= 4, var_r26 > 0) {
+				temp_r4_2 = *arg2;
+				M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(
+				    M2C_FIELD(temp_r4_2, s32*, var_r18_2), temp_r4_2);
+			}
+			return 0;
 		}
-		return 0;
 	}
-	var_r18 += 0xC;
-	var_r19 += 4;
-	var_r26 += 1;
-	goto loop_53;
+	M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(temp_r3_4, lbl_8042C9A4);
+	M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(temp_r3_3, lbl_8042C9A4);
+	return 1;
 }
+#pragma dont_inline reset

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -1418,15 +1418,11 @@ void fn_802273D0(u8* arg0, s32 arg1, s32 arg2, M2C_UNK arg_sp0)
 	temp_r23 = M2C_FIELD((temp_r6 + temp_r4), u8*, 1);
 	var_r22  = 0;
 	temp_r24 = (M2C_FIELD(temp_r6, u8*, temp_r4) * 2) & 0xFE;
-	var_r25  = 0;
-loop_7:
-	if (var_r25 < temp_r23) {
-		var_r21  = 0U;
+	for (var_r25 = 0; var_r25 < temp_r23; var_r25 += 1) {
 		temp_r3  = (u8*)(temp_r24 + (M2C_FIELD(arg0, s32*, 0x44) + ((var_r25 * 2) & 0x1FE)));
 		temp_r26 = M2C_FIELD(temp_r3, u8*, 1);
 		var_r29  = M2C_FIELD(temp_r3, u8*, 0) << 6;
-	loop_5:
-		if (var_r21 < temp_r26) {
+		for (var_r21 = 0U; var_r21 < temp_r26; var_r22 += 3, var_r29 += 0x40, var_r21 += 1) {
 			temp_r5 = (u8*)(M2C_FIELD(lbl_8029BB30, s32*, 0xC) + var_r29);
 			sp8[0]  = -M2C_FIELD(temp_r5, f32*, 0);
 			sp8[1]  = -M2C_FIELD(temp_r5, f32*, 0x10);
@@ -1444,13 +1440,7 @@ loop_7:
 			if (arg2 != 0) {
 				GXLoadNrmMtxImm(sp8, var_r22);
 			}
-			var_r22 += 3;
-			var_r29 += 0x40;
-			var_r21 += 1;
-			goto loop_5;
 		}
-		var_r25 += 1;
-		goto loop_7;
 	}
 }
 

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -1454,6 +1454,7 @@ loop_7:
 	}
 }
 
+#pragma dont_inline on
 u8* fn_80227528(u8* arg0, u8* arg1, M2C_UNK arg_sp0)
 {
 	f32 sp8[12];
@@ -1466,13 +1467,14 @@ u8* fn_80227528(u8* arg0, u8* arg1, M2C_UNK arg_sp0)
 	s32 temp_cr0_eq;
 	s32 temp_cr0_eq_2;
 	s32 temp_r18;
+	s32 temp_r3_6;
 	s32 temp_r18_2;
 	s32 temp_r20;
 	s32 temp_r22;
 	s32 temp_r4_4;
 	s32 var_r15;
 	s32 var_r15_2;
-	u16 var_r31;
+	u32 var_r31;
 	u32* temp_r5;
 	u32 temp_r6;
 	u32 var_r16;
@@ -1526,10 +1528,8 @@ u8* fn_80227528(u8* arg0, u8* arg1, M2C_UNK arg_sp0)
 	var_r29   = temp_r4_2 + 0x10;
 	if (((u32)M2C_FIELD(temp_r3, u32*, 0x10) == 1U)
 	    && ((u32)M2C_FIELD(temp_r3, u32*, 0x34) == 0U)) {
-		var_r16 = 0U;
-		var_r18 = 0;
-	loop_12:
-		if (var_r16 < (u32)M2C_FIELD(temp_r3, u32*, 4)) {
+		for (var_r16 = 0U, var_r18 = 0; var_r16 < (u32)M2C_FIELD(temp_r3, u32*, 4);
+		    var_r18 += 3, var_r16 += 1) {
 			temp_r6   = M2C_FIELD(arg1, u32*, 8);
 			temp_r5_2 = (u8*)(M2C_FIELD(lbl_8029BB30, s32*, 0xC)
 			    + (M2C_FIELD(M2C_FIELD(temp_r3, u32**, 8), u32*, var_r16) << 6));
@@ -1549,24 +1549,18 @@ u8* fn_80227528(u8* arg0, u8* arg1, M2C_UNK arg_sp0)
 			if ((s32)((temp_r6 >> 4U) & 1) != 0) {
 				GXLoadNrmMtxImm(sp68, var_r18);
 			}
-			var_r18 += 3;
-			var_r16 += 1;
-			goto loop_12;
 		}
 	}
 	if (M2C_FIELD(arg1, u32*, 8) & 0x84) {
-	loop_31:
-		temp_cr0_eq = var_r31 == 0;
-		var_r31 -= 1;
-		if (temp_cr0_eq == 0) {
+		while (temp_cr0_eq = var_r31 == 0, var_r31 -= 1, temp_cr0_eq == 0) {
 			temp_r15_2 = M2C_FIELD(M2C_FIELD(var_r29, u8**, 8), s32***, 0);
 			fn_801B1D0C(temp_r15_2, 0);
 			if (temp_r15_2 != NULL) {
 				temp_r4_3 = *temp_r15_2;
 				if (temp_r4_3 != NULL) {
 					temp_r4_4 = *temp_r4_3;
-					fn_801AF914(
-					    (M2C_FIELD(temp_r4_4, u32*, lbl_8042CA48 + 0x14) & 1) ^ 1, (s32)temp_r4_4);
+					temp_r3_6 = lbl_8042CA48 + 0x14;
+					fn_801AF914((M2C_FIELD(temp_r4_4, u32*, temp_r3_6) & 1) ^ 1, (s32)temp_r4_4);
 				}
 			}
 			if (temp_r28 != NULL) {
@@ -1576,21 +1570,18 @@ u8* fn_80227528(u8* arg0, u8* arg1, M2C_UNK arg_sp0)
 			if (((u32)M2C_FIELD(temp_r3, u32*, 0x10) == 1U)
 			    && ((u32)M2C_FIELD(temp_r3, u32*, 0x34) != 0U)) {
 				var_r22   = 0;
-				var_r19   = 0;
 				temp_r18  = ((u32)M2C_FIELD(arg1, u32*, 8) >> 4U) & 1;
 				temp_r3_2 = (u8*)(M2C_FIELD(temp_r3, s32*, 0x40)
 				    + ((M2C_FIELD(M2C_FIELD(arg1, u8**, 4), u16*, 4) - (var_r31 + 1)) * 2));
 				temp_r21  = M2C_FIELD(temp_r3_2, u8*, 1);
 				temp_r20  = (M2C_FIELD(temp_r3_2, u8*, 0) * 2) & 0xFE;
-			loop_29:
-				if (var_r19 < temp_r21) {
-					var_r23    = 0U;
+				for (var_r19 = 0; var_r19 < temp_r21; var_r19 += 1) {
 					temp_r3_3  = (u8*)(temp_r20
 					    + (M2C_FIELD(temp_r3, s32*, 0x44) + ((var_r19 * 2) & 0x1FE)));
 					temp_r16_2 = M2C_FIELD(temp_r3_3, u8*, 1);
 					var_r15    = M2C_FIELD(temp_r3_3, u8*, 0) << 6;
-				loop_27:
-					if (var_r23 < temp_r16_2) {
+					for (var_r23 = 0U; var_r23 < temp_r16_2;
+					    var_r22 += 3, var_r15 += 0x40, var_r23 += 1) {
 						temp_r5_4 = (u8*)(M2C_FIELD(lbl_8029BB30, s32*, 0xC) + var_r15);
 						sp38[0]   = -M2C_FIELD(temp_r5_4, f32*, 0);
 						sp38[1]   = -M2C_FIELD(temp_r5_4, f32*, 0x10);
@@ -1608,25 +1599,15 @@ u8* fn_80227528(u8* arg0, u8* arg1, M2C_UNK arg_sp0)
 						if (temp_r18 != 0) {
 							GXLoadNrmMtxImm(sp38, var_r22);
 						}
-						var_r22 += 3;
-						var_r15 += 0x40;
-						var_r23 += 1;
-						goto loop_27;
 					}
-					var_r19 += 1;
-					goto loop_29;
 				}
 			}
 			GXCallDisplayList(M2C_FIELD(var_r30, s32*, 0), M2C_FIELD(var_r30, s32*, 4));
 			var_r30 += 8;
 			var_r29 += 0xC;
-			goto loop_31;
 		}
 	} else {
-	loop_47:
-		temp_cr0_eq_2 = var_r31 == 0;
-		var_r31 -= 1;
-		if (temp_cr0_eq_2 == 0) {
+		while (temp_cr0_eq_2 = var_r31 == 0, var_r31 -= 1, temp_cr0_eq_2 == 0) {
 			if (temp_r28 != NULL) {
 				temp_r5_5 = M2C_FIELD(var_r29, u8**, 8);
 				temp_r28(arg1 + 0xC, temp_r5_5 + 4, temp_r5_5, M2C_FIELD(temp_r5_5, f32*, 0xC));
@@ -1634,21 +1615,18 @@ u8* fn_80227528(u8* arg0, u8* arg1, M2C_UNK arg_sp0)
 			if (((u32)M2C_FIELD(temp_r3, u32*, 0x10) == 1U)
 			    && ((u32)M2C_FIELD(temp_r3, u32*, 0x34) != 0U)) {
 				var_r20    = 0;
-				var_r23_2  = 0;
 				temp_r18_2 = ((u32)M2C_FIELD(arg1, u32*, 8) >> 4U) & 1;
 				temp_r3_4  = (u8*)(M2C_FIELD(temp_r3, s32*, 0x40)
 				    + ((M2C_FIELD(M2C_FIELD(arg1, u8**, 4), u16*, 4) - (var_r31 + 1)) * 2));
 				temp_r21_2 = M2C_FIELD(temp_r3_4, u8*, 1);
 				temp_r22   = (M2C_FIELD(temp_r3_4, u8*, 0) * 2) & 0xFE;
-			loop_45:
-				if (var_r23_2 < temp_r21_2) {
-					var_r19_2 = 0U;
+				for (var_r23_2 = 0; var_r23_2 < temp_r21_2; var_r23_2 += 1) {
 					temp_r3_5 = (u8*)(temp_r22
 					    + (M2C_FIELD(temp_r3, s32*, 0x44) + ((var_r23_2 * 2) & 0x1FE)));
 					temp_r17  = M2C_FIELD(temp_r3_5, u8*, 1);
 					var_r15_2 = M2C_FIELD(temp_r3_5, u8*, 0) << 6;
-				loop_43:
-					if (var_r19_2 < temp_r17) {
+					for (var_r19_2 = 0U; var_r19_2 < temp_r17;
+					    var_r20 += 3, var_r15_2 += 0x40, var_r19_2 += 1) {
 						temp_r5_6 = (u8*)(M2C_FIELD(lbl_8029BB30, s32*, 0xC) + var_r15_2);
 						sp8[0]    = -M2C_FIELD(temp_r5_6, f32*, 0);
 						sp8[1]    = -M2C_FIELD(temp_r5_6, f32*, 0x10);
@@ -1666,24 +1644,18 @@ u8* fn_80227528(u8* arg0, u8* arg1, M2C_UNK arg_sp0)
 						if (temp_r18_2 != 0) {
 							GXLoadNrmMtxImm(sp8, var_r20);
 						}
-						var_r20 += 3;
-						var_r15_2 += 0x40;
-						var_r19_2 += 1;
-						goto loop_43;
 					}
-					var_r23_2 += 1;
-					goto loop_45;
 				}
 			}
 			GXCallDisplayList(M2C_FIELD(var_r30, s32*, 0), M2C_FIELD(var_r30, s32*, 4));
 			var_r30 += 8;
 			var_r29 += 0xC;
-			goto loop_47;
 		}
 	}
 	return arg0;
 }
 
+#pragma dont_inline reset
 u8* fn_80227AA8(u8* arg0, u32 arg1)
 {
 	f32* temp_r11;

--- a/src/game/rw_gcn_raster.c
+++ b/src/game/rw_gcn_raster.c
@@ -172,7 +172,7 @@ u32* fn_80225248(u32* arg0, u8* arg1)
 	s32 temp_r25;
 	s32 temp_r26;
 	s32 temp_r27;
-	s32 temp_r5x;
+	s32 temp_r5;
 	s32 temp_r6;
 	u32 temp_r28;
 	u8* temp_r31;
@@ -220,9 +220,9 @@ u32* fn_80225248(u32* arg0, u8* arg1)
 		if (var_r4 == NULL) {
 			return NULL;
 		}
-		temp_r6  = M2C_FIELD(arg1, s32*, 0);
-		temp_r5x = (u32)M2C_FIELD(temp_r31, u32*, 4) * 2 + (M2C_FIELD(temp_r31, s32*, 8) * 2);
-		if (fn_801979AC(arg0, M2C_FIELD(temp_r31, s32*, 0xC), temp_r6 + temp_r5x) == 0U) {
+		temp_r6 = M2C_FIELD(arg1, s32*, 0);
+		temp_r5 = (u32)M2C_FIELD(temp_r31, u32*, 4) * 2 + (M2C_FIELD(temp_r31, s32*, 8) * 2);
+		if (fn_801979AC(arg0, M2C_FIELD(temp_r31, s32*, 0xC), temp_r6 + temp_r5) == 0U) {
 			M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(temp_r31, lbl_8042C9A4);
 			return NULL;
 		}
@@ -1072,7 +1072,7 @@ void fn_80226B2C(s32 arg0, u8* arg1, M2C_UNK* arg2, u8* arg3)
 	M2C_UNK sp8[16];
 	M2C_UNK* var_r29;
 	M2C_UNK* var_r6;
-	s32 temp_r0x;
+	s32 temp_r0;
 	s32 temp_r23;
 	s32 temp_r29;
 	s32 temp_r3;
@@ -1106,11 +1106,11 @@ void fn_80226B2C(s32 arg0, u8* arg1, M2C_UNK* arg2, u8* arg3)
 			var_r27  = var_r31;
 			for (var_r30 = 0U; var_r30 < temp_r24;
 			    var_r30 += 1, var_r27 += 1, var_r25 += 1, var_r31 += 1) {
-				sp88[3]  = 0;
-				temp_r4  = M2C_FIELD(arg3, u8**, 0x10);
-				temp_r0x = (*var_r31 * 0x10) + 0xC;
+				sp88[3] = 0;
+				temp_r4 = M2C_FIELD(arg3, u8**, 0x10);
+				temp_r0 = (*var_r31 * 0x10) + 0xC;
 				fn_80195674(sp88, (M2C_UNK*)(temp_r23 + (*var_r25 << 6)),
-				    fn_8019E8EC(M2C_FIELD(temp_r4, s32*, temp_r0x)));
+				    fn_8019E8EC(M2C_FIELD(temp_r4, s32*, temp_r0)));
 				fn_80195674((M2C_UNK*)(arg0 + (*var_r27 << 6)), sp88, (M2C_UNK*)var_r29);
 			}
 			return;


### PR DESCRIPTION
## What

`game/rw_gcn_raster.c` (the RenderWare GameCube raster/native-texture backend) went from **17.77% -> 28.37%** matched code and **26/47 -> 30/47** matched functions; fuzzy match rose from 82.09% to 93.54%. No other unit moved (checked with `objdiff-cli report generate` before and after).

Four functions now match exactly: `fn_80225BF0`, `fn_80225B60`, `fn_8022824C`, `fn_80227F48`.

| function | before | after |
| --- | ---: | ---: |
| fn_80226080 | 55.7% | 93.9% |
| fn_80225D48 | 61.8% | 95.1% |
| fn_802285D8 | 65.1% | 87.1% |
| fn_80225434 | 64.0% | 86.7% |
| fn_802273D0 | 66.1% | 79.7% |
| fn_80227AA8 | 70.0% | 94.1% |
| fn_80226D3C | 71.0% | 75.0% |
| fn_80227528 | 76.3% | 87.4% |
| fn_80225248 | 77.3% | 96.9% |
| fn_80227018 | 79.4% | 95.3% |
| fn_80226B2C | 89.9% | 95.7% |
| fn_8022824C | 94.1% | **100%** |
| fn_80227F48 | 95.2% | **100%** |
| fn_80225B60 | 86.6% | **100%** |
| fn_80225BF0 | 99.7% | **100%** |

## How

The unit was almost entirely raw m2c output, so the same few problems repeated across it:

- **Loop shape.** m2c writes every loop as a top-tested `if` plus a `goto`; retail tests at the bottom. Rewriting them as `for`/`while` fixed the block layout everywhere, and writing the counted ones as counting `for` loops is what puts them back on `ctr` (`bdnz`). One hand-unrolled copy in `fn_802285D8` turned out to be the compiler's own 8x unroll of a plain loop.
- **Dropped arguments.** `fn_801659DC`, `fn_802290F0` and `fn_8022A028` take three arguments; `fn_80192F38` takes the stream first; `fn_8019408C` is variadic; `fn_801979AC`'s length is a word, not a byte; `fn_8015F3FC` takes four, not five. The two RenderWare stream callbacks take the five arguments the SDK passes them, which is why the raster arrived in `r5` and not `r4`.
- **Types and widths.** Several stores were bytes where retail writes words, one indexed byte group sat eight bytes off, and a 0x40-byte tile move is a struct assignment the compiler expands inline.
- **Expression grouping.** A few size sums get reassociated when written as one expression; accumulating them term by term matches.
- **Inlining.** `fn_80226468` is called out of line in three places that sit after its definition, so those carry `#pragma dont_inline`.

Only `src/game/rw_gcn_raster.c` changes. Nothing under `tools/` or `.github/`.

## Verification

`build/tools/objdiff-cli.exe diff` per function after every step, plus a whole-project `report generate` diff to confirm no unit regressed. The local `main.elf` link still hits the known `ELF_gen.c:2336` linker alert on this machine — `main` fails the same way with byte-identical link inputs, so CI is the authority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)