### PR TITLE
match: fix mangled externs and three more m2c idioms in stage11

### DIFF
--- a/src/rel/e_capture.cpp
+++ b/src/rel/e_capture.cpp
@@ -188,6 +188,59 @@ typedef struct TObject {
 	/* 0x588 */ f32 unk588;         /* inferred */
 } TObject;                          /* size >= 0x58C */
 
+/* The renderer class keeps its vtable pointer at object offset 0x18, which is
+ * what a polymorphic class derived from a 0x18-byte non-polymorphic base
+ * looks like: the base's data is laid out first and `this` is not adjusted,
+ * exactly as retail's `lwz r12, 0x18(r3)` reads it. Slot numbers are the
+ * retail vtable offsets divided by four, and the two implicit deleting
+ * destructor slots occupy 0 and 1, so a method at slot k needs k - 2
+ * placeholders ahead of it. */
+class TRendererBase
+{
+public:
+	u8 pad0[0x18];
+};
+
+class TRenderer : public TRendererBase
+{
+public:
+	virtual void vslot2();
+	virtual void vslot3();
+	virtual void vslot4();
+	virtual void vslot5();
+	virtual void vslot6();
+	virtual void vslot7();
+	virtual void vslot8();
+	virtual void vslot9();
+	virtual void vslot10();
+	virtual void vslot11();
+	virtual void vslot12();
+	virtual void vslot13();
+	virtual void Slot38();
+	virtual void Slot3C();
+	virtual void Slot40();
+	virtual void vslot17();
+	virtual void vslot18();
+	virtual void vslot19();
+	virtual void Slot50(s32, s32);
+	virtual void vslot21();
+	virtual void vslot22();
+	virtual void vslot23();
+	virtual void vslot24();
+	virtual void vslot25();
+	virtual void vslot26();
+	virtual void vslot27();
+	virtual void vslot28();
+	virtual void vslot29();
+	virtual void vslot30();
+	virtual void Slot7C();
+	virtual void vslot32();
+	virtual void vslot33();
+	virtual void Slot88(void*);
+	virtual void vslot35();
+	virtual s32 Slot90();
+};
+
 extern "C" {
 
 M2C_UNK SetPosAng__15TEnemyParalysisFPC5RwV3dPC6sAngle(
@@ -1004,7 +1057,7 @@ void fn_8_990C4(void* arg0, M2C_UNK arg_sp0)
 	u8* var_r29_2;
 
 	if ((s32)M2C_FIELD(arg0, s32*, 0x28C) != 0) {
-		M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x90)();
+		((TRenderer*)arg0)->Slot90();
 		fn_80113874();
 		fn_80113940();
 		fn_801138B4();
@@ -1067,7 +1120,7 @@ void fn_8_99254(void* arg0)
 		var_r31 += 0x14;
 		var_r30 += 1;
 	} while (var_r30 < 2);
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*), 0x90)(arg0);
+	((TRenderer*)arg0)->Slot90();
 	fn_80113874();
 	fn_8014FF2C(M2C_FIELD(arg0, void**, 0xE8));
 	if ((u32)M2C_FIELD(arg0, u32*, 0x2E8) != 0U) {
@@ -1586,7 +1639,7 @@ void fn_8_9A188(void* arg0, s32 arg1)
 				fn_800E1208(0xF, 0);
 				M2C_FIELD(arg0, s32*, 0x278) = -1;
 			}
-			M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*), 0x3C)(arg0);
+			((TRenderer*)arg0)->Slot3C();
 			return;
 		case 1:
 			M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
@@ -2093,7 +2146,7 @@ void fn_8_9AB68(void* arg0, u32 arg1, s32 arg2)
 						fn_800E1208(0xF, 0);
 						M2C_FIELD(arg0, s32*, 0x278) = -1;
 					}
-					M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*), 0x3C)(arg0);
+					((TRenderer*)arg0)->Slot3C();
 					return;
 				case 1: /* switch 5 */
 					M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
@@ -2796,7 +2849,7 @@ void* fn_8_9C4BC(void* arg0, s16 arg1)
 	return arg0;
 }
 
-TObject* fn_8_9C694(TObject* arg0)
+TObject* fn_8_9C694(TObject* arg0, TObject* arg1)
 {
 	TEnemyParalysis* temp_r3_2;
 	TEnemyParalysis* var_r0_3;
@@ -2925,7 +2978,7 @@ TObject* fn_8_9CA9C(void)
 
 	var_r0 = (TObject*)fn_80018A34(lbl_8042C148, 0x58C);
 	if (var_r0 != NULL) {
-		var_r0 = fn_8_9C694(lbl_8042C10C);
+		var_r0 = fn_8_9C694((TObject*)var_r0, lbl_8042C10C);
 	}
 	return var_r0;
 }
@@ -3116,8 +3169,11 @@ void captureObjectLoad(M2C_UNK arg_sp0)
 
 void captureObjectCreate(void)
 {
-	if (fn_80018A34(lbl_8042C148, 0x58C) != NULL) {
-		fn_8_9C694(lbl_8042C10C);
+	TEnemyParalysis* temp_r3;
+
+	temp_r3 = fn_80018A34(lbl_8042C148, 0x58C);
+	if (temp_r3 != NULL) {
+		fn_8_9C694((TObject*)temp_r3, lbl_8042C10C);
 	}
 }
 

--- a/src/rel/e_capture_collision_stage11.cpp
+++ b/src/rel/e_capture_collision_stage11.cpp
@@ -21,6 +21,7 @@ typedef struct TObject {
 	/* 0x44 */ s32 unk44;   /* inferred */
 } TObject;                  /* size >= 0x48 */
 
+extern "C" {
 void* __ct__7TObjectFP7TObject(TObject* self, TObject* arg0); /* extern */
 void* __dt__7TObjectFv(TObject* self, s16 destroyFlag);       /* extern */
 M2C_UNK dtor_8005BD3C(void*, M2C_UNK);                        /* extern */
@@ -31,6 +32,7 @@ s32 fn_8005B9F0(s32);                                         /* extern */
 M2C_UNK fn_8005BE6C(M2C_UNK*);                                /* extern */
 M2C_UNK fn_800A31B8(s32);                                     /* extern */
 M2C_UNK fn_8_9CAF0(s32);                                      /* extern */
+}
 extern TObject* lbl_8042C10C;
 extern s32 lbl_8042C148;
 extern f32 lbl_8_rodata_1704;

--- a/src/rel/e_flyer_stage11.cpp
+++ b/src/rel/e_flyer_stage11.cpp
@@ -18,6 +18,59 @@ public:
 	virtual void Release(s32, s32);
 };
 
+/* The renderer class keeps its vtable pointer at object offset 0x18, which is
+ * what a polymorphic class derived from a 0x18-byte non-polymorphic base
+ * looks like: the base's data is laid out first and `this` is not adjusted,
+ * exactly as retail's `lwz r12, 0x18(r3)` reads it. Slot numbers are the
+ * retail vtable offsets divided by four, and the two implicit deleting
+ * destructor slots occupy 0 and 1, so a method at slot k needs k - 2
+ * placeholders ahead of it. */
+class TRendererBase
+{
+public:
+	u8 pad0[0x18];
+};
+
+class TRenderer : public TRendererBase
+{
+public:
+	virtual void vslot2();
+	virtual void vslot3();
+	virtual void vslot4();
+	virtual void vslot5();
+	virtual void vslot6();
+	virtual void vslot7();
+	virtual void vslot8();
+	virtual void vslot9();
+	virtual void vslot10();
+	virtual void vslot11();
+	virtual void vslot12();
+	virtual void vslot13();
+	virtual void Slot38();
+	virtual void Slot3C();
+	virtual void Slot40();
+	virtual void vslot17();
+	virtual void vslot18();
+	virtual void vslot19();
+	virtual void Slot50(s32, s32);
+	virtual void vslot21();
+	virtual void vslot22();
+	virtual void vslot23();
+	virtual void vslot24();
+	virtual void vslot25();
+	virtual void vslot26();
+	virtual void vslot27();
+	virtual void vslot28();
+	virtual void vslot29();
+	virtual void vslot30();
+	virtual void Slot7C();
+	virtual void vslot32();
+	virtual void vslot33();
+	virtual void Slot88(void*);
+	virtual void vslot35();
+	virtual s32 Slot90();
+};
+
 extern "C" {
 
 void* __ct__10HAnimClassFv(void* self);                                          /* extern */
@@ -662,7 +715,7 @@ void fn_8_A325C(void* arg0)
 		temp_r3                        = M2C_FIELD(arg0, void**, 0xB0);
 		M2C_FIELD(temp_r3, s32*, 0x18) = (s32)(M2C_FIELD(temp_r3, s32*, 0x18) | 0x01000000);
 	}
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*), 0x7C)(arg0);
+	((TRenderer*)arg0)->Slot7C();
 	temp_r0 = M2C_FIELD(lbl_8042C180, u8*, 0x24);
 	if ((((s8)temp_r0 == 4) || ((s8)temp_r0 == 8))
 	    && (((s32)M2C_FIELD(&lbl_8029C310, s32*, 0x2C) == 4)
@@ -673,7 +726,7 @@ void fn_8_A325C(void* arg0)
 		M2C_FIELD(temp_r3_3, s32*, 0x18) = (s32)(M2C_FIELD(temp_r3_3, s32*, 0x18) | 0x200);
 	}
 	fn_8005BC04((u8*)arg0 + 0xB0);
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*), 0x40)(arg0);
+	((TRenderer*)arg0)->Slot40();
 	temp_r0_2 = M2C_FIELD(arg0, s32*, 0x230);
 	if (temp_r0_2 != -1) {
 		temp_r3_4 = lbl_802AD070[temp_r0_2];
@@ -684,8 +737,7 @@ void fn_8_A325C(void* arg0)
 				fn_8011CB64((u8*)arg0 + 0x140,
 				    (s8)M2C_FIELD(
 				        ((u8*)temp_r30 + (s8)M2C_FIELD(temp_r30, u8*, 0x3A)), u8*, 0x110));
-				M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*, void*), 0x88)(
-				    arg0, (u8*)arg0 + 0x140);
+				((TRenderer*)arg0)->Slot88((u8*)arg0 + 0x140);
 			}
 		}
 	}
@@ -885,7 +937,7 @@ void fn_8_A38F8(void* arg0)
 
 void fn_8_A39C8(void* arg0)
 {
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x90)();
+	((TRenderer*)arg0)->Slot90();
 	fn_80113874();
 	fn_80113940();
 	fn_801138B4();
@@ -896,7 +948,7 @@ void fn_8_A39C8(void* arg0)
 
 void fn_8_A3A20(void* arg0)
 {
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x90)();
+	((TRenderer*)arg0)->Slot90();
 	fn_80113874();
 	fn_8014FF2C(M2C_FIELD(arg0, s32*, 0xE8));
 	if (((s32)M2C_FIELD(arg0, s32*, 0x2E4) != 0) && ((u32)M2C_FIELD(arg0, u32*, 0x2A0) != 0U)) {
@@ -1034,13 +1086,12 @@ void fn_8_A3C88(M2C_UNK* arg0)
 		fn_8019EE04(M2C_FIELD(temp_r3, s32*, 4));
 	}
 	fn_800A5B34(arg0);
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(M2C_UNK*), 0x38)(arg0);
+	((TRenderer*)arg0)->Slot38();
 	temp_r3_2 = M2C_FIELD(arg0, void***, 0x240);
 	if (temp_r3_2 != NULL) {
 		M2C_FIELD(*temp_r3_2, M2C_UNK(**)(M2C_UNK*), 0xC)(arg0);
 	}
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(M2C_UNK*, s32, M2C_UNK), 0x50)(
-	    arg0, M2C_FIELD(arg0, s32*, 0x19C), 1);
+	((TRenderer*)arg0)->Slot50(M2C_FIELD(arg0, s32*, 0x19C), 1);
 	fn_8_A549C(arg0);
 	fn_800A3D48(arg0);
 	if ((u32)M2C_FIELD(arg0, u32*, 0x280) != 0U) {
@@ -1176,7 +1227,7 @@ void fn_8_A4140(void* arg0, s32 arg1)
 				sp6C = M2C_FIELD(arg0, s32*, 0x230);
 				fn_80100D24(&sp8, 0);
 			}
-			M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*), 0x3C)(arg0);
+			((TRenderer*)arg0)->Slot3C();
 			return;
 		case 1:
 			M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
@@ -1188,11 +1239,14 @@ void fn_8_A4230(void* arg0, s32 arg1)
 {
 	switch (arg1) { /* irregular */
 		case 0:
-			M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x3C)();
-			return;
+			((TRenderer*)arg0)->Slot3C();
+			break;
 		case 1:
 			M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
-			return;
+			break;
+		case 2:
+		case 3:
+			break;
 	}
 }
 
@@ -1365,7 +1419,7 @@ void fn_8_A44D4(M2C_UNK* arg0, s32 arg1, s32 arg2)
 		case 36:            /* switch 1 */
 			switch (arg2) { /* switch 5; irregular */
 				case 0:     /* switch 5 */
-					M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x3C)();
+					((TRenderer*)arg0)->Slot3C();
 					return;
 				case 1: /* switch 5 */
 					M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
@@ -1394,7 +1448,7 @@ void fn_8_A44D4(M2C_UNK* arg0, s32 arg1, s32 arg2)
 						sp6C = M2C_FIELD(arg0, s32*, 0x230);
 						fn_80100D24(&sp8, 0);
 					}
-					M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(M2C_UNK*), 0x3C)(arg0);
+					((TRenderer*)arg0)->Slot3C();
 					return;
 				case 1: /* switch 6 */
 					M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
@@ -1697,7 +1751,7 @@ void fn_8_A4E44(M2C_UNK* arg0)
 			spA0 = M2C_FIELD(arg0, f32*, 0x2F8);
 			spA4 = M2C_FIELD(arg0, f32*, 0x2FC);
 			spA8 = M2C_FIELD(arg0, f32*, 0x300);
-			spC4 = M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), s32(**)(M2C_UNK*), 0x90)(arg0);
+			spC4 = ((TRenderer*)arg0)->Slot90();
 			fn_8_A9C6C(&sp88);
 			M2C_FIELD(arg0, s32*, 0x2E4) = 0;
 			if ((u32)lbl_8042C388 != 0U) {
@@ -1732,7 +1786,7 @@ void fn_8_A4E44(M2C_UNK* arg0)
 			sp68 = M2C_FIELD(arg0, f32*, 0x2EC);
 			sp6C = M2C_FIELD(arg0, f32*, 0x2F0);
 			sp70 = M2C_FIELD(arg0, f32*, 0x2F4);
-			sp84 = M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), s32(**)(M2C_UNK*), 0x90)(arg0);
+			sp84 = ((TRenderer*)arg0)->Slot90();
 			fn_8_A8B60(&sp5C);
 			M2C_FIELD(arg0, s32*, 0x2E4) = 0;
 			return;
@@ -2176,7 +2230,7 @@ void* fn_8_A5E08(void* arg0, s16 arg1)
 	return arg0;
 }
 
-M2C_UNK* fn_8_A5F50(M2C_UNK* arg0)
+M2C_UNK* fn_8_A5F50(M2C_UNK* arg0, void* arg1)
 {
 	s32 sp8;
 	s32 spC, sp10, sp14, sp18, sp1C, sp20, sp24, sp28;
@@ -2414,7 +2468,7 @@ M2C_UNK* fn_8_A66D4(void)
 
 	var_r0 = fn_80018A34(lbl_8042C148, 0x3C4);
 	if (var_r0 != NULL) {
-		var_r0 = fn_8_A5F50(lbl_8042C10C);
+		var_r0 = fn_8_A5F50(var_r0, lbl_8042C10C);
 	}
 	return var_r0;
 }
@@ -2564,8 +2618,11 @@ void flyerObjectLoad(void)
 
 void flyerObjectCreate(void)
 {
-	if (fn_80018A34(lbl_8042C148, 0x3C4) != NULL) {
-		fn_8_A5F50(lbl_8042C10C);
+	M2C_UNK* temp_r3;
+
+	temp_r3 = fn_80018A34(lbl_8042C148, 0x3C4);
+	if (temp_r3 != NULL) {
+		fn_8_A5F50(temp_r3, lbl_8042C10C);
 	}
 }
 

--- a/src/rel/e_rinoliner_collision_stage11.cpp
+++ b/src/rel/e_rinoliner_collision_stage11.cpp
@@ -549,7 +549,7 @@ void fn_8_B533C(void* arg0, s32 arg1)
 			M2C_FIELD(arg0, s32*, 0x18)
 			    = (s32)M2C_FIELD(M2C_FIELD(arg0, void**, 0x14), s32*, 0x2B0);
 			M2C_FIELD(arg0, s32*, 0x10) = 2;
-			return;
+			break;
 		case 1:
 			if (fn_8_B0A74(M2C_FIELD(arg0, void**, 0x14)) != 0) {
 				temp_r0                     = M2C_FIELD(arg0, s32*, 0x18) - 1;
@@ -561,7 +561,10 @@ void fn_8_B533C(void* arg0, s32 arg1)
 					((TObjectDispatch*)arg0)->Release((s32)M2C_FIELD(arg0, s32*, 4), 0);
 				}
 			}
-			return;
+			break;
+		case 2:
+		case 3:
+			break;
 	}
 }
 
@@ -587,7 +590,7 @@ void fn_8_B5428(void* arg0, s32 arg1)
 		case 0:
 			M2C_FIELD(arg0, s32*, 0x1C) = 0xF0;
 			M2C_FIELD(arg0, s32*, 0x10) = 0x24;
-			return;
+			break;
 		case 1:
 			temp_r0                     = M2C_FIELD(arg0, s32*, 0x1C) - 1;
 			M2C_FIELD(arg0, s32*, 0x1C) = temp_r0;
@@ -598,7 +601,10 @@ void fn_8_B5428(void* arg0, s32 arg1)
 				M2C_FIELD(arg0, s32*, 4) = temp_r31;
 				((TObjectDispatch*)arg0)->Release((s32)M2C_FIELD(arg0, s32*, 4), 0);
 			}
-			return;
+			break;
+		case 2:
+		case 3:
+			break;
 	}
 }
 
@@ -624,7 +630,7 @@ void fn_8_B5504(void* arg0, s32 arg1)
 		case 0:
 			M2C_FIELD(arg0, s32*, 0x18) = 1;
 			M2C_FIELD(arg0, s32*, 0x10) = 0x20;
-			return;
+			break;
 		case 1:
 			temp_r0                     = M2C_FIELD(arg0, s32*, 0x18) - 1;
 			M2C_FIELD(arg0, s32*, 0x18) = temp_r0;
@@ -635,7 +641,10 @@ void fn_8_B5504(void* arg0, s32 arg1)
 				M2C_FIELD(arg0, s32*, 4) = temp_r31;
 				((TObjectDispatch*)arg0)->Release((s32)M2C_FIELD(arg0, s32*, 4), 0);
 			}
-			return;
+			break;
+		case 2:
+		case 3:
+			break;
 	}
 }
 

--- a/src/rel/e_rinoliner_stage11.cpp
+++ b/src/rel/e_rinoliner_stage11.cpp
@@ -862,7 +862,7 @@ void* fn_8_B3CC4(void* arg0, s16 arg1)
 	return arg0;
 }
 
-TObject* fn_8_B3E0C(TObject* arg0)
+TObject* fn_8_B3E0C(TObject* arg0, TObject* arg1)
 {
 	f32 sp30;
 	f32 sp2C;
@@ -1071,7 +1071,7 @@ TEnemyParalysis* fn_8_B4394(void)
 
 	var_r0 = fn_80018A34(lbl_8042C148, 0x320);
 	if (var_r0 != NULL) {
-		var_r0 = (TEnemyParalysis*)fn_8_B3E0C(lbl_8042C10C);
+		var_r0 = (TEnemyParalysis*)fn_8_B3E0C((TObject*)var_r0, lbl_8042C10C);
 	}
 	return var_r0;
 }
@@ -1255,8 +1255,11 @@ void rinolinerObjectLoad(void)
 
 void rinolinerObjectCreate(void)
 {
-	if (fn_80018A34(lbl_8042C148, 0x320) != NULL) {
-		fn_8_B3E0C(lbl_8042C10C);
+	TEnemyParalysis* temp_r3;
+
+	temp_r3 = fn_80018A34(lbl_8042C148, 0x320);
+	if (temp_r3 != NULL) {
+		fn_8_B3E0C((TObject*)temp_r3, lbl_8042C10C);
 	}
 }
 

--- a/src/rel/e_strategy_flyer_stage11.cpp
+++ b/src/rel/e_strategy_flyer_stage11.cpp
@@ -89,6 +89,7 @@ struct _struct_lbl_8_rodata_17F4_0xC {
 	/* 0x8 */ f32 unk8; /* inferred */
 }; /* size = 0xC */
 
+extern "C" {
 void* __ct__10HAnimClassFv(void* self);                                   /* extern */
 void* __ct__7TObjectFP7TObject(TObject* self, TObject* arg0);             /* extern */
 M2C_UNK __dl__FPv(void* arg0);                                            /* extern */
@@ -175,6 +176,7 @@ M2C_UNK fn_8_D06B8(u32);                                                  /* ext
 M2C_UNK fn_8_D07F4(u32);                                                  /* extern */
 s32 fn_8_D2190();                                                         /* extern */
 M2C_UNK fn_8_D8E90(M2C_UNK, M2C_UNK, M2C_UNK);                            /* extern */
+}
 extern M2C_UNK fn_8005BF88;
 extern M2C_UNK lbl_80239984;
 extern M2C_UNK lbl_8029BBD0;
@@ -254,6 +256,59 @@ public:
 	virtual void vslot2();
 	virtual void vslot3();
 	virtual void Release(s32, s32);
+};
+
+/* The renderer class keeps its vtable pointer at object offset 0x18, which is
+ * what a polymorphic class derived from a 0x18-byte non-polymorphic base
+ * looks like: the base's data is laid out first and `this` is not adjusted,
+ * exactly as retail's `lwz r12, 0x18(r3)` reads it. Slot numbers are the
+ * retail vtable offsets divided by four, and the two implicit deleting
+ * destructor slots occupy 0 and 1, so a method at slot k needs k - 2
+ * placeholders ahead of it. */
+class TRendererBase
+{
+public:
+	u8 pad0[0x18];
+};
+
+class TRenderer : public TRendererBase
+{
+public:
+	virtual void vslot2();
+	virtual void vslot3();
+	virtual void vslot4();
+	virtual void vslot5();
+	virtual void vslot6();
+	virtual void vslot7();
+	virtual void vslot8();
+	virtual void vslot9();
+	virtual void vslot10();
+	virtual void vslot11();
+	virtual void vslot12();
+	virtual void vslot13();
+	virtual void Slot38();
+	virtual void Slot3C();
+	virtual void Slot40();
+	virtual void vslot17();
+	virtual void vslot18();
+	virtual void vslot19();
+	virtual void Slot50(s32, s32);
+	virtual void vslot21();
+	virtual void vslot22();
+	virtual void vslot23();
+	virtual void vslot24();
+	virtual void vslot25();
+	virtual void vslot26();
+	virtual void vslot27();
+	virtual void vslot28();
+	virtual void vslot29();
+	virtual void vslot30();
+	virtual void Slot7C();
+	virtual void vslot32();
+	virtual void vslot33();
+	virtual void Slot88(void*);
+	virtual void vslot35();
+	virtual s32 Slot90();
 };
 
 extern "C" {
@@ -1436,8 +1491,7 @@ void fn_8_9FA94(void* arg0, M2C_UNK arg_sp0)
 	if (temp_r3 != NULL) {
 		M2C_FIELD(*temp_r3, M2C_UNK(**)(void*), 0xC)(arg0);
 	}
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*, s32, M2C_UNK), 0x50)(
-	    arg0, M2C_FIELD(arg0, s32*, 0x19C), 1);
+	((TRenderer*)arg0)->Slot50(M2C_FIELD(arg0, s32*, 0x19C), 1);
 	temp_r3_2 = M2C_FIELD(arg0, void**, 0xE8);
 	if (temp_r3_2 != NULL) {
 		temp_r31 = M2C_FIELD(temp_r3_2, s32*, 4);
@@ -1568,14 +1622,17 @@ void fn_8_9FF78(void* arg0, s32 arg1)
 	switch (arg1) { /* irregular */
 		case 0:
 			fn_8005BC04((u8*)arg0 + 0xB0);
-			return;
+			break;
 		case 1:
 			if ((s8)M2C_FIELD(lbl_8042C180, u8*, 0x20) == 0) {
 				fn_80019898(&lbl_8029C310, 0);
 				M2C_FIELD(&lbl_8029C310, s32*, 0x290) = 0;
 				M2C_FIELD(arg0, u16*, 4)              = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
 			}
-			return;
+			break;
+		case 2:
+		case 3:
+			break;
 	}
 }
 

--- a/src/rel/e_strategy_magician_stage11.cpp
+++ b/src/rel/e_strategy_magician_stage11.cpp
@@ -76,6 +76,59 @@ typedef struct TObject {
 	/* 0x34C */ f32 unk34C;        /* inferred */
 } TObject;                         /* size >= 0x350 */
 
+/* The renderer class keeps its vtable pointer at object offset 0x18, which is
+ * what a polymorphic class derived from a 0x18-byte non-polymorphic base
+ * looks like: the base's data is laid out first and `this` is not adjusted,
+ * exactly as retail's `lwz r12, 0x18(r3)` reads it. Slot numbers are the
+ * retail vtable offsets divided by four, and the two implicit deleting
+ * destructor slots occupy 0 and 1, so a method at slot k needs k - 2
+ * placeholders ahead of it. */
+class TRendererBase
+{
+public:
+	u8 pad0[0x18];
+};
+
+class TRenderer : public TRendererBase
+{
+public:
+	virtual void vslot2();
+	virtual void vslot3();
+	virtual void vslot4();
+	virtual void vslot5();
+	virtual void vslot6();
+	virtual void vslot7();
+	virtual void vslot8();
+	virtual void vslot9();
+	virtual void vslot10();
+	virtual void vslot11();
+	virtual void vslot12();
+	virtual void vslot13();
+	virtual void Slot38();
+	virtual void Slot3C();
+	virtual void Slot40();
+	virtual void vslot17();
+	virtual void vslot18();
+	virtual void vslot19();
+	virtual void Slot50(s32, s32);
+	virtual void vslot21();
+	virtual void vslot22();
+	virtual void vslot23();
+	virtual void vslot24();
+	virtual void vslot25();
+	virtual void vslot26();
+	virtual void vslot27();
+	virtual void vslot28();
+	virtual void vslot29();
+	virtual void vslot30();
+	virtual void Slot7C();
+	virtual void vslot32();
+	virtual void vslot33();
+	virtual void Slot88(void*);
+	virtual void vslot35();
+	virtual s32 Slot90();
+};
+
 extern "C" {
 
 void* __ct__7TObjectFP7TObject(void*, void*); /* extern */
@@ -597,7 +650,7 @@ void fn_8_AB7AC(void* arg0)
 	if (M2C_FIELD(arg0, f32*, 0x2B8) != lbl_8_rodata_1AC8) {
 		M2C_ERROR(/* unknown instruction: cror eq, gt, eq */);
 		if (M2C_FIELD(arg0, f32*, 0x2B4) == lbl_8_rodata_1ABC) {
-			M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x90)();
+			((TRenderer*)arg0)->Slot90();
 			fn_80113874();
 			sp8  = M2C_FIELD(&lbl_8_rodata_1A84, s32*, 0);
 			spC  = M2C_FIELD(&lbl_8_rodata_1A84, s32*, 4);
@@ -643,13 +696,12 @@ void fn_8_AB890(void* arg0)
 		M2C_FIELD(arg0, f32*, 0x148) = (f32)M2C_FIELD(arg0, f32*, 0x90);
 	}
 	fn_800A5B34(arg0);
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*), 0x38)(arg0);
+	((TRenderer*)arg0)->Slot38();
 	temp_r3 = M2C_FIELD(arg0, void***, 0x248);
 	if (temp_r3 != NULL) {
 		M2C_FIELD(*temp_r3, M2C_UNK(**)(void*), 0xC)(arg0);
 	}
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*, s32, M2C_UNK), 0x50)(
-	    arg0, M2C_FIELD(arg0, s32*, 0x19C), 1);
+	((TRenderer*)arg0)->Slot50(M2C_FIELD(arg0, s32*, 0x19C), 1);
 	fn_8_AE604(arg0);
 	fn_800A3D48(arg0);
 	if ((fn_80017800(arg0) != 0) && ((u32)M2C_FIELD(arg0, u32*, 0x38) != 0U)) {
@@ -1253,11 +1305,14 @@ void fn_8_ACDC4(void* arg0, s32 arg1)
 {
 	switch (arg1) { /* irregular */
 		case 0:
-			M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x3C)();
-			return;
+			((TRenderer*)arg0)->Slot3C();
+			break;
 		case 1:
 			M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
-			return;
+			break;
+		case 2:
+		case 3:
+			break;
 	}
 }
 }

--- a/src/rel/e_strategy_rinoliner_stage11.cpp
+++ b/src/rel/e_strategy_rinoliner_stage11.cpp
@@ -82,7 +82,7 @@ void fn_8_AFB20(void* arg0, s32 arg1)
 	switch (arg1) { /* irregular */
 		case 0:
 			M2C_FIELD(arg0, s32*, 0x10) = 0x3A;
-			return;
+			break;
 		case 1:
 			if ((s32)M2C_FIELD(M2C_FIELD(arg0, void**, 0x14), s32*, 0x2D8) == 0) {
 				M2C_FIELD(arg0, s32*, 8) = (s32)M2C_FIELD(arg0, s32*, 4);
@@ -90,7 +90,10 @@ void fn_8_AFB20(void* arg0, s32 arg1)
 				M2C_FIELD(arg0, s32*, 4) = 3;
 				((TObjectDispatch*)arg0)->Release((s32)M2C_FIELD(arg0, s32*, 4), 0);
 			}
-			return;
+			break;
+		case 2:
+		case 3:
+			break;
 	}
 }
 

--- a/src/rel/e_turtle_stage11.cpp
+++ b/src/rel/e_turtle_stage11.cpp
@@ -214,6 +214,59 @@ public:
 	virtual void Release(s32, s32);
 };
 
+/* The renderer class keeps its vtable pointer at object offset 0x18, which is
+ * what a polymorphic class derived from a 0x18-byte non-polymorphic base
+ * looks like: the base's data is laid out first and `this` is not adjusted,
+ * exactly as retail's `lwz r12, 0x18(r3)` reads it. Slot numbers are the
+ * retail vtable offsets divided by four, and the two implicit deleting
+ * destructor slots occupy 0 and 1, so a method at slot k needs k - 2
+ * placeholders ahead of it. */
+class TRendererBase
+{
+public:
+	u8 pad0[0x18];
+};
+
+class TRenderer : public TRendererBase
+{
+public:
+	virtual void vslot2();
+	virtual void vslot3();
+	virtual void vslot4();
+	virtual void vslot5();
+	virtual void vslot6();
+	virtual void vslot7();
+	virtual void vslot8();
+	virtual void vslot9();
+	virtual void vslot10();
+	virtual void vslot11();
+	virtual void vslot12();
+	virtual void vslot13();
+	virtual void Slot38();
+	virtual void Slot3C();
+	virtual void Slot40();
+	virtual void vslot17();
+	virtual void vslot18();
+	virtual void vslot19();
+	virtual void Slot50(s32, s32);
+	virtual void vslot21();
+	virtual void vslot22();
+	virtual void vslot23();
+	virtual void vslot24();
+	virtual void vslot25();
+	virtual void vslot26();
+	virtual void vslot27();
+	virtual void vslot28();
+	virtual void vslot29();
+	virtual void vslot30();
+	virtual void Slot7C();
+	virtual void vslot32();
+	virtual void vslot33();
+	virtual void Slot88(void*);
+	virtual void vslot35();
+	virtual s32 Slot90();
+};
+
 extern "C" {
 void Debug__7TObjectFv(void);
 void Error__7TObjectFPc(void);
@@ -1730,7 +1783,7 @@ void fn_8_BF9A4(void) { }
 
 void fn_8_BF9A8(void* arg0)
 {
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x90)();
+	((TRenderer*)arg0)->Slot90();
 	fn_80113874();
 	fn_8011398C(turtleObjectGlobalA, M2C_FIELD(arg0, s32*, 0x310));
 	fn_8014FF2C(M2C_FIELD(arg0, s32*, 0xE8));
@@ -2157,7 +2210,7 @@ void fn_8_C0690(void* arg0, s32 arg1)
 {
 	switch (arg1) { /* irregular */
 		case 0:
-			M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x3C)();
+			((TRenderer*)arg0)->Slot3C();
 			break;
 		case 1:
 			M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
@@ -2505,7 +2558,7 @@ void fn_8_C0D74(void* arg0, u32 arg1, s32 arg2)
 		case 29:            /* switch 1 */
 			switch (arg2) { /* switch 6; irregular */
 				case 0:     /* switch 6 */
-					M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x3C)();
+					((TRenderer*)arg0)->Slot3C();
 					return;
 				case 1: /* switch 6 */
 					M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);

--- a/src/rel/o_colli_communication_stage11.cpp
+++ b/src/rel/o_colli_communication_stage11.cpp
@@ -6,6 +6,59 @@ typedef s32 M2C_UNK;
 #define M2C_ERROR(...)
 #define M2C_BITWISE(type, value) (*(type*)&(value))
 
+/* The renderer class keeps its vtable pointer at object offset 0x18, which is
+ * what a polymorphic class derived from a 0x18-byte non-polymorphic base
+ * looks like: the base's data is laid out first and `this` is not adjusted,
+ * exactly as retail's `lwz r12, 0x18(r3)` reads it. Slot numbers are the
+ * retail vtable offsets divided by four, and the two implicit deleting
+ * destructor slots occupy 0 and 1, so a method at slot k needs k - 2
+ * placeholders ahead of it. */
+class TRendererBase
+{
+public:
+	u8 pad0[0x18];
+};
+
+class TRenderer : public TRendererBase
+{
+public:
+	virtual void vslot2();
+	virtual void vslot3();
+	virtual void vslot4();
+	virtual void vslot5();
+	virtual void vslot6();
+	virtual void vslot7();
+	virtual void vslot8();
+	virtual void vslot9();
+	virtual void vslot10();
+	virtual void vslot11();
+	virtual void vslot12();
+	virtual void vslot13();
+	virtual void Slot38();
+	virtual void Slot3C();
+	virtual void Slot40();
+	virtual void vslot17();
+	virtual void vslot18();
+	virtual void vslot19();
+	virtual void Slot50(s32, s32);
+	virtual void vslot21();
+	virtual void vslot22();
+	virtual void vslot23();
+	virtual void vslot24();
+	virtual void vslot25();
+	virtual void vslot26();
+	virtual void vslot27();
+	virtual void vslot28();
+	virtual void vslot29();
+	virtual void vslot30();
+	virtual void Slot7C();
+	virtual void vslot32();
+	virtual void vslot33();
+	virtual void Slot88(void*);
+	virtual void vslot35();
+	virtual s32 Slot90();
+};
+
 extern "C" {
 
 M2C_UNK __dl__FPv(void*); /* extern */
@@ -637,7 +690,7 @@ void fn_8_B1A90(void) { }
 
 void fn_8_B1A94(void* arg0)
 {
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x90)();
+	((TRenderer*)arg0)->Slot90();
 	fn_80113874();
 	fn_8014FF2C(M2C_FIELD(arg0, s32*, 0xE8));
 	fn_8014FF2C(M2C_FIELD(arg0, s32*, 0x310));
@@ -717,13 +770,12 @@ void fn_8_B1C1C(void* arg0)
 		M2C_FIELD(arg0, f32*, 0x148) = (f32)M2C_FIELD(arg0, f32*, 0x90);
 	}
 	fn_800A5B34(arg0);
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*), 0x38)(arg0);
+	((TRenderer*)arg0)->Slot38();
 	temp_r3 = M2C_FIELD(arg0, void***, 0x244);
 	if (temp_r3 != NULL) {
 		M2C_FIELD(*temp_r3, M2C_UNK(**)(void*), 0xC)(arg0);
 	}
-	M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(void*, s32, M2C_UNK), 0x50)(
-	    arg0, M2C_FIELD(arg0, s32*, 0x19C), 1);
+	((TRenderer*)arg0)->Slot50(M2C_FIELD(arg0, s32*, 0x19C), 1);
 	fn_8_B3598(arg0);
 	fn_800A3D48(arg0);
 	if ((s32)M2C_FIELD(arg0, s32*, 0x2E0) != 0) {
@@ -761,7 +813,7 @@ void fn_8_B1E38(void* arg0, s32 arg1)
 {
 	switch (arg1) { /* irregular */
 		case 0:
-			M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), M2C_UNK(**)(), 0x3C)();
+			((TRenderer*)arg0)->Slot3C();
 			return;
 		case 1:
 			M2C_FIELD(arg0, u16*, 4) = (u16)(M2C_FIELD(arg0, u16*, 4) | 1);
@@ -960,7 +1012,7 @@ void fn_8_B2224(void* arg0, s32 arg1)
 					sp40 = 0;
 				}
 				sp3C = 0x258;
-				sp44 = M2C_FIELD(M2C_FIELD(arg0, void**, 0x18), s32(**)(void*), 0x90)(arg0);
+				sp44 = ((TRenderer*)arg0)->Slot90();
 				fn_8_B5160(&sp14);
 				sp8  = M2C_FIELD(&lbl_8_rodata_1BB8, s32*, 0);
 				spC  = M2C_FIELD(&lbl_8_rodata_1BB8, s32*, 4);


### PR DESCRIPTION
Fifteen more functions are byte-exact. Game Code 69.00% -> 69.15%, 4894 ->
4909 matched functions. Zero units regress.

| unit | matched code | functions | fuzzy |
| --- | --- | --- | --- |
| `rel/e_rinoliner_collision_stage11` | 7.50% -> 13.13% | 20 -> 23 | 78.69% -> 78.93% |
| `rel/e_strategy_rinoliner_stage11` | 5.35% -> 9.60% | 6 -> 7 | 82.18% -> 82.39% |
| `rel/e_rinoliner_stage11` | 6.89% -> 8.92% | 3 -> 5 | 84.09% -> 84.27% |
| `rel/e_flyer_stage11` | 8.01% -> 9.38% | 14 -> 17 | 80.36% -> 80.53% |
| `rel/e_strategy_magician_stage11` | 0.50% -> 1.59% | 3 -> 4 | 81.82% -> 81.96% |
| `rel/e_turtle_stage11` | 16.46% -> 17.35% | 25 -> 27 | 94.51% |
| `rel/e_strategy_flyer_stage11` | 9.35% -> 10.18% | 31 -> 32 | 90.32% -> 90.37% |
| `rel/e_capture` | 3.07% -> 3.81% | 9 -> 11 | 85.50% -> 85.58% |

## Two units were calling C++-mangled symbols that cannot exist

`e_strategy_flyer_stage11` and `e_capture_collision_stage11` open their
`extern "C" {` block *after* their extern declarations instead of before it.
Every call in those files therefore went to a mangled name:

```
U fn_80018A34__Fii
U fn_800189A4__FiP7TObject
U __ct__7TObjectFP7TObject__FP7TObjectP7TObject
```

The second one shows what happens when an already-mangled retail name is
mangled a second time. Nothing links these; the units are `NonMatching`, so
their retail objects are what the RELs actually use, and the defect was
invisible in the SHA-1 gate while costing accuracy on every function that
makes a call.

Wrapping the declaration run in `extern "C"` moved **every** function in
`e_strategy_flyer_stage11` - 48 of them - and made two exact on its own.
A sweep of every compiled object for undefined `__F` symbols confirms these
were the only two units affected; what remains is `__dl__FPv`, which is
genuinely `operator delete`.

## The offset-0x18 vtable, applied to the other five units carrying it

#507 established that a dispatch reading `lwz r12, 0x18(r3)` with `r3`
unchanged is a polymorphic class derived from a 0x18-byte non-polymorphic
base. Thirty more sites across `e_flyer_stage11`, `e_capture`,
`e_turtle_stage11`, `e_strategy_magician_stage11`,
`e_strategy_flyer_stage11` and `o_colli_communication_stage11` take the same
`TRenderer` shape, with named methods at slots 14, 15, 16, 20, 31, 34 and
36. Nineteen functions improve, two become exact, none regress.

## Seven switches were missing their empty upper cases

The mirror of the #506 idiom: there the source had a `case 4` retail does
not label, here the source is missing the empty `case 2` / `case 3` that
retail's dead `cmpwi rX, 0x4` proves are present. All seven matched on the
first build.

## Three more constructors had their `this` dropped

`captureObjectCreate`, `flyerObjectCreate` and `rinolinerObjectCreate`
repeat `wallObjectCreate` exactly: the allocation stays in `r3` and the
global goes to `r4`. Threading the allocation through the constructor and
its sibling loader made all six functions exact.

## Verification

- `python3 configure.py && ninja` - `18 files OK`; direct `sha1sum` against
  `config/G9SE8P/build.sha1` clean.
- Report comparison against `main`: zero units regressed on matched
  functions or fuzzy.
- `clang-format` clean on all ten files.