### PR TITLE
match: recover the stream callback table in rw_gcn_core

### DIFF
--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -1,6 +1,15 @@
 #include "types.h"
 
 typedef s32 M2C_UNK;
+typedef struct {
+	s32 words[2];
+} M2C_BLOCK8;
+typedef struct {
+	s32 words[3];
+} M2C_BLOCK12;
+typedef struct {
+	s32 words[4];
+} M2C_BLOCK16;
 #define M2C_FIELD(base, type, offset) (*(type)((u8*)(base) + (offset)))
 #define M2C_BITWISE(type, value)      (*(type*)&(value))
 #define M2C_ERROR(...)                0
@@ -3382,9 +3391,9 @@ loop_103:
 						    + ((temp_f26 * M2C_FIELD(temp_r15, f32*, 8)) + sp18));
 					} else {
 						if (var_r23 != var_r24) {
-							M2C_STRUCT_COPY(var_r23, var_r24, 0xC);
-							M2C_STRUCT_COPY(var_r23, var_r24, 0xC);
-							M2C_STRUCT_COPY(var_r23, var_r24, 0xC);
+							*(M2C_BLOCK12*)var_r23        = *(M2C_BLOCK12*)var_r24;
+							*(M2C_BLOCK12*)var_r23        = *(M2C_BLOCK12*)var_r24;
+							*(M2C_BLOCK12*)var_r23        = *(M2C_BLOCK12*)var_r24;
 							M2C_FIELD(var_r23, s32*, 0xC) = (s32)M2C_FIELD(var_r24, s32*, 0xC);
 						}
 						sp10 = M2C_FIELD(var_r24, f32*, 0x30);
@@ -3431,7 +3440,7 @@ loop_103:
 						    = (f32)((var_f31 * M2C_FIELD(temp_r27, f32*, 0xC))
 						        + M2C_FIELD(temp_r27, f32*, 4));
 					} else if ((u32)var_r19 != var_r20) {
-						M2C_STRUCT_COPY(var_r19, var_r20, 8);
+						*(M2C_BLOCK8*)var_r19 = *(M2C_BLOCK8*)var_r20;
 					}
 					var_r19 += spD8;
 				}
@@ -3469,7 +3478,7 @@ loop_103:
 						    = (f32)((var_f31 * M2C_FIELD(temp_r28, f32*, 0x1C))
 						        + M2C_FIELD(temp_r28, f32*, 0xC));
 					} else if ((u32)var_r21 != var_r22) {
-						M2C_STRUCT_COPY(var_r21, var_r22, 0x10);
+						*(M2C_BLOCK16*)var_r21 = *(M2C_BLOCK16*)var_r22;
 					}
 					var_r21 += spDC;
 				}

--- a/src/game/rw_gcn_core.c
+++ b/src/game/rw_gcn_core.c
@@ -3538,7 +3538,7 @@ loop_103:
 	return spC;
 }
 
-u8* fn_80236AE4(u8* arg1)
+u8* fn_80236AE4(s32 arg0, u8* arg1)
 {
 	s32 sp90;
 	M2C_UNK* sp8C;
@@ -4187,7 +4187,7 @@ block_100:
 }
 
 #pragma dont_inline on
-u8* fn_80237EBC(u8* arg1)
+u8* fn_80237EBC(s32 arg0, u8* arg1)
 {
 	s32 temp_r3;
 	u8* temp_r6;
@@ -4200,10 +4200,10 @@ u8* fn_80237EBC(u8* arg1)
 		M2C_FIELD(temp_r6, s32*, 4)    = 0;
 		M2C_FIELD(temp_r6, f32*, 0x74) = (f32)lbl_8043026C;
 		M2C_FIELD(temp_r6, f32*, 0x78) = (f32)lbl_8043026C;
-		M2C_FIELD(temp_r6, s8*, 0x7C)  = 0xFF;
-		M2C_FIELD(temp_r6, s8*, 0x7D)  = 0xFF;
-		M2C_FIELD(temp_r6, s8*, 0x7E)  = 0xFF;
-		M2C_FIELD(temp_r6, s8*, 0x7F)  = 0xFF;
+		M2C_FIELD(temp_r6, u8*, 0x7C)  = 0xFF;
+		M2C_FIELD(temp_r6, u8*, 0x7D)  = 0xFF;
+		M2C_FIELD(temp_r6, u8*, 0x7E)  = 0xFF;
+		M2C_FIELD(temp_r6, u8*, 0x7F)  = 0xFF;
 		M2C_FIELD(temp_r6, f32*, 0x84) = (f32)lbl_80430268;
 		M2C_FIELD(temp_r6, f32*, 0x88) = (f32)lbl_80430268;
 		M2C_FIELD(temp_r6, f32*, 0x8C) = (f32)lbl_8043026C;
@@ -4220,21 +4220,21 @@ u8* fn_80237EBC(u8* arg1)
 #pragma dont_inline reset
 
 #pragma dont_inline on
-u8* fn_80237F90(u8* arg1)
+u8* fn_80237F90(s32 arg0, u8* arg1)
 {
 	s32 temp_r3;
+	u8* temp_r3_3;
 
 	temp_r3 = fn_8023506C(M2C_FIELD(M2C_FIELD(arg1, u8**, 0xC), u8**, 0x10), 1);
-	if ((temp_r3 >= 0) && (M2C_FIELD(arg1, s32*, 4) & 0x200)
-	    && ((u32)M2C_FIELD((arg1 + temp_r3), u32*, 0xA4) != 0U)) {
-		fn_801A491C();
+	if ((temp_r3 >= 0) && (temp_r3_3 = arg1 + temp_r3, M2C_FIELD(arg1, s32*, 4) & 0x200)
+	    && ((u32)M2C_FIELD(temp_r3_3, u32*, 0xA4) != 0U)) {
+		fn_801A491C(M2C_FIELD(temp_r3_3, u32*, 0xA4));
 	}
-	return arg1;
 }
 #pragma dont_inline reset
 
 #pragma dont_inline on
-u8* fn_80237FF4(u8* arg1, u8* arg2)
+u8* fn_80237FF4(s32 arg0, u8* arg1, u8* arg2)
 {
 	M2C_UNK* temp_r5;
 	M2C_UNK* temp_r5_2;
@@ -4348,7 +4348,7 @@ s32 fn_80238228(u8* arg0, u8* arg1, f32* arg2)
 	return (s32)arg1;
 }
 
-s32 fn_80238328(s32 arg1)
+s32 fn_80238328(s32 arg0, s32 arg1)
 {
 	f32 temp_f1;
 	u32 temp_r3;
@@ -4356,8 +4356,7 @@ s32 fn_80238328(s32 arg1)
 
 	temp_r5 = (u8*)arg1 + M2C_FIELD(lbl_8042AC68, s32*, 0x98);
 	temp_f1 = M2C_FIELD(temp_r5, f32*, 8);
-	M2C_ERROR(/* unknown instruction: cror eq, gt, eq */);
-	if (temp_f1 == M2C_FIELD(temp_r5, f32*, 0x40)) {
+	if (temp_f1 >= M2C_FIELD(temp_r5, f32*, 0x40)) {
 		M2C_FIELD(temp_r5, f32*, 0x3C) = temp_f1;
 		temp_r3                        = (M2C_FIELD(temp_r5, u32*, 0) * 0x0BB38435) + 0x3619636B;
 		M2C_FIELD(temp_r5, f32*, 0x40)
@@ -4670,50 +4669,23 @@ u8* fn_80238D3C(u8* arg1, s32* arg2)
 
 u8* fn_80238E6C(u8* arg0)
 {
-	u8* (*sp30)(u8*, u8*);
-	u8* (*sp2C)(u8*, s32*);
-	u8* (*sp28)(s32, u8*, s32*);
-	u8* (*sp24)(s32, u8*, s32*);
-	u8* (*sp20)(u8*);
-	u8* (*sp1C)(u8*);
-	s32 sp18;
-	u8* (*sp14)(s32, u8*);
-	s32 (*sp10)(s32);
-	s32 (*spC)(u8*, u8*, f32*);
-	u8* (*sp8)(u8*);
+	void* sp8[11];
 	s32 var_ctr;
-	u8* (**var_r6)(u8*);
 
-	var_r6  = &sp8 + 0x28;
-	sp8     = NULL;
-	spC     = NULL;
-	sp10    = NULL;
-	sp14    = NULL;
-	sp18    = 0;
-	sp1C    = NULL;
-	sp20    = NULL;
-	sp24    = NULL;
-	sp28    = NULL;
-	sp2C    = NULL;
-	var_ctr = 0xB - 0xA;
-	if (0xA < 0xB) {
-		do {
-			*var_r6 = NULL;
-			var_r6 += 4;
-			var_ctr -= 1;
-		} while (var_ctr != 0);
+	for (var_ctr = 0; var_ctr < 11; var_ctr += 1) {
+		sp8[var_ctr] = NULL;
 	}
-	sp1C = fn_80237EBC;
-	sp20 = fn_80237F90;
-	sp8  = fn_80236AE4;
-	spC  = fn_80238228;
-	sp10 = fn_80238328;
-	sp14 = fn_802383C0;
-	sp24 = fn_80238444;
-	sp28 = fn_802388D4;
-	sp2C = fn_80238D3C;
-	sp30 = fn_80237FF4;
-	fn_8023239C(arg0, 1, (u8*)&sp8);
+	sp8[5]  = (void*)fn_80237EBC;
+	sp8[6]  = (void*)fn_80237F90;
+	sp8[0]  = (void*)fn_80236AE4;
+	sp8[1]  = (void*)fn_80238228;
+	sp8[2]  = (void*)fn_80238328;
+	sp8[3]  = (void*)fn_802383C0;
+	sp8[7]  = (void*)fn_80238444;
+	sp8[8]  = (void*)fn_802388D4;
+	sp8[9]  = (void*)fn_80238D3C;
+	sp8[10] = (void*)fn_80237FF4;
+	fn_8023239C(arg0, 1, (u8*)sp8);
 	return arg0;
 }
 


### PR DESCRIPTION
## What

Follow-on to #498. `game/rw_gcn_core.c` goes from **13.66% -> 15.29%** matched code and **45 -> 47** matched functions; fuzzy 79.9% -> 80.9%. No unit and no function regresses (checked with `objdiff-cli report generate` before and after).

`fn_80238E6C` and `fn_80237EBC` now match exactly. `fn_80237F90` 81% -> 91%, `fn_80235E64` 76% -> 79%, `fn_80238328` 66% -> 75%, `fn_80237FF4` and `fn_80236AE4` move up with them.

## How

- **The callback table.** `fn_80238E6C` builds an eleven-slot table of stream callbacks. m2c had it as eleven separate locals plus a pointer walking off the end of the first one; written as the array it is, cleared by a loop, it compiles to what retail has. That in turn pins the entries' signatures — every one of them takes the plugin offset in r3, so the object arrives in r4, which is why they all looked one parameter short.
- **A float comparison.** `fn_80238328` gates on `>=`, which m2c rendered as `==` plus an unrepresentable `cror`.
- **Pointer forming.** `fn_80237F90` computes the extension pointer once between its two flag tests instead of folding the field offset into an indexed load.
- **Small struct copies.** m2c routes 8-, 12- and 16-byte copies through `memcpy`; retail expands them in place, which is what a struct assignment compiles to.

## Verification

`objdiff-cli diff` per function after each step, plus a whole-project report diff for both matched and fuzzy regressions. The local `main.elf` link still hits the known `ELF_gen.c:2336` alert on this machine (`main` fails identically with byte-identical link inputs), so CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)