### PR TITLE
match: recover the plugin-registry paths in rw_gcn_core

### DIFF
--- a/docs/decomp-work-tracking.md
+++ b/docs/decomp-work-tracking.md
@@ -8,7 +8,8 @@ This file records active ownership so parallel decompilation work does not overl
 | Codex | `game/cri/axrna.c` | Attempted; no net improvement after source-form and compiler-flag trials |
 | Codex | `game/cri/svm.c` | Attempted; BSS layout identified, but no net object improvement |
 | Codex | `game/cri/rnares.c` | Attempted; aggregate evidence retained, no text improvement without synthetic layout code |
-| Codex | `game/rw_gcn_raster.c` | Active; `fn_80227300` restored to 100%, `fn_80225BF0` improved; continuing |
+| Codex | `game/rw_gcn_raster.c` | Complete for now; PR #497 took the unit 17.8% -> 28.4% matched (30/47 functions). What is left is register allocation, not structure |
+| Claude Code | `game/rw_gcn_core.c` | Active; reserved |
 | Codex | `game/skyfs_adx.c` (`0x80013038`–`0x80014154`) | Complete; `pr-skyfs-adx` |
 | Codex | `game/Peripheral.cpp` (`0x80014154`–`0x80015AC0`) | Complete; `pr-peripheral` (stacked on `pr-skyfs-adx`) |
 | Codex | `game/main.cpp` (`0x80015AC0`–`0x80016514`) | Complete; `pr-game-main-cpp` |

--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -174,6 +174,8 @@ M2C_UNK* fn_802321EC(void)
 s32 fn_80232288(M2C_UNK* arg0)
 {
 	M2C_UNK* temp_r0;
+	u8* temp_r3_2;
+	u8* temp_r3_3;
 	M2C_UNK* var_r4;
 	M2C_UNK* var_r5;
 
@@ -205,11 +207,13 @@ s32 fn_80232288(M2C_UNK* arg0)
 			}
 		}
 	}
-	if ((u32)M2C_FIELD(arg0, u32*, 0x18) != 0U) {
-		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(), 0x138)(lbl_8042C9A4);
+	temp_r3_2 = M2C_FIELD(arg0, u8**, 0x18);
+	if (temp_r3_2 != NULL) {
+		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(u8*, M2C_UNK*), 0x138)(temp_r3_2, lbl_8042C9A4);
 	}
-	if ((u32)M2C_FIELD(arg0, u32*, 0x10) != 0U) {
-		fn_80234EA0();
+	temp_r3_3 = M2C_FIELD(arg0, u8**, 0x10);
+	if (temp_r3_3 != NULL) {
+		fn_80234EA0(temp_r3_3);
 	}
 	memset(arg0, 0, 4);
 	M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(M2C_UNK*, M2C_UNK*), 0x138)(arg0, lbl_8042C9A4);
@@ -1681,6 +1685,7 @@ M2C_UNK* fn_80234058(M2C_UNK* arg0)
 M2C_UNK* fn_80234338(void)
 {
 	M2C_UNK* temp_r3;
+	M2C_UNK* temp_r4;
 
 	temp_r3 = M2C_FIELD(lbl_8042C9A4, M2C_UNK * (**)(M2C_UNK, M2C_UNK*), 0x134)(0x1C, lbl_8042C9A4);
 	if (temp_r3 != NULL) {
@@ -1688,11 +1693,12 @@ M2C_UNK* fn_80234338(void)
 		M2C_FIELD(temp_r3, M2C_UNK**, 0) = temp_r3;
 		M2C_FIELD(temp_r3, M2C_UNK**, 4) = temp_r3;
 		M2C_FIELD(temp_r3, s32*, 8)      = 1;
-		if ((M2C_UNK*)M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64) == NULL) {
-			M2C_FIELD(temp_r3, M2C_UNK**, 0) = temp_r3;
+		temp_r4                          = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64);
+		if (temp_r4 == NULL) {
+			*temp_r3 = (M2C_UNK)temp_r3;
 		} else {
-			M2C_FIELD(temp_r3, M2C_UNK**, 0)         = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64);
-			M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64) = temp_r3;
+			*temp_r3 = *temp_r4;
+			*temp_r4 = (M2C_UNK)temp_r3;
 		}
 		M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64) = temp_r3;
 	}

--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -5,124 +5,124 @@ typedef s32 M2C_UNK;
 #define M2C_BITWISE(type, value)      (*(type*)&(value))
 #define M2C_ERROR(...)                0
 
-s32 RwEngineRegisterPlugin(M2C_UNK, M2C_UNK, void (*)(), s32 (*)(s32, M2C_UNK)); /* extern */
-void fn_8014F1B0();                                                              /* extern */
-M2C_UNK fn_8014F854();                                                           /* extern */
-u8* fn_80150140();                                                               /* extern */
-M2C_UNK fn_8015028C();                                                           /* extern */
-M2C_UNK fn_80150358();                                                           /* extern */
-s32 fn_801520D0();                                                               /* extern */
-s32 fn_80152150();                                                               /* extern */
-M2C_UNK fn_80152220();                                                           /* extern */
-s32 fn_80152288();                                                               /* extern */
-M2C_UNK fn_80152EEC();                                                           /* extern */
-M2C_UNK fn_8015498C();                                                           /* extern */
-u32 fn_80192ED8();                                                               /* extern */
-s32 fn_80192F38();                                                               /* extern */
-M2C_UNK fn_8019336C();                                                           /* extern */
-M2C_UNK fn_80193474();                                                           /* extern */
-M2C_UNK fn_801937A0();                                                           /* extern */
-M2C_UNK fn_80193884();                                                           /* extern */
-s32 fn_80193B58();                                                               /* extern */
-M2C_UNK fn_80193B60();                                                           /* extern */
-M2C_UNK fn_80193DA4();                                                           /* extern */
-M2C_UNK fn_80195674();                                                           /* extern */
-M2C_UNK fn_801979AC();                                                           /* extern */
-M2C_UNK fn_80197B48();                                                           /* extern */
-M2C_UNK fn_801990E0();                                                           /* extern */
-f32 fn_801991F4();                                                               /* extern */
-M2C_UNK fn_8019941C();                                                           /* extern */
-M2C_UNK fn_8019947C();                                                           /* extern */
-s32 fn_8019AA5C();                                                               /* extern */
-M2C_UNK fn_8019AAFC();                                                           /* extern */
-s32 fn_8019ADB4();                                                               /* extern */
-u8* fn_8019E344();                                                               /* extern */
-M2C_UNK fn_8019E480();                                                           /* extern */
-s32 fn_8019E8EC();                                                               /* extern */
-M2C_UNK fn_801A491C();                                                           /* extern */
-u8* fn_801FCEA0();                                                               /* extern */
-s32* fn_801FD214();                                                              /* extern */
-s32 fn_801FD224();                                                               /* extern */
-M2C_UNK fn_801FD3B4();                                                           /* extern */
-M2C_UNK memcpy();                                                                /* extern */
-M2C_UNK memset(M2C_UNK*, M2C_UNK, s32);                                          /* extern */
-M2C_UNK* fn_802321EC();                                                          /* static */
-s32 fn_80232288();                                                               /* static */
-u8* fn_8023239C();                                                               /* static */
-u8* fn_802324E0();                                                               /* static */
-M2C_UNK* fn_80232604();                                                          /* static */
-M2C_UNK* fn_80232648();                                                          /* static */
-u8* fn_8023268C();                                                               /* static */
-M2C_UNK* fn_8023271C();                                                          /* static */
-s32 fn_80232960();                                                               /* static */
-u8* fn_80232968();                                                               /* static */
-s32 fn_80232A9C();                                                               /* static */
-u8* fn_80232BAC();                                                               /* static */
-M2C_UNK* fn_80232E34();                                                          /* static */
-u8* fn_80232E58();                                                               /* static */
-M2C_UNK* fn_80232F98();                                                          /* static */
-u8* fn_8023312C();                                                               /* static */
-M2C_UNK* fn_802332AC();                                                          /* static */
-M2C_UNK* fn_80233714();                                                          /* static */
-u8* fn_802338B8();                                                               /* static */
-u8* fn_80233DF8();                                                               /* static */
-M2C_UNK* fn_80233F50();                                                          /* static */
-M2C_UNK* fn_80234058();                                                          /* static */
-M2C_UNK* fn_80234338();                                                          /* static */
-s32 fn_802343C4();                                                               /* static */
-u8* fn_802344D8();                                                               /* static */
-u8* fn_802345C8();                                                               /* static */
-M2C_UNK* fn_802346EC();                                                          /* static */
-M2C_UNK* fn_80234730();                                                          /* static */
-u8* fn_80234774();                                                               /* static */
-M2C_UNK* fn_80234804();                                                          /* static */
-s32 fn_80234A30();                                                               /* static */
-s32 fn_80234A38();                                                               /* static */
-s32 fn_80234EA0();                                                               /* static */
-s32 fn_8023501C();                                                               /* static */
-s32 fn_8023506C();                                                               /* static */
-u8* fn_802350D4();                                                               /* static */
-u8* fn_80235118();                                                               /* static */
-u8* fn_8023521C();                                                               /* static */
-u8* fn_802354D4();                                                               /* static */
-s32 fn_80235590();                                                               /* static */
-void fn_802355D4();                                                              /* static */
-u8* fn_80235614();                                                               /* static */
-void fn_802356AC();                                                              /* static */
-u8* fn_802356F0();                                                               /* static */
-u8* fn_802357A8();                                                               /* static */
-u8* fn_8023582C();                                                               /* static */
-s32 fn_802358B0();                                                               /* static */
-M2C_UNK* fn_802358B8();                                                          /* static */
-M2C_UNK* fn_80235CEC();                                                          /* static */
-u8* fn_80235E64();                                                               /* static */
-u8* fn_80236AE4();                                                               /* static */
-u8* fn_80237EBC();                                                               /* static */
-u8* fn_80237F90();                                                               /* static */
-u8* fn_80237FF4();                                                               /* static */
-s32 fn_80238228();                                                               /* static */
-s32 fn_80238328();                                                               /* static */
-u8* fn_802383C0();                                                               /* static */
-u8* fn_80238444();                                                               /* static */
-u8* fn_802388D4();                                                               /* static */
-u8* fn_80238D3C();                                                               /* static */
-u8* fn_80238E6C();                                                               /* static */
-s32 fn_80238F88();                                                               /* static */
-void fn_80238FEC();                                                              /* static */
-s32 fn_80238FF0();                                                               /* static */
-void fn_8023914C();                                                              /* static */
-void fn_80239178();                                                              /* static */
-s32 fn_80239184();                                                               /* static */
-s32 fn_802391FC();                                                               /* static */
-s32 fn_8023927C();                                                               /* static */
-s32 fn_80239290();                                                               /* static */
-s32* fn_802392DC();                                                              /* static */
-s32* fn_802393A0();                                                              /* static */
-s32 fn_8023943C();                                                               /* static */
-M2C_UNK* (*fn_80239690())();                                                     /* static */
-u8* fn_80239738();                                                               /* static */
-s32 fn_80239888();                                                               /* static */
-s32 fn_8023989C();                                                               /* static */
+s32 RwEngineRegisterPlugin(M2C_UNK, M2C_UNK, void (*)(), s32 (*)(s32)); /* extern */
+void fn_8014F1B0();                                                     /* extern */
+M2C_UNK fn_8014F854();                                                  /* extern */
+u8* fn_80150140();                                                      /* extern */
+M2C_UNK fn_8015028C();                                                  /* extern */
+M2C_UNK fn_80150358();                                                  /* extern */
+s32 fn_801520D0();                                                      /* extern */
+s32 fn_80152150();                                                      /* extern */
+M2C_UNK fn_80152220();                                                  /* extern */
+s32 fn_80152288();                                                      /* extern */
+M2C_UNK fn_80152EEC();                                                  /* extern */
+M2C_UNK fn_8015498C();                                                  /* extern */
+u32 fn_80192ED8();                                                      /* extern */
+s32 fn_80192F38();                                                      /* extern */
+M2C_UNK fn_8019336C();                                                  /* extern */
+M2C_UNK fn_80193474();                                                  /* extern */
+M2C_UNK fn_801937A0();                                                  /* extern */
+M2C_UNK fn_80193884();                                                  /* extern */
+s32 fn_80193B58();                                                      /* extern */
+M2C_UNK fn_80193B60();                                                  /* extern */
+M2C_UNK fn_80193DA4();                                                  /* extern */
+M2C_UNK fn_80195674();                                                  /* extern */
+M2C_UNK fn_801979AC();                                                  /* extern */
+M2C_UNK fn_80197B48();                                                  /* extern */
+M2C_UNK fn_801990E0();                                                  /* extern */
+f32 fn_801991F4();                                                      /* extern */
+M2C_UNK fn_8019941C();                                                  /* extern */
+M2C_UNK fn_8019947C();                                                  /* extern */
+s32 fn_8019AA5C();                                                      /* extern */
+M2C_UNK fn_8019AAFC();                                                  /* extern */
+s32 fn_8019ADB4();                                                      /* extern */
+u8* fn_8019E344();                                                      /* extern */
+M2C_UNK fn_8019E480();                                                  /* extern */
+s32 fn_8019E8EC();                                                      /* extern */
+M2C_UNK fn_801A491C();                                                  /* extern */
+u8* fn_801FCEA0();                                                      /* extern */
+s32* fn_801FD214();                                                     /* extern */
+s32 fn_801FD224();                                                      /* extern */
+M2C_UNK fn_801FD3B4();                                                  /* extern */
+M2C_UNK memcpy();                                                       /* extern */
+M2C_UNK memset(M2C_UNK*, M2C_UNK, s32);                                 /* extern */
+M2C_UNK* fn_802321EC();                                                 /* static */
+s32 fn_80232288();                                                      /* static */
+u8* fn_8023239C();                                                      /* static */
+u8* fn_802324E0();                                                      /* static */
+M2C_UNK* fn_80232604();                                                 /* static */
+M2C_UNK* fn_80232648();                                                 /* static */
+u8* fn_8023268C();                                                      /* static */
+M2C_UNK* fn_8023271C();                                                 /* static */
+s32 fn_80232960();                                                      /* static */
+u8* fn_80232968();                                                      /* static */
+s32 fn_80232A9C();                                                      /* static */
+u8* fn_80232BAC();                                                      /* static */
+M2C_UNK* fn_80232E34();                                                 /* static */
+u8* fn_80232E58();                                                      /* static */
+M2C_UNK* fn_80232F98();                                                 /* static */
+u8* fn_8023312C();                                                      /* static */
+M2C_UNK* fn_802332AC();                                                 /* static */
+M2C_UNK* fn_80233714();                                                 /* static */
+u8* fn_802338B8();                                                      /* static */
+u8* fn_80233DF8();                                                      /* static */
+M2C_UNK* fn_80233F50();                                                 /* static */
+M2C_UNK* fn_80234058();                                                 /* static */
+M2C_UNK* fn_80234338();                                                 /* static */
+s32 fn_802343C4();                                                      /* static */
+u8* fn_802344D8();                                                      /* static */
+u8* fn_802345C8();                                                      /* static */
+M2C_UNK* fn_802346EC();                                                 /* static */
+M2C_UNK* fn_80234730();                                                 /* static */
+u8* fn_80234774();                                                      /* static */
+M2C_UNK* fn_80234804();                                                 /* static */
+s32 fn_80234A30();                                                      /* static */
+s32 fn_80234A38();                                                      /* static */
+s32 fn_80234EA0();                                                      /* static */
+s32 fn_8023501C();                                                      /* static */
+s32 fn_8023506C();                                                      /* static */
+u8* fn_802350D4();                                                      /* static */
+u8* fn_80235118();                                                      /* static */
+u8* fn_8023521C();                                                      /* static */
+u8* fn_802354D4();                                                      /* static */
+s32 fn_80235590();                                                      /* static */
+void fn_802355D4();                                                     /* static */
+u8* fn_80235614();                                                      /* static */
+void fn_802356AC();                                                     /* static */
+u8* fn_802356F0();                                                      /* static */
+u8* fn_802357A8();                                                      /* static */
+u8* fn_8023582C();                                                      /* static */
+s32 fn_802358B0();                                                      /* static */
+M2C_UNK* fn_802358B8();                                                 /* static */
+M2C_UNK* fn_80235CEC();                                                 /* static */
+u8* fn_80235E64();                                                      /* static */
+u8* fn_80236AE4();                                                      /* static */
+u8* fn_80237EBC();                                                      /* static */
+u8* fn_80237F90();                                                      /* static */
+u8* fn_80237FF4();                                                      /* static */
+s32 fn_80238228();                                                      /* static */
+s32 fn_80238328();                                                      /* static */
+u8* fn_802383C0();                                                      /* static */
+u8* fn_80238444();                                                      /* static */
+u8* fn_802388D4();                                                      /* static */
+u8* fn_80238D3C();                                                      /* static */
+u8* fn_80238E6C();                                                      /* static */
+s32 fn_80238F88();                                                      /* static */
+void fn_80238FEC();                                                     /* static */
+s32 fn_80238FF0();                                                      /* static */
+void fn_8023914C();                                                     /* static */
+void fn_80239178();                                                     /* static */
+s32 fn_80239184();                                                      /* static */
+s32 fn_802391FC();                                                      /* static */
+s32 fn_8023927C();                                                      /* static */
+s32 fn_80239290();                                                      /* static */
+s32* fn_802392DC();                                                     /* static */
+s32* fn_802393A0();                                                     /* static */
+s32 fn_8023943C();                                                      /* static */
+M2C_UNK* (*fn_80239690())();                                            /* static */
+u8* fn_80239738();                                                      /* static */
+s32 fn_80239888();                                                      /* static */
+s32 fn_8023989C();                                                      /* static */
 extern M2C_UNK* lbl_8042C9A4;
 extern s32 lbl_8042CF48;
 extern f32 lbl_80430248;
@@ -571,7 +571,7 @@ u8* fn_80232968(u8* arg0)
 }
 
 #pragma dont_inline on
-s32 fn_80232A9C(u8* arg0, M2C_UNK arg_sp0)
+s32 fn_80232A9C(u8* arg0)
 {
 	M2C_UNK* temp_r31;
 	s32 temp_r3;
@@ -622,7 +622,7 @@ loop_5:
 #pragma dont_inline reset
 
 #pragma dont_inline on
-u8* fn_80232BAC(M2C_UNK* arg0, M2C_UNK arg_sp0)
+u8* fn_80232BAC(M2C_UNK* arg0)
 {
 	M2C_UNK* temp_r28_2;
 	s32 temp_r3;
@@ -756,7 +756,7 @@ M2C_UNK* fn_80232E34(M2C_UNK* arg0, M2C_UNK* arg1)
 	return arg1;
 }
 
-u8* fn_80232E58(u8* arg0, M2C_UNK arg_sp0)
+u8* fn_80232E58(u8* arg0)
 {
 	s32 spC;
 	u8** sp8;
@@ -829,7 +829,7 @@ block_16:
 	goto loop_1;
 }
 
-M2C_UNK* fn_80232F98(u8* arg0, M2C_UNK arg_sp0)
+M2C_UNK* fn_80232F98(u8* arg0)
 {
 	M2C_UNK** temp_r3;
 	M2C_UNK* temp_r3_2;
@@ -914,7 +914,7 @@ M2C_UNK* fn_80232F98(u8* arg0, M2C_UNK arg_sp0)
 	return var_r28;
 }
 
-u8* fn_8023312C(u8* arg0, M2C_UNK* arg1, s32 arg2, M2C_UNK arg_sp0)
+u8* fn_8023312C(u8* arg0, M2C_UNK* arg1, s32 arg2)
 {
 	s32 spC;
 	u8** sp8;
@@ -1004,7 +1004,7 @@ void fn_80233298(u8* arg0, s32* arg1, s32* arg2)
 	*arg2 = M2C_FIELD(arg0, s32*, 0x14);
 }
 
-M2C_UNK* fn_802332AC(u8* arg0, M2C_UNK* arg1, s32 arg2, M2C_UNK arg_sp0)
+M2C_UNK* fn_802332AC(u8* arg0, M2C_UNK* arg1, s32 arg2)
 {
 	M2C_UNK* temp_r27;
 	M2C_UNK* temp_r28;
@@ -1226,7 +1226,7 @@ block_72:
 	return arg1;
 }
 
-M2C_UNK* fn_80233714(s32 arg0, M2C_UNK* arg1, s32* arg2, M2C_UNK arg_sp0)
+M2C_UNK* fn_80233714(s32 arg0, M2C_UNK* arg1, s32* arg2)
 {
 	M2C_UNK** temp_r3;
 	M2C_UNK* temp_r23;
@@ -1312,7 +1312,7 @@ block_25:
 }
 
 #pragma dont_inline on
-u8* fn_802338B8(u8* arg0, s32* arg1, M2C_UNK arg_sp0)
+u8* fn_802338B8(u8* arg0, s32* arg1)
 {
 	s32 sp20;
 	u8** sp1C;
@@ -1545,7 +1545,7 @@ loop_58:
 #pragma dont_inline reset
 
 #pragma dont_inline on
-u8* fn_80233DF8(s32 arg0, u8* arg1, s32* arg2, M2C_UNK arg_sp0)
+u8* fn_80233DF8(s32 arg0, u8* arg1, s32* arg2)
 {
 	s32 spC;
 	s32 sp8;
@@ -1590,7 +1590,7 @@ loop_8:
 #pragma dont_inline reset
 
 #pragma dont_inline on
-M2C_UNK* fn_80233F50(s32 arg0, M2C_UNK* arg1, s32* arg2, M2C_UNK arg_sp0)
+M2C_UNK* fn_80233F50(s32 arg0, M2C_UNK* arg1, s32* arg2)
 {
 	s32 sp8;
 	s32 temp_r29;
@@ -1763,7 +1763,7 @@ s32 fn_802343C4(M2C_UNK* arg0)
 	return 1;
 }
 
-u8* fn_802344D8(u8* arg0, s32 arg1, u8* arg2, M2C_UNK arg_sp0)
+u8* fn_802344D8(u8* arg0, s32 arg1, u8* arg2)
 {
 	s32 temp_r0;
 	s32 var_ctr;
@@ -1947,7 +1947,7 @@ M2C_UNK* fn_80234804(s32* arg0)
 	u8* temp_r31;
 	u8* temp_r8;
 
-	fn_80193884(&sp8, (s32*)4U);
+	fn_80193884(arg0, &sp8, 4);
 	fn_80193884(arg0, &spC, 4);
 	var_r4 = NULL;
 	var_r5 = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64);
@@ -2041,7 +2041,7 @@ s32 fn_80234A30(void)
 	return 8;
 }
 
-s32 fn_80234A38(s32 arg0, s32* arg1, s32* arg2, M2C_UNK arg_sp0)
+s32 fn_80234A38(s32 arg0, s32* arg1, s32* arg2)
 {
 	s32* var_r26;
 	s32* var_r31;
@@ -2416,7 +2416,7 @@ u8* fn_802350D4(s32 arg0)
 	return var_r6;
 }
 
-u8* fn_80235118(s32 arg0, s32* arg1, s32* arg2, s32 arg_sp0)
+u8* fn_80235118(s32 arg0, s32* arg1, s32* arg2)
 {
 	s32* var_r12;
 	s32* var_r31;
@@ -2486,7 +2486,7 @@ u8* fn_80235118(s32 arg0, s32* arg1, s32* arg2, s32 arg_sp0)
 	return var_r27;
 }
 
-u8* fn_8023521C(s32* arg0, M2C_UNK arg_sp0)
+u8* fn_8023521C(s32* arg0)
 {
 	s32 spC;
 	s32 sp8;
@@ -2596,7 +2596,7 @@ block_8:
 	}
 	var_r29 = var_r6;
 	if (var_r6 == NULL) {
-		var_r29 = (u8*)fn_80234A38(sp8, var_r31, var_r30, 0);
+		var_r29 = (u8*)fn_80234A38(sp8, var_r31, var_r30);
 	} else {
 		M2C_FIELD(var_r6, s32*, 0xC) = (s32)(M2C_FIELD(var_r6, s32*, 0xC) + 1);
 	}
@@ -2732,7 +2732,7 @@ void fn_802356AC(u8* arg0, u8* arg1)
 	M2C_FIELD(arg0, s32*, 0x30) = (s32)M2C_FIELD(arg1, s32*, 0x30);
 }
 
-u8* fn_802356F0(u8* arg0, M2C_UNK arg_sp0)
+u8* fn_802356F0(u8* arg0)
 {
 	s32 spC;
 	s32 sp8;
@@ -2788,7 +2788,7 @@ s32 fn_802358B0(void)
 }
 
 #pragma dont_inline on
-M2C_UNK* fn_802358B8(M2C_UNK* arg0, M2C_UNK arg_sp0)
+M2C_UNK* fn_802358B8(M2C_UNK* arg0)
 {
 	f32 sp1C;
 	f32 sp18;
@@ -2951,6 +2951,7 @@ M2C_UNK* fn_802358B8(M2C_UNK* arg0, M2C_UNK arg_sp0)
 #pragma dont_inline on
 M2C_UNK* fn_80235CEC(M2C_UNK* arg0, u8* arg1)
 {
+	s32 temp_r0_2;
 	s32* temp_r3;
 	s32* temp_r3_3;
 	u32 temp_r3_4;
@@ -2980,9 +2981,10 @@ M2C_UNK* fn_80235CEC(M2C_UNK* arg0, u8* arg1)
 	M2C_FIELD(temp_r31, s32*, 0x20) = 0;
 	M2C_FIELD(temp_r31, s32*, 0x24) = 0;
 	if ((u8*)M2C_FIELD(temp_r31, u8**, 0x18) != NULL) {
-		temp_r3_3 = fn_801FD214();
+		temp_r3_3 = fn_801FD214(M2C_FIELD(temp_r31, u8**, 0x18));
+		temp_r0_2 = *temp_r3_3 * 3;
 		M2C_FIELD(temp_r31, u32*, 0x1C)
-		    = M2C_FIELD(lbl_8042C9A4, u32(**)(s32), 0x134)(*temp_r3_3 * 0xC);
+		    = M2C_FIELD(lbl_8042C9A4, u32(**)(s32), 0x134)(temp_r0_2 * 4);
 		temp_r3_4 = M2C_FIELD(temp_r31, u32*, 0x1C);
 		if (temp_r3_4 == 0U) {
 			var_r0 = NULL;
@@ -3729,7 +3731,7 @@ u8* fn_80236AE4(u8* arg1)
 			}
 		}
 		if ((sp7C > 0) && (sp74 == NULL)) {
-			temp_r3_2 = fn_80232F98(sp8, 0);
+			temp_r3_2 = fn_80232F98(sp8);
 			sp74      = temp_r3_2;
 			if (temp_r3_2 != NULL) {
 				M2C_FIELD(temp_r3_2, s32*, 0x10) = 0;
@@ -4368,7 +4370,7 @@ s32 fn_80238328(s32 arg1)
 }
 
 #pragma dont_inline on
-u8* fn_802383C0(u8* arg1)
+u8* fn_802383C0(s32 arg0, u8* arg1)
 {
 	s32 temp_r3;
 	u8* temp_r3_2;
@@ -4682,7 +4684,7 @@ u8* fn_80238E6C(u8* arg0)
 	u8* (*sp20)(u8*);
 	u8* (*sp1C)(u8*);
 	s32 sp18;
-	u8* (*sp14)(u8*);
+	u8* (*sp14)(s32, u8*);
 	s32 (*sp10)(s32);
 	s32 (*spC)(u8*, u8*, f32*);
 	u8* (*sp8)(u8*);
@@ -4741,7 +4743,7 @@ s32 fn_80238F88(s32 arg0)
 	sp1C = 0;
 	sp20 = 0;
 	sp8  = fn_80235E64;
-	fn_802344D8((u8*)1, (s32)&sp8, NULL, 0);
+	fn_802344D8((u8*)1, (s32)&sp8, NULL);
 	return arg0;
 }
 #pragma dont_inline reset
@@ -4749,7 +4751,7 @@ s32 fn_80238F88(s32 arg0)
 void fn_80238FEC(void) { }
 
 #pragma dont_inline on
-s32 fn_80238FF0(s32 arg0, M2C_UNK arg_sp0)
+s32 fn_80238FF0(s32 arg0)
 {
 	M2C_UNK* var_r27;
 	M2C_UNK* var_r28;
@@ -4833,7 +4835,7 @@ s32 fn_80239184(s32 arg0, s32 arg1)
 		var_r3   = temp_r31;
 		do {
 			temp_r30 = (M2C_UNK*)*var_r3;
-			fn_80232A9C((u8*)var_r3, 0);
+			fn_80232A9C((u8*)var_r3);
 			var_r3 = temp_r30;
 		} while (temp_r30 != temp_r31);
 	}
@@ -4842,7 +4844,7 @@ s32 fn_80239184(s32 arg0, s32 arg1)
 }
 
 #pragma dont_inline on
-s32 fn_802391FC(s32 arg0, s32 arg1, s32 arg2, M2C_UNK arg_sp0)
+s32 fn_802391FC(s32 arg0, s32 arg1, s32 arg2)
 {
 	M2C_UNK** temp_r3;
 	M2C_UNK* temp_r31;
@@ -4856,7 +4858,7 @@ s32 fn_802391FC(s32 arg0, s32 arg1, s32 arg2, M2C_UNK arg_sp0)
 		temp_r31 = *temp_r3;
 		var_r30  = temp_r31;
 		do {
-			temp_r3_2 = fn_80232BAC(var_r30, 0);
+			temp_r3_2 = fn_80232BAC(var_r30);
 			if (temp_r3_2 != NULL) {
 				M2C_FIELD(temp_r3_2, s32*, 8) = arg0;
 				var_r29                       = fn_80232E34(var_r29, (M2C_UNK*)temp_r3_2);
@@ -4887,23 +4889,19 @@ s32 fn_80239290(s32 arg0, s32 arg1)
 	return sp8;
 }
 
-s32* fn_802392DC(s32* arg0, u8* arg2)
+s32* fn_802392DC(s32* arg0, s32 arg1, u8* arg2)
 {
 	s32 sp8;
 	s32 temp_r0;
 	s32 var_r30;
 
-	fn_80193884(&sp8, (s32*)4U);
+	fn_80193884(arg0, &sp8, 4);
 	temp_r0                            = sp8 & 0xFFFFFF;
 	M2C_FIELD(lbl_8042AC68, u32*, 0xC) = (u32)((u32)sp8 >> 0x18U);
 	sp8                                = temp_r0;
 	if (temp_r0 > 0) {
-		var_r30 = 0;
-	loop_3:
-		if (var_r30 < sp8) {
-			fn_802338B8(arg2, arg0, 0);
-			var_r30 += 1;
-			goto loop_3;
+		for (var_r30 = 0; var_r30 < sp8; var_r30 += 1) {
+			fn_802338B8(arg2, arg0);
 		}
 		M2C_FIELD(arg2, void (**)(s32), 0x48) = fn_8023914C;
 		if (((void (*)())M2C_FIELD(arg2, void (**)(), 0x48)) == NULL) {
@@ -4914,7 +4912,7 @@ s32* fn_802392DC(s32* arg0, u8* arg2)
 	return arg0;
 }
 
-s32* fn_802393A0(s32* arg0, M2C_UNK* (*arg2)(s32, M2C_UNK*, s32*, M2C_UNK), s32 arg3)
+s32* fn_802393A0(s32* arg0, s32 arg1, M2C_UNK* (*arg2)(s32, M2C_UNK*, s32*, M2C_UNK), s32 arg3)
 {
 	s32 sp8;
 
@@ -4924,9 +4922,11 @@ s32* fn_802393A0(s32* arg0, M2C_UNK* (*arg2)(s32, M2C_UNK*, s32*, M2C_UNK), s32 
 		sp8 |= 0x03000000;
 		fn_80193474(arg0, &sp8, 4);
 		fn_80239690(arg2, (s32*)fn_80233DF8, arg0);
-		return arg0;
+		goto block_ok;
 	}
 	return NULL;
+block_ok:
+	return arg0;
 }
 
 s32 fn_8023943C(void)
@@ -4992,10 +4992,10 @@ u8* fn_802395BC(void)
 				fn_80152EEC(temp_r3_2);
 			} else {
 				fn_80152EEC(temp_r3_2);
-				fn_80232A9C(temp_r3, 0);
+				fn_80232A9C(temp_r3);
 			}
 		} else {
-			fn_80232A9C(temp_r3, 0);
+			fn_80232A9C(temp_r3);
 		}
 	}
 	return var_r29;
@@ -5044,7 +5044,7 @@ u8* fn_80239738(u8* arg0, u8* arg1)
 }
 #pragma dont_inline reset
 
-u8* fn_80239798(u8* arg0, s32 arg1, M2C_UNK arg_sp0)
+u8* fn_80239798(u8* arg0, s32 arg1)
 {
 	M2C_UNK** temp_r3;
 	M2C_UNK* temp_r29;
@@ -5066,7 +5066,7 @@ u8* fn_80239798(u8* arg0, s32 arg1, M2C_UNK arg_sp0)
 			var_r28  = temp_r29;
 		loop_5:
 			temp_r30 = (M2C_UNK*)*var_r28;
-			if (fn_802332AC(arg0, var_r28, arg1, 0) != var_r28) {
+			if (fn_802332AC(arg0, var_r28, arg1) != var_r28) {
 				var_r0 = NULL;
 			} else {
 				var_r28 = temp_r30;

--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -343,17 +343,19 @@ void fn_802325F8(u8* arg0, s32* arg1)
 M2C_UNK* fn_80232604(s32 arg0)
 {
 	M2C_UNK* var_r4;
+	M2C_UNK* var_r5;
 	M2C_UNK* var_r6;
 
 	var_r6 = NULL;
-	var_r4 = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60);
-	if ((M2C_UNK*)M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60) != NULL) {
+	var_r5 = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60);
+	var_r4 = var_r5;
+	if (var_r5 != NULL) {
 	loop_1:
 		if ((s32)M2C_FIELD(var_r4, s32*, 4) == arg0) {
 			var_r6 = var_r4;
 		} else {
 			var_r4 = M2C_FIELD(var_r4, M2C_UNK**, 0);
-			if (var_r4 != (M2C_UNK*)M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60)) {
+			if (var_r4 != var_r5) {
 				goto loop_1;
 			}
 		}
@@ -364,17 +366,19 @@ M2C_UNK* fn_80232604(s32 arg0)
 M2C_UNK* fn_80232648(u8* arg0)
 {
 	M2C_UNK* var_r4;
+	M2C_UNK* var_r5;
 	M2C_UNK* var_r6;
 
 	var_r6 = NULL;
-	var_r4 = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60);
-	if ((M2C_UNK*)M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60) != NULL) {
+	var_r5 = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60);
+	var_r4 = var_r5;
+	if (var_r5 != NULL) {
 	loop_1:
 		if ((u32)M2C_FIELD(var_r4, u32*, 0x10) == (u32)arg0) {
 			var_r6 = var_r4;
 		} else {
 			var_r4 = M2C_FIELD(var_r4, M2C_UNK**, 0);
-			if (var_r4 != (M2C_UNK*)M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60)) {
+			if (var_r4 != var_r5) {
 				goto loop_1;
 			}
 		}
@@ -1851,17 +1855,19 @@ void fn_802346E0(u8* arg0, s32* arg1)
 M2C_UNK* fn_802346EC(s32 arg0)
 {
 	M2C_UNK* var_r4;
+	M2C_UNK* var_r5;
 	M2C_UNK* var_r6;
 
 	var_r6 = NULL;
-	var_r4 = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64);
-	if ((M2C_UNK*)M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64) != NULL) {
+	var_r5 = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64);
+	var_r4 = var_r5;
+	if (var_r5 != NULL) {
 	loop_1:
 		if ((s32)M2C_FIELD(var_r4, s32*, 4) == arg0) {
 			var_r6 = var_r4;
 		} else {
 			var_r4 = M2C_FIELD(var_r4, M2C_UNK**, 0);
-			if (var_r4 != (M2C_UNK*)M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64)) {
+			if (var_r4 != var_r5) {
 				goto loop_1;
 			}
 		}
@@ -1872,17 +1878,19 @@ M2C_UNK* fn_802346EC(s32 arg0)
 M2C_UNK* fn_80234730(u8* arg0)
 {
 	M2C_UNK* var_r4;
+	M2C_UNK* var_r5;
 	M2C_UNK* var_r6;
 
 	var_r6 = NULL;
-	var_r4 = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64);
-	if ((M2C_UNK*)M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64) != NULL) {
+	var_r5 = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64);
+	var_r4 = var_r5;
+	if (var_r5 != NULL) {
 	loop_1:
 		if ((u32)M2C_FIELD(var_r4, u32*, 0x10) == (u32)arg0) {
 			var_r6 = var_r4;
 		} else {
 			var_r4 = M2C_FIELD(var_r4, M2C_UNK**, 0);
-			if (var_r4 != (M2C_UNK*)M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64)) {
+			if (var_r4 != var_r5) {
 				goto loop_1;
 			}
 		}
@@ -2369,17 +2377,19 @@ loop_4:
 u8* fn_802350D4(s32 arg0)
 {
 	u8* var_r4;
+	u8* var_r5;
 	u8* var_r6;
 
 	var_r6 = NULL;
-	var_r4 = M2C_FIELD(lbl_8042AC68, u8**, 0x68);
-	if ((u8*)M2C_FIELD(lbl_8042AC68, u8**, 0x68) != NULL) {
+	var_r5 = M2C_FIELD(lbl_8042AC68, u8**, 0x68);
+	var_r4 = var_r5;
+	if (var_r5 != NULL) {
 	loop_1:
 		if ((s32)M2C_FIELD(var_r4, s32*, 8) == arg0) {
 			var_r6 = var_r4;
 		} else {
 			var_r4 = M2C_FIELD(var_r4, u8**, 4);
-			if (var_r4 != (u8*)M2C_FIELD(lbl_8042AC68, u8**, 0x68)) {
+			if (var_r4 != var_r5) {
 				goto loop_1;
 			}
 		}

--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -395,7 +395,7 @@ M2C_UNK* fn_80232648(u8* arg0)
 
 u8* fn_8023268C(u8* arg0, s32* arg1)
 {
-	if (fn_80192ED8(arg1, 0x25, fn_80232960(), 0x35000, 0xFFFF) == 0U) {
+	if (fn_80192ED8(arg1, 0x25, fn_80232960(arg0), 0x35000, 0xFFFF) == 0U) {
 		return NULL;
 	}
 	fn_80193474(arg1, arg0 + 4, 4);
@@ -514,7 +514,7 @@ M2C_UNK* fn_8023271C(s32* arg0)
 	return var_r30;
 }
 
-s32 fn_80232960(void)
+s32 fn_80232960(u8* arg0)
 {
 	return 8;
 }
@@ -570,6 +570,7 @@ u8* fn_80232968(u8* arg0)
 	return var_r28;
 }
 
+#pragma dont_inline on
 s32 fn_80232A9C(u8* arg0, M2C_UNK arg_sp0)
 {
 	M2C_UNK* temp_r31;
@@ -618,7 +619,9 @@ loop_5:
 	}
 	return var_r28;
 }
+#pragma dont_inline reset
 
+#pragma dont_inline on
 u8* fn_80232BAC(M2C_UNK* arg0, M2C_UNK arg_sp0)
 {
 	M2C_UNK* temp_r28_2;
@@ -740,6 +743,7 @@ u8* fn_80232BAC(M2C_UNK* arg0, M2C_UNK arg_sp0)
 	}
 	return var_r26;
 }
+#pragma dont_inline reset
 
 M2C_UNK* fn_80232E34(M2C_UNK* arg0, M2C_UNK* arg1)
 {
@@ -1307,6 +1311,7 @@ block_25:
 	return arg1;
 }
 
+#pragma dont_inline on
 u8* fn_802338B8(u8* arg0, s32* arg1, M2C_UNK arg_sp0)
 {
 	s32 sp20;
@@ -1537,7 +1542,9 @@ loop_58:
 	var_r19_5 += 1;
 	goto loop_58;
 }
+#pragma dont_inline reset
 
+#pragma dont_inline on
 u8* fn_80233DF8(s32 arg0, u8* arg1, s32* arg2, M2C_UNK arg_sp0)
 {
 	s32 spC;
@@ -1580,7 +1587,9 @@ loop_8:
 	var_r30 += 1;
 	goto loop_8;
 }
+#pragma dont_inline reset
 
+#pragma dont_inline on
 M2C_UNK* fn_80233F50(s32 arg0, M2C_UNK* arg1, s32* arg2, M2C_UNK arg_sp0)
 {
 	s32 sp8;
@@ -1598,32 +1607,30 @@ M2C_UNK* fn_80233F50(s32 arg0, M2C_UNK* arg1, s32* arg2, M2C_UNK arg_sp0)
 	temp_r30 = M2C_FIELD(arg1, u8**, 0x18);
 	var_r29  = 0x14;
 	if ((s32)M2C_FIELD(lbl_8042AC68, s32*, 0x7C) == 1) {
-		temp_r29   = fn_80235590(M2C_FIELD(temp_r30, u8**, 0x10)) + 0x14 + 0xC;
-		temp_r29_2 = temp_r29 + fn_80235590(M2C_FIELD(temp_r28, u8**, 0x10)) + 0xC;
-		temp_r29_3 = temp_r29_2 + fn_80234A30(temp_r30) + 0xC;
-		var_r29    = temp_r29_3 + fn_80232960() + 0xC;
+		var_r29 = fn_80235590(M2C_FIELD(temp_r30, u8**, 0x10)) + 0x14;
+		var_r29 += 0xC;
+		var_r29 += fn_80235590(M2C_FIELD(temp_r28, u8**, 0x10));
+		var_r29 += 0xC;
+		var_r29 += fn_80234A30(temp_r30);
+		var_r29 += 0xC;
+		var_r29 += fn_80232960(temp_r28);
+		var_r29 += 0xC;
 	}
-	var_r30 = 0;
-	var_r31 = 0;
-loop_8:
-	if (var_r30 >= (s32)M2C_FIELD(temp_r28, s32*, 0x14)) {
-		*arg2 += var_r29;
-		return arg1;
-	}
-	temp_r12 = (u32 (*)(s32, M2C_UNK*, s32*))
-	    * (u32*)((u8*)M2C_FIELD(temp_r28, u8**, 0x18) + var_r31 + 0x24);
-	if (temp_r12 != NULL) {
-		if ((M2C_UNK*)temp_r12(arg0, arg1, &sp8) != arg1) {
-			return NULL;
+	for (var_r30 = 0, var_r31 = 0; var_r30 < (s32)M2C_FIELD(temp_r28, s32*, 0x14);
+	    var_r31 += 0x2C, var_r30 += 1) {
+		temp_r12 = (u32 (*)(s32, M2C_UNK*, s32*))
+		    * (u32*)((u8*)M2C_FIELD(temp_r28, u8**, 0x18) + var_r31 + 0x24);
+		if (temp_r12 != NULL) {
+			if ((M2C_UNK*)temp_r12(arg0, arg1, &sp8) != arg1) {
+				return NULL;
+			}
+			var_r29 += sp8;
 		}
-		var_r29 += sp8;
-		goto block_7;
 	}
-block_7:
-	var_r31 += 0x2C;
-	var_r30 += 1;
-	goto loop_8;
+	*arg2 += var_r29;
+	return arg1;
 }
+#pragma dont_inline reset
 
 M2C_UNK* fn_80234058(M2C_UNK* arg0)
 {
@@ -2780,6 +2787,7 @@ s32 fn_802358B0(void)
 	return 0x14;
 }
 
+#pragma dont_inline on
 M2C_UNK* fn_802358B8(M2C_UNK* arg0, M2C_UNK arg_sp0)
 {
 	f32 sp1C;
@@ -2938,7 +2946,9 @@ M2C_UNK* fn_802358B8(M2C_UNK* arg0, M2C_UNK arg_sp0)
 	    = (s32)M2C_FIELD(temp_r29, s32*, 0x30);
 	return arg0;
 }
+#pragma dont_inline reset
 
+#pragma dont_inline on
 M2C_UNK* fn_80235CEC(M2C_UNK* arg0, u8* arg1)
 {
 	s32* temp_r3;
@@ -2991,6 +3001,7 @@ M2C_UNK* fn_80235CEC(M2C_UNK* arg0, u8* arg1)
 	}
 	return arg0;
 }
+#pragma dont_inline reset
 
 u8* fn_80235E64(u8* arg0, u8* arg1, f32* arg2)
 {
@@ -4173,6 +4184,7 @@ block_100:
 	return var_r14;
 }
 
+#pragma dont_inline on
 u8* fn_80237EBC(u8* arg1)
 {
 	s32 temp_r3;
@@ -4203,7 +4215,9 @@ u8* fn_80237EBC(u8* arg1)
 	}
 	return arg1;
 }
+#pragma dont_inline reset
 
+#pragma dont_inline on
 u8* fn_80237F90(u8* arg1)
 {
 	s32 temp_r3;
@@ -4215,7 +4229,9 @@ u8* fn_80237F90(u8* arg1)
 	}
 	return arg1;
 }
+#pragma dont_inline reset
 
+#pragma dont_inline on
 u8* fn_80237FF4(u8* arg1, u8* arg2)
 {
 	M2C_UNK* temp_r5;
@@ -4291,6 +4307,7 @@ u8* fn_80237FF4(u8* arg1, u8* arg2)
 	}
 	return arg2;
 }
+#pragma dont_inline reset
 
 s32 fn_80238228(u8* arg0, u8* arg1, f32* arg2)
 {
@@ -4350,6 +4367,7 @@ s32 fn_80238328(s32 arg1)
 	return arg1;
 }
 
+#pragma dont_inline on
 u8* fn_802383C0(u8* arg1)
 {
 	s32 temp_r3;
@@ -4374,7 +4392,9 @@ u8* fn_802383C0(u8* arg1)
 	}
 	return var_r31;
 }
+#pragma dont_inline reset
 
+#pragma dont_inline on
 u8* fn_80238444(u8* arg1, s32* arg2)
 {
 	s32 sp8;
@@ -4486,7 +4506,9 @@ u8* fn_80238444(u8* arg1, s32* arg2)
 	}
 	return arg1;
 }
+#pragma dont_inline reset
 
+#pragma dont_inline on
 u8* fn_802388D4(u8* arg1, s32* arg2)
 {
 	s32 sp8;
@@ -4604,7 +4626,9 @@ u8* fn_802388D4(u8* arg1, s32* arg2)
 	}
 	return arg1;
 }
+#pragma dont_inline reset
 
+#pragma dont_inline on
 u8* fn_80238D3C(u8* arg1, s32* arg2)
 {
 	s32 temp_r3;
@@ -4647,6 +4671,7 @@ u8* fn_80238D3C(u8* arg1, s32* arg2)
 	*arg2 = var_r31;
 	return arg1;
 }
+#pragma dont_inline reset
 
 u8* fn_80238E6C(u8* arg0)
 {
@@ -4697,6 +4722,7 @@ u8* fn_80238E6C(u8* arg0)
 	return arg0;
 }
 
+#pragma dont_inline on
 s32 fn_80238F88(s32 arg0)
 {
 	s32 sp20;
@@ -4718,9 +4744,11 @@ s32 fn_80238F88(s32 arg0)
 	fn_802344D8((u8*)1, (s32)&sp8, NULL, 0);
 	return arg0;
 }
+#pragma dont_inline reset
 
 void fn_80238FEC(void) { }
 
+#pragma dont_inline on
 s32 fn_80238FF0(s32 arg0, M2C_UNK arg_sp0)
 {
 	M2C_UNK* var_r27;
@@ -4780,6 +4808,7 @@ s32 fn_80238FF0(s32 arg0, M2C_UNK arg_sp0)
 	M2C_FIELD(lbl_8042AC68, s32*, 0x8C) = 0;
 	return arg0;
 }
+#pragma dont_inline reset
 
 void fn_8023914C(s32 arg0)
 {
@@ -4812,6 +4841,7 @@ s32 fn_80239184(s32 arg0, s32 arg1)
 	return arg0;
 }
 
+#pragma dont_inline on
 s32 fn_802391FC(s32 arg0, s32 arg1, s32 arg2, M2C_UNK arg_sp0)
 {
 	M2C_UNK** temp_r3;
@@ -4837,6 +4867,7 @@ s32 fn_802391FC(s32 arg0, s32 arg1, s32 arg2, M2C_UNK arg_sp0)
 	*(M2C_UNK**)(arg0 + arg2) = var_r29;
 	return arg0;
 }
+#pragma dont_inline reset
 
 s32 fn_8023927C(s32 arg1, s32* arg2)
 {
@@ -5003,6 +5034,7 @@ s32 fn_80239724(s32 arg0)
 	return *(s32*)(arg0 + M2C_FIELD(lbl_8042AC68, s32*, 4));
 }
 
+#pragma dont_inline on
 u8* fn_80239738(u8* arg0, u8* arg1)
 {
 	*(M2C_UNK**)(arg0 + M2C_FIELD(lbl_8042AC68, s32*, 4))
@@ -5010,6 +5042,7 @@ u8* fn_80239738(u8* arg0, u8* arg1)
 	M2C_FIELD(arg1, u8**, 8) = arg0;
 	return arg0;
 }
+#pragma dont_inline reset
 
 u8* fn_80239798(u8* arg0, s32 arg1, M2C_UNK arg_sp0)
 {

--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -268,7 +268,8 @@ u8* fn_8023239C(u8* arg0, s32 arg1, u8* arg2)
 			goto loop_5;
 		}
 		if ((u8*)M2C_FIELD(arg0, u8**, 0x18) != NULL) {
-			M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(M2C_UNK*), 0x138)(lbl_8042C9A4);
+			M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(u8*, M2C_UNK*), 0x138)(
+			    M2C_FIELD(arg0, u8**, 0x18), lbl_8042C9A4);
 		}
 		M2C_FIELD(arg0, s32*, 0x14) = arg1;
 		var_r28                     = arg0;
@@ -297,7 +298,7 @@ u8* fn_802324E0(u8* arg0, u8* arg1)
 	u8* temp_r6;
 
 	if ((u8*)M2C_FIELD(arg0, u8**, 0x10) != NULL) {
-		fn_80234EA0();
+		fn_80234EA0(M2C_FIELD(arg0, u8**, 0x10));
 	}
 	var_r8                      = 0;
 	M2C_FIELD(arg1, s32*, 0xC)  = (s32)(M2C_FIELD(arg1, s32*, 0xC) + 1);
@@ -1784,7 +1785,8 @@ u8* fn_802344D8(u8* arg0, s32 arg1, u8* arg2, M2C_UNK arg_sp0)
 			} while (var_ctr != 0);
 		}
 		if ((u8*)M2C_FIELD(arg0, u8**, 0x18) != NULL) {
-			M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(M2C_UNK*), 0x138)(lbl_8042C9A4);
+			M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(u8*, M2C_UNK*), 0x138)(
+			    M2C_FIELD(arg0, u8**, 0x18), lbl_8042C9A4);
 		}
 		M2C_FIELD(arg0, s32*, 0x14) = arg1;
 		var_r31                     = arg0;
@@ -1813,7 +1815,7 @@ u8* fn_802345C8(u8* arg0, u8* arg1)
 	u8* temp_r6;
 
 	if ((u8*)M2C_FIELD(arg0, u8**, 0x10) != NULL) {
-		fn_80234EA0();
+		fn_80234EA0(M2C_FIELD(arg0, u8**, 0x10));
 	}
 	var_r8                      = 0;
 	M2C_FIELD(arg1, s32*, 0xC)  = (s32)(M2C_FIELD(arg1, s32*, 0xC) + 1);
@@ -2959,7 +2961,8 @@ M2C_UNK* fn_80235CEC(M2C_UNK* arg0, u8* arg1)
 	M2C_FIELD(temp_r3_2, s32*, 0x40) = (s32)(M2C_FIELD(temp_r3_2, s32*, 0x40) | 0x800000);
 	M2C_FIELD(*(u8**)(arg1 + lbl_8042CF48), s32*, 4) = 0;
 	if ((u32)M2C_FIELD(temp_r31, u32*, 0x1C) != 0U) {
-		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(M2C_UNK*), 0x138)(lbl_8042C9A4);
+		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(u8*, M2C_UNK*), 0x138)(
+		    M2C_FIELD(temp_r31, u8**, 0x1C), lbl_8042C9A4);
 	}
 	M2C_FIELD(temp_r31, u32*, 0x1C) = 0U;
 	M2C_FIELD(temp_r31, s32*, 0x20) = 0;
@@ -4762,12 +4765,14 @@ s32 fn_80238FF0(s32 arg0, M2C_UNK arg_sp0)
 		M2C_FIELD(lbl_8042AC68, u8**, 0x68) = NULL;
 	}
 	if ((u32)M2C_FIELD(lbl_8042AC68, u32*, 0x80) != 0U) {
-		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(M2C_UNK*), 0x138)(lbl_8042C9A4);
+		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(u8*, M2C_UNK*), 0x138)(
+		    M2C_FIELD(lbl_8042AC68, u8**, 0x80), lbl_8042C9A4);
 	}
 	M2C_FIELD(lbl_8042AC68, u32*, 0x80) = 0U;
 	M2C_FIELD(lbl_8042AC68, s32*, 0x84) = 0;
 	if ((u32)M2C_FIELD(lbl_8042AC68, u32*, 0x88) != 0U) {
-		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(M2C_UNK*), 0x138)(lbl_8042C9A4);
+		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(u8*, M2C_UNK*), 0x138)(
+		    M2C_FIELD(lbl_8042AC68, u8**, 0x88), lbl_8042C9A4);
 	}
 	M2C_FIELD(lbl_8042AC68, u32*, 0x88) = 0U;
 	M2C_FIELD(lbl_8042AC68, s32*, 0x8C) = 0;

--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -152,6 +152,7 @@ M2C_UNK* fn_802321EC(void)
 {
 	M2C_UNK* sp8;
 	M2C_UNK* temp_r3;
+	M2C_UNK* temp_r4;
 
 	temp_r3 = M2C_FIELD(lbl_8042C9A4, M2C_UNK * (**)(M2C_UNK, M2C_UNK*), 0x134)(0x1C, lbl_8042C9A4);
 	if (temp_r3 != NULL) {
@@ -160,11 +161,12 @@ M2C_UNK* fn_802321EC(void)
 		M2C_FIELD(sp8, M2C_UNK**, 0)  = sp8;
 		M2C_FIELD(sp8, M2C_UNK***, 4) = &sp8;
 		M2C_FIELD(sp8, s32*, 8)       = 1;
-		if ((M2C_UNK*)M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60) == NULL) {
+		temp_r4                       = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60);
+		if (temp_r4 == NULL) {
 			*temp_r3 = (M2C_UNK)temp_r3;
 		} else {
-			*temp_r3                                  = *M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60);
-			*M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60) = (M2C_UNK)temp_r3;
+			*temp_r3 = *temp_r4;
+			*temp_r4 = (M2C_UNK)temp_r3;
 		}
 		M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x60) = temp_r3;
 	}

--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -4397,7 +4397,7 @@ u8* fn_802383C0(s32 arg0, u8* arg1)
 #pragma dont_inline reset
 
 #pragma dont_inline on
-u8* fn_80238444(u8* arg1, s32* arg2)
+u8* fn_80238444(s32 arg0, u8* arg1, s32* arg2)
 {
 	s32 sp8;
 	u8* temp_r29;
@@ -4440,12 +4440,8 @@ u8* fn_80238444(u8* arg1, s32* arg2)
 		M2C_FIELD(temp_r29, u8*, 0x7D) = (u8)((u32)sp8 >> 0x10U);
 		M2C_FIELD(temp_r29, u8*, 0x7E) = (u8)((u32)sp8 >> 8U);
 		M2C_FIELD(temp_r29, s8*, 0x7F) = (s8)sp8;
-		sp8                            = 0;
-	loop_3:
-		if (sp8 < 4) {
+		for (sp8 = 0; sp8 < 4; sp8 += 1) {
 			fn_801937A0(arg2, temp_r29 + ((sp8 * 8) + 0x84), 8);
-			sp8 += 1;
-			goto loop_3;
 		}
 		fn_80193884(arg2, &sp8, 4);
 		if ((sp8 > 0) && (fn_80192F38(arg2, 6, 0, 0) != 0)) {
@@ -4511,7 +4507,7 @@ u8* fn_80238444(u8* arg1, s32* arg2)
 #pragma dont_inline reset
 
 #pragma dont_inline on
-u8* fn_802388D4(u8* arg1, s32* arg2)
+u8* fn_802388D4(s32 arg0, u8* arg1, s32* arg2)
 {
 	s32 sp8;
 	u8* temp_r29;
@@ -4560,11 +4556,8 @@ u8* fn_802388D4(u8* arg1, s32* arg2)
 		        | ((temp_r6 << 8) & 0xFF00));
 		fn_80193474(arg2, &sp8, 4, temp_r6, temp_r7);
 		sp8 = 0;
-	loop_3:
-		if (sp8 < 4) {
+		for (sp8 = 0; sp8 < 4; sp8 += 1) {
 			fn_8019336C(arg2, temp_r29 + ((sp8 * 8) + 0x84), 8);
-			sp8 += 1;
-			goto loop_3;
 		}
 		if ((u32)M2C_FIELD(temp_r29, u32*, 0xA4) != 0U) {
 			sp8 = 1;
@@ -4679,8 +4672,8 @@ u8* fn_80238E6C(u8* arg0)
 {
 	u8* (*sp30)(u8*, u8*);
 	u8* (*sp2C)(u8*, s32*);
-	u8* (*sp28)(u8*, s32*);
-	u8* (*sp24)(u8*, s32*);
+	u8* (*sp28)(s32, u8*, s32*);
+	u8* (*sp24)(s32, u8*, s32*);
 	u8* (*sp20)(u8*);
 	u8* (*sp1C)(u8*);
 	s32 sp18;
@@ -4825,8 +4818,8 @@ void fn_80239178(s32 arg0, s32 arg1)
 s32 fn_80239184(s32 arg0, s32 arg1)
 {
 	M2C_UNK** temp_r3;
-	M2C_UNK* temp_r30;
 	M2C_UNK* temp_r31;
+	M2C_UNK* temp_r30;
 	M2C_UNK* var_r3;
 
 	temp_r3 = *(M2C_UNK***)(arg0 + arg1);
@@ -4848,8 +4841,8 @@ s32 fn_802391FC(s32 arg0, s32 arg1, s32 arg2)
 {
 	M2C_UNK** temp_r3;
 	M2C_UNK* temp_r31;
-	M2C_UNK* var_r29;
 	M2C_UNK* var_r30;
+	M2C_UNK* var_r29;
 	u8* temp_r3_2;
 
 	temp_r3 = *(M2C_UNK***)(arg1 + arg2);
@@ -4969,13 +4962,13 @@ s32 fn_8023944C(void)
 	return 1;
 }
 
-u8* fn_802395BC(void)
+u8* fn_802395BC(u8* arg0)
 {
-	s32 temp_r3_2;
 	u8* temp_r3;
+	s32 temp_r3_2;
 	u8* var_r29;
 
-	temp_r3 = fn_80232968(NULL);
+	temp_r3 = fn_80232968(arg0);
 	var_r29 = NULL;
 	if (temp_r3 != NULL) {
 		temp_r3_2 = fn_80152288(lbl_80430298);
@@ -5006,9 +4999,9 @@ M2C_UNK* (*fn_80239690(M2C_UNK* (*arg0)(s32, M2C_UNK*, s32*, M2C_UNK),
     M2C_UNK arg_sp0))(s32, M2C_UNK*, s32*, M2C_UNK)
 {
 	M2C_UNK** temp_r3;
-	M2C_UNK* temp_r29;
 	M2C_UNK* temp_r31;
 	M2C_UNK* var_r30;
+	M2C_UNK* temp_r29;
 
 	temp_r3 = *(M2C_UNK***)((u8*)arg0 + M2C_FIELD(lbl_8042AC68, s32*, 4));
 	if (temp_r3 != NULL) {

--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -2755,7 +2755,7 @@ loop_4:
 
 u8* fn_802357A8(s32* arg0, u8* arg1)
 {
-	fn_801979AC(arg1 + 0x10, 4);
+	fn_801979AC(arg0, arg1 + 0x10, 4);
 	fn_801979AC(arg0, arg1 + 0x14, 4);
 	fn_80193884(arg0, arg1 + 0x28, 4);
 	fn_80193884(arg0, arg1 + 0x2C, 4);
@@ -2765,7 +2765,7 @@ u8* fn_802357A8(s32* arg0, u8* arg1)
 
 u8* fn_8023582C(s32* arg0, u8* arg1)
 {
-	fn_80197B48(arg1 + 0x10, 4);
+	fn_80197B48(arg0, arg1 + 0x10, 4);
 	fn_80197B48(arg0, arg1 + 0x14, 4);
 	fn_80193474(arg0, arg1 + 0x28, 4);
 	fn_80193474(arg0, arg1 + 0x2C, 4);
@@ -4779,9 +4779,9 @@ s32 fn_80238FF0(s32 arg0, M2C_UNK arg_sp0)
 	return arg0;
 }
 
-void fn_8023914C(void)
+void fn_8023914C(s32 arg0)
 {
-	fn_80239690(fn_80233714, NULL);
+	fn_80239690(arg0, fn_80233714, NULL);
 }
 
 void fn_80239178(s32 arg0, s32 arg1)
@@ -4849,7 +4849,7 @@ s32 fn_80239290(s32 arg0, s32 arg1)
 	sp8 = 0;
 	if (*(u32*)(arg0 + arg1) != 0U) {
 		sp8 = 4;
-		fn_80239690(fn_80233F50, &sp8);
+		fn_80239690(arg0, fn_80233F50, &sp8);
 	}
 	return sp8;
 }
@@ -4872,7 +4872,7 @@ s32* fn_802392DC(s32* arg0, u8* arg2)
 			var_r30 += 1;
 			goto loop_3;
 		}
-		M2C_FIELD(arg2, void (**)(), 0x48) = fn_8023914C;
+		M2C_FIELD(arg2, void (**)(s32), 0x48) = fn_8023914C;
 		if (((void (*)())M2C_FIELD(arg2, void (**)(), 0x48)) == NULL) {
 			M2C_FIELD(arg2, void (**)(), 0x48) = fn_8014F1B0;
 		}
@@ -4951,7 +4951,7 @@ u8* fn_802395BC(void)
 			if (var_r29 != NULL) {
 				*(u8**)(var_r29 + M2C_FIELD(lbl_8042AC68, s32*, 4)) = temp_r3;
 				M2C_FIELD(temp_r3, u8**, 8)                         = var_r29;
-				M2C_FIELD(var_r29, void (**)(), 0x48)               = fn_8023914C;
+				M2C_FIELD(var_r29, void (**)(s32), 0x48)            = fn_8023914C;
 				if (((void (*)())M2C_FIELD(var_r29, void (**)(), 0x48)) == NULL) {
 					M2C_FIELD(var_r29, void (**)(), 0x48) = fn_8014F1B0;
 				}

--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -1630,7 +1630,7 @@ M2C_UNK* fn_80234058(M2C_UNK* arg0)
 	temp_r3 = M2C_FIELD(M2C_FIELD(arg0, u8**, 0xC), u8**, 0x10);
 	if (temp_r3 != (u8*)M2C_FIELD(lbl_8042AC68, u8**, 0x90)) {
 		M2C_FIELD(lbl_8042AC68, u8**, 0x90) = temp_r3;
-		M2C_FIELD(lbl_8042AC68, s32*, 0x98) = fn_8023506C((u8*)1U);
+		M2C_FIELD(lbl_8042AC68, s32*, 0x98) = fn_8023506C(temp_r3, 1, lbl_8042AC68);
 		M2C_FIELD(lbl_8042AC68, s32*, 0x9C)
 		    = fn_8023506C(M2C_FIELD(M2C_FIELD(arg0, u8**, 0xC), u8**, 0x10), 2, lbl_8042AC68);
 		M2C_FIELD(lbl_8042AC68, s32*, 0xA0)
@@ -1647,7 +1647,7 @@ M2C_UNK* fn_80234058(M2C_UNK* arg0)
 	temp_r3_2 = M2C_FIELD(M2C_FIELD(arg0, u8**, 0x18), u8**, 0x10);
 	if (temp_r3_2 != (u8*)M2C_FIELD(lbl_8042AC68, u8**, 0x94)) {
 		M2C_FIELD(lbl_8042AC68, u8**, 0x94) = temp_r3_2;
-		M2C_FIELD(lbl_8042AC68, s32*, 0xB8) = fn_8023506C(NULL);
+		M2C_FIELD(lbl_8042AC68, s32*, 0xB8) = fn_8023506C(temp_r3_2, 0, lbl_8042AC68);
 		M2C_FIELD(lbl_8042AC68, s32*, 0xBC)
 		    = fn_8023506C(M2C_FIELD(M2C_FIELD(arg0, u8**, 0x18), u8**, 0x10), 2, lbl_8042AC68);
 		M2C_FIELD(lbl_8042AC68, s32*, 0xC0)
@@ -1708,6 +1708,7 @@ M2C_UNK* fn_80234338(void)
 s32 fn_802343C4(M2C_UNK* arg0)
 {
 	M2C_UNK* temp_r0;
+	u8* temp_r3;
 	M2C_UNK* var_r4;
 	M2C_UNK* var_r5;
 
@@ -1720,7 +1721,7 @@ s32 fn_802343C4(M2C_UNK* arg0)
 		    && ((M2C_UNK*)M2C_FIELD(arg0, M2C_UNK**, 0) == arg0)) {
 			M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64) = NULL;
 		} else {
-			temp_r0 = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64);
+			temp_r0 = (M2C_UNK*)*M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64);
 			var_r5  = M2C_FIELD(lbl_8042AC68, M2C_UNK**, 0x64);
 			var_r4  = temp_r0;
 		loop_7:
@@ -1743,8 +1744,9 @@ s32 fn_802343C4(M2C_UNK* arg0)
 		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(M2C_UNK*, M2C_UNK*), 0x138)(
 		    (M2C_UNK*)M2C_FIELD(arg0, u32*, 0x18), lbl_8042C9A4);
 	}
-	if ((u32)M2C_FIELD(arg0, u32*, 0x10) != 0U) {
-		fn_80234EA0();
+	temp_r3 = M2C_FIELD(arg0, u8**, 0x10);
+	if (temp_r3 != NULL) {
+		fn_80234EA0(temp_r3);
 	}
 	memset(arg0, 0, 0x1C);
 	M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(M2C_UNK*, M2C_UNK*), 0x138)(arg0, lbl_8042C9A4);
@@ -2685,19 +2687,21 @@ u8* fn_80235614(u8* arg0)
 {
 	u32 temp_r31;
 	u8* temp_r3;
+	u8* temp_r3_2;
 
 	temp_r3 = M2C_FIELD(arg0, u8**, 0x18);
 	if (temp_r3 != NULL) {
 		temp_r31 = M2C_FIELD(temp_r3, u32*, 4);
-		fn_80152220(NULL);
+		fn_80152220(temp_r3, NULL);
 		if (temp_r31 != 0U) {
 			fn_8019E480(temp_r31);
 		}
 		fn_80150358(M2C_FIELD(arg0, u8**, 0x18));
 	}
 	M2C_FIELD(arg0, u8**, 0x18) = NULL;
-	if ((u32)M2C_FIELD(arg0, u32*, 0x1C) != 0U) {
-		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(M2C_UNK*), 0x138)(lbl_8042C9A4);
+	temp_r3_2                   = M2C_FIELD(arg0, u8**, 0x1C);
+	if (temp_r3_2 != NULL) {
+		M2C_FIELD(lbl_8042C9A4, M2C_UNK(**)(u8*, M2C_UNK*), 0x138)(temp_r3_2, lbl_8042C9A4);
 	}
 	M2C_FIELD(arg0, u32*, 0x1C) = 0U;
 	M2C_FIELD(arg0, s32*, 0x20) = 0;


### PR DESCRIPTION
## What

`game/rw_gcn_core.c` goes from **4.25% -> 13.66%** matched code and **25 -> 45** matched functions; fuzzy match 62.9% -> 79.9%. No other unit moved, and no function regresses on fuzzy either (checked with `objdiff-cli report generate` before and after).

Twenty functions now match exactly, including all five plugin-registry `find` helpers, both stream twins, and the plugin insert/unlink pair. Several more land in the high 90s: `fn_80234058` 99.7%, `fn_802392DC` 99.3%, `fn_802395BC` 98.8%, `fn_80235CEC` 98.9%, `fn_80233F50` 97.2%, `fn_80238444` 96.4%, `fn_802388D4` 95.9%.

## How

Four m2c artefacts account for essentially all of it, and each repeats across the unit:

- **Inlining.** objdiff showed retail issuing a `bl` where our build had folded the callee in — seventeen callers. Marking them `dont_inline` moved every one of them, several from 0%: `fn_802388D4` 31% -> 94%, `fn_802383C0` 28% -> 99%, `fn_80239738` 10% -> 100%, `fn_80235CEC` 56% -> 99%.
- **Phantom and missing parameters.** Eighteen functions carried an `arg_sp0` nobody reads; while it sat in the signature the call sites could not take the argument counts retail uses. Conversely several functions are short a *leading* parameter — m2c names parameters by register and drops the ones it cannot see used, so an object arriving in r5 means there are hidden r3/r4 parameters. Teardown helpers take the block they are freeing; the stream writers take the stream.
- **Saved-register order.** MWCC hands out r31, r30, r29 in declaration order, so the register permutations objdiff was reporting are a declaration-order question, not an allocation mystery.
- **The circular plugin list.** m2c re-reads the list-head global at every compare; retail reads it once into a local, seeds the cursor from it *before* the empty-list test, and links new entries through that same pointer.

Also records in `docs/decomp-work-tracking.md` where `game/rw_gcn_raster.c` was left after #497 and reserves this unit.

## Verification

`objdiff-cli diff` per function after each step, plus a whole-project report diff for both matched and fuzzy regressions. The local `main.elf` link still hits the known `ELF_gen.c:2336` alert on this machine (`main` fails identically with byte-identical link inputs), so CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)