### PR TITLE
fix: revert the goal_ring fn_80150588 signature that cost fn_8_4D0CC

### DIFF
--- a/src/rel/goal_ring_stage11.cpp
+++ b/src/rel/goal_ring_stage11.cpp
@@ -56,7 +56,7 @@ void fn_8003C618(...);
 void fn_8003BF04(...);
 void dtor_8003C52C(...);
 void dtor_8005BD3C(...);
-void* fn_80150588(void*);
+void* fn_80150588(...);
 void fn_8015BB08(...);
 void fn_8015BBF8(...);
 void fn_80150958(void*);


### PR DESCRIPTION
#509 tripped the match-progress check: `fn_8_4D0CC` in
`rel/goal_ring_stage11` went 36.23% -> 35.84% fuzzy. This reverts the one
declaration responsible and restores it, with nothing else affected.

`fn_8_4D0CC` calls `fn_80150588` four times. Typing that symbol
`void* fn_80150588(void*)` removed its `crclr` but re-coloured the function
for a net loss. Putting the declaration back to `(...)` returns the function
to 36.23% and changes no other function in the unit.

## Why the sweep's own guard missed it

The per-function guard in #509 compared `objdiff-cli diff`'s per-symbol
`match_percent`. CI compares `report.json`'s `fuzzy_match_percent`. They are
not the same number and they do not move together: this function measured
34.99% -> 35.84% (an improvement) on the first metric while measuring
36.23% -> 35.84% (a regression) on the second, so the guard kept a change CI
rejects.

The remaining 70 signatures in #509 are clean under the report metric. A
full per-function comparison of `report.json` against the commit before
#509 shows **51 functions up, 0 down** once this one declaration is
reverted.

## Verification

- `python3 configure.py && ninja` - `18 files OK`; direct `sha1sum` against
  `config/G9SE8P/build.sha1` clean.
- `report.json` per-function comparison against the pre-#509 commit: 51 up,
  0 down.
- `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)