### PR TITLE
match: close five more e_wall_stage11 functions

### DIFF
--- a/src/rel/e_wall_stage11.cpp
+++ b/src/rel/e_wall_stage11.cpp
@@ -227,12 +227,66 @@ typedef struct TObject {
  * vtable through the already-materialised `this` in r3 and keeps the slot in
  * r12, which manual vtable indexing does not reproduce. Two implicit
  * destructor slots plus the two placeholders below put Release at slot 4. */
+/* The renderer class keeps its vtable pointer at object offset 0x18, which is
+ * what a polymorphic class derived from a 0x18-byte non-polymorphic base
+ * looks like: the base's data is laid out first and `this` is not adjusted,
+ * exactly as retail's `lwz r12, 0x18(r3)` reads it. Slot numbers are the
+ * retail vtable offsets divided by four, and the two implicit deleting
+ * destructor slots occupy 0 and 1, so a method at slot k needs k - 2
+ * placeholders ahead of it. */
+class TRendererBase
+{
+public:
+	u8 pad0[0x18];
+};
+
+class TRenderer : public TRendererBase
+{
+public:
+	virtual void vslot2();
+	virtual void vslot3();
+	virtual void vslot4();
+	virtual void vslot5();
+	virtual void vslot6();
+	virtual void vslot7();
+	virtual void vslot8();
+	virtual void vslot9();
+	virtual void vslot10();
+	virtual void vslot11();
+	virtual void vslot12();
+	virtual void vslot13();
+	virtual void vslot14();
+	virtual void Slot3C();
+	virtual void Slot40();
+	virtual void vslot17();
+	virtual void vslot18();
+	virtual void vslot19();
+	virtual void vslot20();
+	virtual void vslot21();
+	virtual void vslot22();
+	virtual void vslot23();
+	virtual void vslot24();
+	virtual void vslot25();
+	virtual void vslot26();
+	virtual void vslot27();
+	virtual void vslot28();
+	virtual void vslot29();
+	virtual void vslot30();
+	virtual void Slot7C();
+	virtual void vslot32();
+	virtual void vslot33();
+	virtual void Slot88(void*);
+	virtual void vslot35();
+	virtual s32 Slot90();
+};
+
 class TObjectDispatch
 {
 public:
 	virtual void vslot2();
 	virtual void vslot3();
 	virtual void Release(s32, s32);
+	virtual s32 vslot5();
 };
 
 extern "C" {
@@ -391,7 +445,7 @@ void fn_8_BBF90(TObject* arg0);                                                 
 void fn_8_BC2CC(TObject* arg0);                                                  /* static */
 void fn_8_BCB60(TObject* arg0);                                                  /* static */
 void fn_8_BCD58(TObject* arg0);                                                  /* static */
-TObject* fn_8_BCF88(TObject* arg0);                                              /* static */
+TObject* fn_8_BCF88(TObject* arg0, TObject* arg1);                               /* static */
 void wallObjectCreate();                                                         /* static */
 void wallObjectLoad();                                                           /* static */
 void wallObjectUnload();                                                         /* static */
@@ -1419,7 +1473,7 @@ void fn_8_B8234(void* arg0, void* arg1)
 {
 	M2C_FIELD(arg0, void**, 0x14) = arg1;
 	M2C_FIELD(arg0, s32*, 0x10)   = 0;
-	if (M2C_FIELD(M2C_FIELD(arg0, void**, 0), s32(**)(), 0x14)() != 0) {
+	if (((TObjectDispatch*)arg0)->vslot5() != 0) {
 		((TObjectDispatch*)arg0)->Release((s32)M2C_FIELD(arg0, s32*, 4), 2);
 	}
 	((TObjectDispatch*)arg0)->Release((s32)M2C_FIELD(arg0, s32*, 4), 1);
@@ -1939,7 +1993,7 @@ void fn_8_B956C(void* arg0)
 		temp_r3                        = M2C_FIELD(arg0, void**, 0xB0);
 		M2C_FIELD(temp_r3, s32*, 0x18) = (s32)(M2C_FIELD(temp_r3, s32*, 0x18) | 0x01000000);
 	}
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*), 0x7C)(arg0);
+	((TRenderer*)arg0)->Slot7C();
 	temp_r0 = M2C_FIELD(lbl_8042C180, u8*, 0x24);
 	if ((((s8)temp_r0 == 4) || ((s8)temp_r0 == 8))
 	    && (((s32)M2C_FIELD(&lbl_8029C310, s32*, 0x2C) == 4)
@@ -1950,7 +2004,7 @@ void fn_8_B956C(void* arg0)
 		M2C_FIELD(temp_r3_3, s32*, 0x18) = (s32)(M2C_FIELD(temp_r3_3, s32*, 0x18) | 0x200);
 	}
 	fn_8005BC04((u8*)arg0 + 0xB0);
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*), 0x40)(arg0);
+	((TRenderer*)arg0)->Slot40();
 	temp_r0_2 = M2C_FIELD(arg0, s32*, 0x230);
 	if (temp_r0_2 != -1) {
 		temp_r3_4 = (void*)(u32) * (&lbl_802AD070 + (temp_r0_2 * 4));
@@ -1961,8 +2015,7 @@ void fn_8_B956C(void* arg0)
 				fn_8011C9A0((u8*)arg0 + 0x140,
 				    (s8)M2C_FIELD(
 				        ((u8*)temp_r30 + (s8)M2C_FIELD(temp_r30, u8*, 0x3A)), u8*, 0x110));
-				M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*, void*), 0x88)(
-				    arg0, (u8*)arg0 + 0x140);
+				((TRenderer*)arg0)->Slot88((u8*)arg0 + 0x140);
 			}
 		}
 	}
@@ -2363,7 +2416,7 @@ void fn_8_BA1EC(void* arg0)
 	if ((s32)M2C_FIELD(arg0, s32*, 0x29C) == 1) {
 		fn_80113940();
 		fn_801138B4();
-		fn_80113874(M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), s32(**)(void*), 0x90)(arg0));
+		fn_80113874(((TRenderer*)arg0)->Slot90());
 		temp_r4 = M2C_FIELD(lbl_8042C180, s32*, 0x30);
 		if ((s32)lbl_8_bss_1B24 != temp_r4) {
 			lbl_8_bss_1B24 = temp_r4;
@@ -2379,7 +2432,7 @@ void fn_8_BA2B0(void* arg0)
 {
 	sVec4i sp8;
 
-	fn_80113874(M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), s32(**)(), 0x90)());
+	fn_80113874(((TRenderer*)arg0)->Slot90());
 	fn_8014FF2C(M2C_FIELD(arg0, s32**, 0xE8));
 	if (((s32)M2C_FIELD(arg0, s32*, 0x288) != 0) && ((s32*)M2C_FIELD(arg0, s32**, 0x2C8) != NULL)) {
 		M2C_FIELD(&sp8, M2C_BLOCK16*, 0) = M2C_FIELD(&lbl_8_rodata_1D00, M2C_BLOCK16*, 0);
@@ -2637,10 +2690,10 @@ void fn_8_BADC4(void* arg0, s32 arg1)
 			M2C_FIELD(arg0, s32*, 0x29C) = 0;
 			if ((u32)lbl_8042C388 != 0U) {
 				fn_800B4A38(lbl_8042C388, 0x4020, (f32*)((u8*)arg0 + 0x140), 0, 1, 0, 0);
-				return;
 			}
+			/* fallthrough */
 		case 2:
-			return;
+			break;
 		case 1:
 			if (((s32)M2C_FIELD(arg0, s32*, 0x294) != 0)
 			    && ((s32)M2C_FIELD(arg0, s32*, 0xD0) == 5)) {
@@ -2837,7 +2890,7 @@ void fn_8_BB584(void* arg0, s32 arg1)
 {
 	switch (arg1) { /* irregular */
 		case 0:
-			M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x3C)();
+			((TRenderer*)arg0)->Slot3C();
 			break;
 		case 1:
 			M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
@@ -3064,7 +3117,7 @@ void fn_8_BBAD0(void* arg0, u32 arg1, s32 arg2)
 		case 0x1D:          /* switch 1 */
 			switch (arg2) { /* switch 3; irregular */
 				case 0:     /* switch 3 */
-					M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x3C)();
+					((TRenderer*)arg0)->Slot3C();
 					return;
 				case 1: /* switch 3 */
 					M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
@@ -3721,7 +3774,7 @@ TObject* fn_8_BCE1C(TObject* arg0, s16 arg1)
 }
 
 #pragma dont_inline on
-TObject* fn_8_BCF88(TObject* arg0)
+TObject* fn_8_BCF88(TObject* arg0, TObject* arg1)
 {
 	f32 sp18;
 	f32 sp14;
@@ -3840,7 +3893,7 @@ TObject* fn_8_BD32C(void)
 
 	var_r0 = fn_80018A34(lbl_8042C148, 0x318);
 	if (var_r0 != NULL) {
-		var_r0 = fn_8_BCF88(lbl_8042C10C);
+		var_r0 = fn_8_BCF88(var_r0, lbl_8042C10C);
 	}
 	return var_r0;
 }
@@ -3988,8 +4041,11 @@ void wallObjectLoad(void)
 
 void wallObjectCreate(void)
 {
-	if (fn_80018A34(lbl_8042C148, 0x318) != NULL) {
-		fn_8_BCF88(lbl_8042C10C);
+	TObject* temp_r3;
+
+	temp_r3 = fn_80018A34(lbl_8042C148, 0x318);
+	if (temp_r3 != NULL) {
+		fn_8_BCF88(temp_r3, lbl_8042C10C);
 	}
 }
 


### PR DESCRIPTION
Follows #506 on the same unit. `rel/e_wall_stage11` goes 23.39% -> 26.25%
matched code, 44 -> 49 functions, fuzzy 95.72% -> 95.81%. Game Code overall
68.94% -> 69.00%.

| function | before | after |
| --- | --- | --- |
| `fn_8_BD32C` | 84.05% | **100%** |
| `wallObjectCreate` | 98.61% | **100%** |
| `fn_8_BADC4` | 98.73% | **100%** |
| `fn_8_BB584` | 99.58% | **100%** |
| `fn_8_BA1EC` | 99.69% | **100%** |
| `fn_8_B8234` | 99.34% | 99.74% |
| `fn_8_BA2B0` | 98.23% | 98.54% |
| `fn_8_B956C` | 94.71% | 95.12% |
| `fn_8_BBAD0` | 95.05% | 95.10% |

## The renderer's vtable pointer sits at object offset 0x18

A second family of dispatches reads `lwz r12, 0x18(r3)` with `r3` still the
original object - no `this` adjustment, so `0x18` is not a pointer field to
another object, it is a second vtable pointer inside the same object.

That layout is what a polymorphic class derived from a **0x18-byte
non-polymorphic base** produces: the base's data is laid out first and the
derived vptr follows it. Modelling it as m2c wrote it (a pointer field,
loaded then dereferenced) adds an indirection and measured *worse* on every
site; modelling it as the derivation reproduces the two instructions:

```c++
class TRendererBase { public: u8 pad0[0x18]; };
class TRenderer : public TRendererBase { public: /* ... */ };
```

Slot numbers are the retail vtable offsets over four, and the two implicit
deleting-destructor slots occupy 0 and 1, so a method at slot k needs k - 2
placeholders. Five slots are reached from this unit: 0x3C, 0x40, 0x7C, 0x88
and 0x90. The same reasoning adds slot 5 (offset 0x14) to `TObjectDispatch`.

## `fn_8_BCF88` is the wall constructor and m2c dropped its `this`

`wallObjectCreate` allocates, then retail calls with `r3` still holding the
allocation and `r4` holding the global:

```
bl fn_80018A34      ; r3 = new object
cmplwi r3, 0x0
beq exit
lis r4, lbl_8042C10C@ha ...
bl fn_8_BCF88       ; (newObject, wallGlobal)
```

`fn_8_BCF88` starts `mr r31, r3`, calls the base constructor and stores the
vtable at `+0x18`, which confirms `r3` is the object under construction, not
the global m2c passed. Giving the function its dropped first parameter and
threading the allocation through both call sites made `wallObjectCreate` and
`fn_8_BD32C` exact.

## An empty case reached by fallthrough emits no branch of its own

`fn_8_BADC4` had one `b` too many. m2c wrote `case 0`'s tail as `return;`
and `case 2` as `return;`, which is two branches to one epilogue. Retail
emits one: `case 0` falls through into an empty `case 2` whose `break` is
the only branch. Removing the `return` and letting the fallthrough reach a
`break` matched the function.

## Not fixed, and why

- `fn_8_B7C50` and `fn_8_B78CC` differ only by retail keeping `this` in `r3`
  live across the whole body while ours spills it to `r31` and reuses `r3`
  for temporaries. Hoisting the tested field into a named local changed
  nothing. This is the register-allocation wall, not a source-shape bug.
- `fn_8_B7210` is 8 bytes in retail: `addi r3, r3, -0xB0` and a tail branch.
  That is a compiler-generated this-adjusting thunk for a secondary base -
  consistent with the 0x18 vptr above - and not something source can spell.
  Writing it as `return callee(...)` does not produce the tail branch.

## Verification

- `python3 configure.py && ninja` - `18 files OK`; direct `sha1sum` against
  `config/G9SE8P/build.sha1` clean.
- Per-function objdiff against the pre-change baseline: nine improve, zero
  regress.
- `clang-format` clean.