### PR TITLE
match: carve the rodata of five more stage11 units

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1719,7 +1719,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "rel/o_colli_communication_stage11.cpp",
-                extra_cflags=["-opt noschedule,nopeephole", "-bool off"],
+                extra_cflags=["-opt noschedule,nopeephole", "-pool off", "-bool off"],
             ),
             Object(
                 Matching,

--- a/src/rel/e_flyer_path_stage11.cpp
+++ b/src/rel/e_flyer_path_stage11.cpp
@@ -212,17 +212,34 @@ static M2C_UNK lbl_8_bss_19D0;
 static M2C_UNK lbl_8_bss_19D4;
 static M2C_UNK lbl_8_bss_1A18;
 static M2C_UNK magicianObjectEntry;
-static M2C_UNK lbl_8_rodata_19B8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_19E0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1A2C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1A38; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1A48; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1A54; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1A60; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1A6C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1A84; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1A94; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1AA0; /* unable to generate initializer: unknown type; const */
+extern const f32 lbl_8_rodata_19A4[1]  = { 20.0f };
+extern const f32 lbl_8_rodata_19A8[1]  = { -0.05999999865889549f };
+extern const f32 lbl_8_rodata_19AC[1]  = { -1000000.0f };
+extern const f32 lbl_8_rodata_19B0[1]  = { 4.0f };
+extern const f32 lbl_8_rodata_19B4[1]  = { 0.0054931640625f };
+extern const f64 lbl_8_rodata_19B8[1]  = { 4503601774854144.0 };
+extern const f32 lbl_8_rodata_19C0[5]  = { 0.0f, 0.0f, 0.0f, 1.5f, 0.0f };
+extern const f32 lbl_8_rodata_19D4[1]  = { 20.0f };
+extern const f32 lbl_8_rodata_19D8[1]  = { 0.0054931640625f };
+extern const f32 lbl_8_rodata_19DC[1]  = { 180.0f };
+extern const f64 lbl_8_rodata_19E0[1]  = { 4503601774854144.0 };
+extern const f32 lbl_8_rodata_19E8[1]  = { 0.0f };
+extern const f32 lbl_8_rodata_19EC[1]  = { 10430.380859375f };
+extern const f32 lbl_8_rodata_19F0[1]  = { 0.20000000298023224f };
+extern const f32 lbl_8_rodata_19F4[1]  = { 2.0f };
+extern const f32 lbl_8_rodata_19F8[13] = { -0.05999999865889549f, 0.0f, 0.0f, 1.5f, 0.0f, 0.0f,
+	0.0f, 1.5f, 0.0f, 0.0f, 0.0f, 1.5f, 0.0f };
+extern const f32 lbl_8_rodata_1A2C[3]  = { 13.0f, 20.0f, 0.0f };
+extern const f32 lbl_8_rodata_1A38[4]
+    = { 0.20000000298023224f, 0.4000000059604645f, 0.4000000059604645f, 0.4000000059604645f };
+extern const f32 lbl_8_rodata_1A48[3] = { 0.0f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1A54[3] = { 0.0f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1A60[3] = { 0.0f, 8.0f, 0.0f };
+extern const f32 lbl_8_rodata_1A6C[6] = { 0.0f, 8.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1A84[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+extern const f32 lbl_8_rodata_1A94[3] = { 20.0f, 1.0f, 20.0f };
+extern const f32 lbl_8_rodata_1AA0[3]
+    = { 0.20000000298023224f, 0.20000000298023224f, 0.20000000298023224f };
 
 void fn_8_A82A0(s32 arg0)
 {
@@ -1359,7 +1376,7 @@ void fn_8_AA69C(void* arg0)
 	s32 temp_r30;
 	void* temp_r3;
 
-	fn_800D5A64((u8*)arg0 + 0x40, &lbl_8_rodata_1AA0, &lbl_8_rodata_1AB0, lbl_8_rodata_1AB0);
+	fn_800D5A64((u8*)arg0 + 0x40, lbl_8_rodata_1AA0, &lbl_8_rodata_1AB0, lbl_8_rodata_1AB0);
 	M2C_FIELD(arg0, f32*, 0x50) = (f32)(M2C_FIELD(arg0, f32*, 0x50) + lbl_8_rodata_1AB4);
 	M2C_FIELD(arg0, f32*, 0x60) = (f32)(M2C_FIELD(arg0, f32*, 0x60) + lbl_8_rodata_1AB8);
 	if (M2C_FIELD(arg0, f32*, 0x50) > lbl_8_rodata_1ABC) {

--- a/src/rel/e_grass_stage11.cpp
+++ b/src/rel/e_grass_stage11.cpp
@@ -222,31 +222,33 @@ static M2C_UNK lbl_8_bss_1CD8;
 static M2C_UNK lbl_8_bss_1CDC;
 static M2C_UNK lbl_8_bss_1CE0;
 static M2C_UNK lbl_8_bss_1CE4;
-static M2C_UNK lbl_8_rodata_1F60;
-static M2C_UNK lbl_8_rodata_1F70; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1F78; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1F84; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1F90; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1F94; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1F98; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1F9C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FA0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FA8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FB0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FB8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FC4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FC8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FCC; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FD0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FD4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FD8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FF0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FF4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1FF8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2000; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2004; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2008; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_200C; /* unable to generate initializer: unknown type; const */
+extern const f32 lbl_8_rodata_1F60[1] = { 0.0f };
+extern const f32 lbl_8_rodata_1F64[1] = { 1.0f };
+extern const f32 lbl_8_rodata_1F68[1] = { 60.0f };
+extern const f64 lbl_8_rodata_1F70[1] = { 4503601774854144.0 };
+extern const f32 lbl_8_rodata_1F78[3] = { 0.0f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1F84[3] = { 0.0f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1F90[1] = { 1.0f };
+extern const f32 lbl_8_rodata_1F94[1] = { 0.019999999552965164f };
+extern const f32 lbl_8_rodata_1F98[1] = { 0.0f };
+extern const f32 lbl_8_rodata_1F9C[1] = { 1.0f };
+extern const f32 lbl_8_rodata_1FA0[1] = { 60.0f };
+extern const f32 lbl_8_rodata_1FA8[2] = { 1.75f, 0.0f };
+extern const f64 lbl_8_rodata_1FB0[1] = { 4503601774854144.0 };
+extern const f32 lbl_8_rodata_1FB8[3] = { 0.0f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1FC4[1] = { 100.0f };
+extern const f32 lbl_8_rodata_1FC8[1] = { 1.0f };
+extern const f32 lbl_8_rodata_1FCC[1] = { 2.5f };
+extern const f32 lbl_8_rodata_1FD0[1] = { 182.04444885253906f };
+extern const f32 lbl_8_rodata_1FD4[1] = { 0.0f };
+extern const f32 lbl_8_rodata_1FD8[6] = { 176.0f, 0.0f, 0.0f, 1.5f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1FF0[1] = { 60.0f };
+extern const f32 lbl_8_rodata_1FF4[1] = { 2.0f };
+extern const f64 lbl_8_rodata_1FF8[1] = { 4503601774854144.0 };
+extern const f32 lbl_8_rodata_2000[1] = { 0.0f };
+extern const f32 lbl_8_rodata_2004[1] = { 1.0f };
+extern const f32 lbl_8_rodata_2008[1] = { 30000.0f };
+extern const f32 lbl_8_rodata_200C[1] = { 24000.0f };
 
 void fn_8_C5FA4(s32 arg0)
 {
@@ -333,8 +335,8 @@ void fn_8_C606C(TObject* arg0, ...)
 			    M2C_FIELD(&lbl_8_data_18978[temp_r0_2] + var_r30, s32*, 0), temp_r0_2 * 0x14);
 			fn_8013F3A4(var_r31->unkFC);
 			fn_8013FC30(var_r31->unkFC);
-			fn_8020D02C(M2C_FIELD(var_r31->unkFC, void***, 0x20), &lbl_8_rodata_1F60, 0.0f);
-			fn_8020CC18(M2C_FIELD(var_r31->unkFC, void***, 0x20), &lbl_8_rodata_1F60, 0.0f);
+			fn_8020D02C(M2C_FIELD(var_r31->unkFC, void***, 0x20), (s32*)lbl_8_rodata_1F60, 0.0f);
+			fn_8020CC18(M2C_FIELD(var_r31->unkFC, void***, 0x20), (s32*)lbl_8_rodata_1F60, 0.0f);
 		}
 		var_r31 = (TObject*)((u8*)var_r31 + 4);
 		var_r30 += 4;
@@ -368,8 +370,8 @@ void fn_8_C606C(TObject* arg0, ...)
 			    M2C_FIELD(&lbl_8_data_18978[temp_r0_4] + var_r31_2, s32*, 0), temp_r0_4 * 0x14);
 			fn_8013F3A4(var_r30_2->unk110);
 			fn_8013FC30(var_r30_2->unk110);
-			fn_8020D02C(M2C_FIELD(var_r30_2->unk110, void***, 0x20), &lbl_8_rodata_1F60, 0.0f);
-			fn_8020CC18(M2C_FIELD(var_r30_2->unk110, void***, 0x20), &lbl_8_rodata_1F60, 0.0f);
+			fn_8020D02C(M2C_FIELD(var_r30_2->unk110, void***, 0x20), (s32*)lbl_8_rodata_1F60, 0.0f);
+			fn_8020CC18(M2C_FIELD(var_r30_2->unk110, void***, 0x20), (s32*)lbl_8_rodata_1F60, 0.0f);
 		}
 		var_r30_2 = (TObject*)((u8*)var_r30_2 + 4);
 		var_r31_2 += 4;

--- a/src/rel/e_rinoliner_collision_stage11.cpp
+++ b/src/rel/e_rinoliner_collision_stage11.cpp
@@ -172,74 +172,75 @@ static M2C_UNK rinoColObjectFieldTypes;  /* unable to generate initializer: unkn
 static M2C_UNK gap_04_000172D9_data;     /* unable to generate initializer: unknown type */
 static void* lbl_8_bss_1A90;
 static M2C_UNK rinoColObjectEntry;
-static M2C_UNK lbl_8_rodata_1C64;
-static M2C_UNK lbl_8_rodata_1C70;
-static M2C_UNK lbl_8_rodata_1C74;
-static M2C_UNK lbl_8_rodata_1C78;
-static M2C_UNK lbl_8_rodata_1C7C;
-static M2C_UNK lbl_8_rodata_1C80;
-static M2C_UNK lbl_8_rodata_1CA4;
-static M2C_UNK lbl_8_rodata_1CB8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1CC4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1CD0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1CDC; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1CE8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1CF4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D00; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D10; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D1C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D2C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D3C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D48; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D54; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D58; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D5C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D60; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D64; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D68; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D6C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D70; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D74; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D78; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D7C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D80; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D84; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D88; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D90; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D98; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1D9C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DA0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DA4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DA8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DAC; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DB0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DB4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DB8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DBC; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DC0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DC4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DC8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DCC; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DD0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DD4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DD8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DDC; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DE0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DE4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DE8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DEC; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DF0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DF4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DF8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1DFC; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1E00; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1E04; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1E08; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1E0C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1E10; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1E14; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1E18; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_1E1C; /* unable to generate initializer: unknown type; const */
+extern const f32 lbl_8_rodata_1C64[3] = { 0.0f, 2.0f, 0.0f };
+extern const f32 lbl_8_rodata_1C70[1] = { 20.0f };
+extern const f32 lbl_8_rodata_1C74[1] = { 100000000.0f };
+extern const f32 lbl_8_rodata_1C78[1] = { 2500.0f };
+extern const f32 lbl_8_rodata_1C7C[1] = { 0.0f };
+extern const f32 lbl_8_rodata_1C80[9]
+    = { 0.05000000074505806f, 0.0f, 0.0f, 1.5f, 0.0f, 0.0f, 0.0f, 1.5f, 0.0f };
+extern const f32 lbl_8_rodata_1CA4[5] = { 0.0f, 0.0f, 1.5f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1CB8[3] = { 0.0f, 1.5f, 0.0f };
+extern const f32 lbl_8_rodata_1CC4[3] = { 16.0f, 18.0f, 0.0f };
+extern const f32 lbl_8_rodata_1CD0[3] = { 0.0f, -10.0f, 0.0f };
+extern const f32 lbl_8_rodata_1CDC[3] = { 0.0f, -10.0f, 0.0f };
+extern const f32 lbl_8_rodata_1CE8[3] = { 0.0f, -10.0f, 0.0f };
+extern const f32 lbl_8_rodata_1CF4[3] = { 0.0f, -10.0f, 0.0f };
+extern const f32 lbl_8_rodata_1D00[4] = { -1.0f, -1.0f, -1.0f, 1.0f };
+extern const f32 lbl_8_rodata_1D10[3] = { 32.0f, 1.0f, 32.0f };
+extern const f32 lbl_8_rodata_1D1C[4] = { -1.0f, -1.0f, -1.0f, 1.0f };
+extern const f32 lbl_8_rodata_1D2C[4] = { -1.0f, -1.0f, -1.0f, 0.0f };
+extern const f32 lbl_8_rodata_1D3C[3] = { 20.0f, 1.0f, 20.0f };
+extern const f32 lbl_8_rodata_1D48[3] = { 0.0f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1D54[1] = { 0.20000000298023224f };
+extern const f32 lbl_8_rodata_1D58[1] = { 1.0f };
+extern const f32 lbl_8_rodata_1D5C[1] = { 1.0f };
+extern const f32 lbl_8_rodata_1D60[1] = { 20.0f };
+extern const f32 lbl_8_rodata_1D64[1] = { 0.004000000189989805f };
+extern const f32 lbl_8_rodata_1D68[1] = { 0.0010000000474974513f };
+extern const f32 lbl_8_rodata_1D6C[1] = { 0.9800000190734863f };
+extern const f32 lbl_8_rodata_1D70[1] = { 0.0054931640625f };
+extern const f32 lbl_8_rodata_1D74[1] = { 0.029999999329447746f };
+extern const f32 lbl_8_rodata_1D78[1] = { 0.10000000149011612f };
+extern const f32 lbl_8_rodata_1D7C[1] = { 0.20000000298023224f };
+extern const f32 lbl_8_rodata_1D80[1] = { 0.0f };
+extern const f32 lbl_8_rodata_1D84[1] = { 0.8999999761581421f };
+extern const f32 lbl_8_rodata_1D88[1] = { -0.8999999761581421f };
+extern const f64 lbl_8_rodata_1D90[1] = { 4503601774854144.0 };
+extern const f32 lbl_8_rodata_1D98[1] = { 3.0f };
+extern const f32 lbl_8_rodata_1D9C[1] = { 80.0f };
+extern const f32 lbl_8_rodata_1DA0[1] = { 250000.0f };
+extern const f32 lbl_8_rodata_1DA4[1] = { 0.05000000074505806f };
+extern const f32 lbl_8_rodata_1DA8[1] = { -1.0f };
+extern const f32 lbl_8_rodata_1DAC[1] = { 1.2000000476837158f };
+extern const f32 lbl_8_rodata_1DB0[1] = { 1600.0f };
+extern const f32 lbl_8_rodata_1DB4[1] = { 6400.0f };
+extern const f32 lbl_8_rodata_1DB8[1] = { 1.5f };
+extern const f32 lbl_8_rodata_1DBC[1] = { 16.0f };
+extern const f32 lbl_8_rodata_1DC0[1] = { 10.0f };
+extern const f32 lbl_8_rodata_1DC4[1] = { 8.0f };
+extern const f32 lbl_8_rodata_1DC8[1] = { 0.5f };
+extern const f32 lbl_8_rodata_1DCC[1] = { 5.0f };
+extern const f32 lbl_8_rodata_1DD0[1] = { 100000000.0f };
+extern const f32 lbl_8_rodata_1DD4[1] = { 4.0f };
+extern const f32 lbl_8_rodata_1DD8[1] = { 42.0f };
+extern const f32 lbl_8_rodata_1DDC[1] = { 2.0f };
+extern const f32 lbl_8_rodata_1DE0[1] = { 180.0f };
+extern const f32 lbl_8_rodata_1DE4[1] = { 15.0f };
+extern const f32 lbl_8_rodata_1DE8[1] = { 0.30000001192092896f };
+extern const f32 lbl_8_rodata_1DEC[1] = { -1000000.0f };
+extern const f32 lbl_8_rodata_1DF0[1] = { 30.0f };
+extern const f32 lbl_8_rodata_1DF4[1] = { 12.0f };
+extern const f32 lbl_8_rodata_1DF8[1] = { 0.800000011920929f };
+extern const f32 lbl_8_rodata_1DFC[1] = { 55.0f };
+extern const f32 lbl_8_rodata_1E00[1] = { 24.0f };
+extern const f32 lbl_8_rodata_1E04[1] = { 0.0f };
+extern const f32 lbl_8_rodata_1E08[1] = { 10000.0f };
+extern const f32 lbl_8_rodata_1E0C[1] = { 0.0f };
+extern const f32 lbl_8_rodata_1E10[1] = { 10000.0f };
+extern const f32 lbl_8_rodata_1E14[1] = { 0.0f };
+extern const s32 lbl_8_rodata_1E18[1] = { 0x00002710 };
+extern const f32 lbl_8_rodata_1E1C[1] = { 0.0f };
 
 void fn_8_B49D8(s32 arg0)
 {
@@ -316,7 +317,7 @@ void fn_8_B4B9C(void* arg0)
 		return;
 	}
 	if ((s32)M2C_FIELD(arg0, s32*, 0xDC) != 0) {
-		temp_r3 = fn_80103324((u8*)arg0 + 0xB0, &lbl_8_rodata_1C74, 1e8f);
+		temp_r3 = fn_80103324((u8*)arg0 + 0xB0, (s32*)lbl_8_rodata_1C74, 1e8f);
 		if (temp_r3 != -1) {
 			temp_r30 = *(void**)((u8*)&lbl_802AD090 + (temp_r3 * 4));
 			if (temp_r30 != NULL) {
@@ -332,7 +333,7 @@ void fn_8_B4B9C(void* arg0)
 				if (((M2C_FIELD(arg0, f32*, 0xC4) * sp1C)
 				        + ((M2C_FIELD(arg0, f32*, 0xBC) * sp14) + (temp_f31 * sp18)))
 				    > 0.0f) {
-					fn_800D5A64((u8*)arg0 + 0xBC, &sp14, &lbl_8_rodata_1C80, 0.05f);
+					fn_800D5A64((u8*)arg0 + 0xBC, &sp14, (s32*)lbl_8_rodata_1C80, 0.05f);
 					M2C_FIELD(arg0, f32*, 0xC0) = temp_f31;
 				} else {
 					M2C_FIELD(arg0, s32*, 0xDC) = 0;
@@ -355,9 +356,9 @@ void fn_8_B4B9C(void* arg0)
 	M2C_FIELD(arg0, f32*, 0xB8) = (f32)(M2C_FIELD(arg0, f32*, 0xB8) + temp_f1_3);
 	M2C_FIELD(arg0, f32*, 0xE8) = (f32)(M2C_FIELD(arg0, f32*, 0xE8) + 0.0f);
 	M2C_FIELD(arg0, f32*, 0xEC)
-	    = (f32)(M2C_FIELD(arg0, f32*, 0xEC) + M2C_FIELD(&lbl_8_rodata_1C64, f32*, 4));
+	    = (f32)(M2C_FIELD(arg0, f32*, 0xEC) + M2C_FIELD(lbl_8_rodata_1C64, f32*, 4));
 	M2C_FIELD(arg0, f32*, 0xF0)
-	    = (f32)(M2C_FIELD(arg0, f32*, 0xF0) + M2C_FIELD(&lbl_8_rodata_1C64, f32*, 8));
+	    = (f32)(M2C_FIELD(arg0, f32*, 0xF0) + M2C_FIELD(lbl_8_rodata_1C64, f32*, 8));
 }
 
 void fn_8_B4DA4(void* arg0)
@@ -1058,7 +1059,7 @@ s32 fn_8_B5E88(void* arg0)
 			sp10 = M2C_FIELD(arg0, f32*, 0xD4);
 			sp14 = M2C_FIELD(arg0, f32*, 0xD8);
 			sp18 = M2C_FIELD(arg0, f32*, 0xDC);
-			fn_80100D24(&sp8, &lbl_8_rodata_1CA4, NULL);
+			fn_80100D24(&sp8, lbl_8_rodata_1CA4, NULL);
 		}
 	}
 	return var_r31;
@@ -1169,7 +1170,7 @@ s32 fn_8_B6058(void* arg0)
 			sp10 = M2C_FIELD(arg0, f32*, 0xD4);
 			sp14 = M2C_FIELD(arg0, f32*, 0xD8);
 			sp18 = M2C_FIELD(arg0, f32*, 0xDC);
-			fn_80100D24(&sp8, &lbl_8_rodata_1CA4, (void*)4);
+			fn_80100D24(&sp8, lbl_8_rodata_1CA4, (void*)4);
 		}
 	}
 	return var_r31;

--- a/src/rel/e_s11_flag_stage11.cpp
+++ b/src/rel/e_s11_flag_stage11.cpp
@@ -169,37 +169,40 @@ static M2C_UNK gap_04_00018C79_data; /* unable to generate initializer: unknown 
 static M2C_UNK s11FlagFieldTypes;    /* unable to generate initializer: unknown type */
 static M2C_UNK gap_04_00018C81_data; /* unable to generate initializer: unknown type */
 static M2C_UNK s11FlagEntry;
-static M2C_UNK lbl_8_rodata_2010; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2040; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_204C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2050; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2054; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2058; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2060; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2068; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_206C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2070; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2074; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2078; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_207C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2080; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2084; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2088; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_208C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2090; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2094; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_2098; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_209C; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_20A0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_20A4; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_20A8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_20B0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_20B8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_20CC; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_20D0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_20D8; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_20E0; /* unable to generate initializer: unknown type; const */
-static M2C_UNK lbl_8_rodata_20E8; /* unable to generate initializer: unknown type; const */
+extern const f32 lbl_8_rodata_2010[12] = { 0.0f, 1.401298464324817e-45f, 2.802596928649634e-45f,
+	4.203895392974451e-45f, 5.605193857299268e-45f, 7.006492321624085e-45f, 8.407790785948902e-45f,
+	9.80908925027372e-45f, 1.1210387714598537e-44f, 1.2611686178923354e-44f, 1.401298464324817e-44f,
+	1.5414283107572988e-44f };
+extern const f32 lbl_8_rodata_2040[3]  = { 1.0f, 0.009999999776482582f, 1.0f };
+extern const f32 lbl_8_rodata_204C[1]  = { 100.0f };
+extern const f32 lbl_8_rodata_2050[1]  = { 1.0f };
+extern const f32 lbl_8_rodata_2054[1]  = { 0.016666699200868607f };
+extern const f64 lbl_8_rodata_2058[1]  = { 4503601774854144.0 };
+extern const f32 lbl_8_rodata_2060[2]  = { 0.10000000149011612f, 0.0f };
+extern const f32 lbl_8_rodata_2068[1]  = { 0.004999999888241291f };
+extern const f32 lbl_8_rodata_206C[1]  = { 0.1550000011920929f };
+extern const f32 lbl_8_rodata_2070[1]  = { 0.0f };
+extern const f32 lbl_8_rodata_2074[1]  = { 0.1599999964237213f };
+extern const f32 lbl_8_rodata_2078[1]  = { -1000000.0f };
+extern const f32 lbl_8_rodata_207C[1]  = { 21.0f };
+extern const f32 lbl_8_rodata_2080[1]  = { 0.0f };
+extern const f32 lbl_8_rodata_2084[1]  = { 20.0f };
+extern const f32 lbl_8_rodata_2088[1]  = { 1.0f };
+extern const f32 lbl_8_rodata_208C[1]  = { 10.0f };
+extern const f32 lbl_8_rodata_2090[1]  = { 100.0f };
+extern const f32 lbl_8_rodata_2094[1]  = { 0.699999988079071f };
+extern const f32 lbl_8_rodata_2098[1]  = { 1.2000000476837158f };
+extern const f32 lbl_8_rodata_209C[1]  = { 3.0517578125e-05f };
+extern const f32 lbl_8_rodata_20A0[1]  = { -0.10000000149011612f };
+extern const f32 lbl_8_rodata_20A4[1]  = { -2.0f };
+extern const f64 lbl_8_rodata_20A8[1]  = { 4503601774854144.0 };
+extern const f32 lbl_8_rodata_20B0[2]  = { 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_20B8[5]  = { 0.0f, 0.0f, 0.0f, 1.5f, 0.0f };
+extern const f32 lbl_8_rodata_20CC[1]  = { 0.0f };
+extern const f32 lbl_8_rodata_20D0[1]  = { 20.0f };
+extern const f64 lbl_8_rodata_20D8[1]  = { 4503601774854144.0 };
+extern const f32 lbl_8_rodata_20E0[2]  = { 100.0f, 0.0f };
+extern const f32 lbl_8_rodata_20E8[1]  = { 10430.380859375f };
 
 void fn_8_C7548(s32 arg0)
 {

--- a/src/rel/o_colli_communication_stage11.cpp
+++ b/src/rel/o_colli_communication_stage11.cpp
@@ -100,22 +100,22 @@ extern void* lbl_8042C380;
 extern u32 lbl_8042C388;
 extern u32 lbl_8042C6D0;
 extern M2C_UNK lbl_8_data_16B98;
-extern M2C_UNK lbl_8_rodata_1BB8;
-extern M2C_UNK lbl_8_rodata_1BC4;
-extern f32 lbl_8_rodata_1BD0;
-extern f32 lbl_8_rodata_1BD4;
-extern f32 lbl_8_rodata_1BD8;
-extern f32 lbl_8_rodata_1BDC;
-extern f32 lbl_8_rodata_1BE0;
-extern f32 lbl_8_rodata_1BE4;
-extern f32 lbl_8_rodata_1BE8;
-extern f32 lbl_8_rodata_1BEC;
-extern f32 lbl_8_rodata_1BF0;
-extern f32 lbl_8_rodata_1BF4;
-extern f32 lbl_8_rodata_1BF8;
-extern f32 lbl_8_rodata_1BFC;
-extern f32 lbl_8_rodata_1C00;
-extern f32 lbl_8_rodata_1C04;
+extern const f32 lbl_8_rodata_1BB8[3] = { 0.0f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1BC4[3] = { 0.0f, 0.0f, 0.0f };
+extern const f32 lbl_8_rodata_1BD0[1] = { 0.0f };
+extern const f32 lbl_8_rodata_1BD4[1] = { 1600.0f };
+extern const f32 lbl_8_rodata_1BD8[1] = { 40000.0f };
+extern const f32 lbl_8_rodata_1BDC[1] = { 2.0f };
+extern const f32 lbl_8_rodata_1BE0[1] = { 5.0f };
+extern const f32 lbl_8_rodata_1BE4[1] = { 100000000.0f };
+extern const f32 lbl_8_rodata_1BE8[1] = { 10000.0f };
+extern const f32 lbl_8_rodata_1BEC[1] = { -1.0f };
+extern const f32 lbl_8_rodata_1BF0[1] = { 0.9700000286102295f };
+extern const f32 lbl_8_rodata_1BF4[1] = { 1.0499999523162842f };
+extern const f32 lbl_8_rodata_1BF8[1] = { 9999999.0f };
+extern const f32 lbl_8_rodata_1BFC[1] = { 10.0f };
+extern const f32 lbl_8_rodata_1C00[1] = { 2250000.0f };
+extern const f32 lbl_8_rodata_1C04[1] = { 1.0f };
 
 M2C_UNK** fn_8_B0924(M2C_UNK** arg0, s16 arg1)
 {
@@ -141,7 +141,7 @@ s32 fn_8_B0974(void* arg0)
 		var_r0 = 0U;
 	}
 	if (var_r0 != 0U) {
-		M2C_FIELD(arg0, f32*, 0x1A4) = (f32)lbl_8_rodata_1BD0;
+		M2C_FIELD(arg0, f32*, 0x1A4) = (f32)lbl_8_rodata_1BD0[0];
 		M2C_FIELD(arg0, s32*, 0x230) = -1;
 		return 1;
 	}
@@ -173,9 +173,9 @@ s32 fn_8_B0A74(void* arg0)
 		if (temp_r3 != 0U) {
 			temp_f1 = fn_800D71DC((u8*)temp_r3 + 0x18, (u8*)arg0 + 0x140);
 			M2C_ERROR(/* unknown instruction: cror eq, lt, eq */);
-			if (lbl_8_rodata_1BD4 == temp_f1) {
+			if (lbl_8_rodata_1BD4[0] == temp_f1) {
 				M2C_ERROR(/* unknown instruction: cror eq, lt, eq */);
-				if (temp_f1 == lbl_8_rodata_1BD8) {
+				if (temp_f1 == lbl_8_rodata_1BD8[0]) {
 					return 1;
 				}
 			}
@@ -189,13 +189,13 @@ void fn_8_B0B00(void* arg0)
 	f32 temp_f1;
 
 	temp_f1 = M2C_FIELD(arg0, f32*, 0x2FC);
-	if (temp_f1 < lbl_8_rodata_1BDC) {
+	if (temp_f1 < lbl_8_rodata_1BDC[0]) {
 		M2C_FIELD(arg0, s32*, 0x2B8) = 0x70;
 		M2C_FIELD(arg0, s32*, 0x2BC) = 0x70;
 		return;
 	}
 	M2C_ERROR(/* unknown instruction: cror eq, gt, eq */);
-	if ((temp_f1 == lbl_8_rodata_1BDC) && (temp_f1 < lbl_8_rodata_1BE0)) {
+	if ((temp_f1 == lbl_8_rodata_1BDC[0]) && (temp_f1 < lbl_8_rodata_1BE0[0])) {
 		M2C_FIELD(arg0, s32*, 0x2B8) = 0x100;
 		M2C_FIELD(arg0, s32*, 0x2BC) = 0x100;
 		return;
@@ -229,11 +229,11 @@ s32 fn_8_B0B94(void* arg0)
 	if ((s16*)M2C_FIELD(arg0, s16**, 0x24C) == NULL) {
 		return 2;
 	}
-	temp_r3 = fn_80103324((u8*)arg0 + 0x140, &lbl_8_rodata_1BE4, lbl_8_rodata_1BE4);
+	temp_r3 = fn_80103324((u8*)arg0 + 0x140, (f32*)lbl_8_rodata_1BE4, lbl_8_rodata_1BE4[0]);
 	if (temp_r3 != -1) {
 		temp_r31 = (void*)*(&lbl_802AD090 + (temp_r3 * 4));
 		if ((temp_r31 != NULL)
-		    && (fn_800D71DC((u8*)temp_r31 + 0x18, (u8*)arg0 + 0x140) > lbl_8_rodata_1BE8)) {
+		    && (fn_800D71DC((u8*)temp_r31 + 0x18, (u8*)arg0 + 0x140) > lbl_8_rodata_1BE8[0])) {
 			sp14    = M2C_FIELD(temp_r31, f32*, 0x18) - M2C_FIELD(arg0, f32*, 0x140);
 			sp18    = M2C_FIELD(temp_r31, f32*, 0x1C) - M2C_FIELD(arg0, f32*, 0x144);
 			temp_f1 = M2C_FIELD(temp_r31, f32*, 0x20);
@@ -247,11 +247,11 @@ s32 fn_8_B0B94(void* arg0)
 			spC  = sp5C;
 			sp10 = sp60;
 			if ((s32)M2C_FIELD(arg0, s32*, 0x2B4) == 0) {
-				sp8 *= lbl_8_rodata_1BEC;
-				spC *= lbl_8_rodata_1BEC;
-				sp10 *= lbl_8_rodata_1BEC;
+				sp8 *= lbl_8_rodata_1BEC[0];
+				spC *= lbl_8_rodata_1BEC[0];
+				sp10 *= lbl_8_rodata_1BEC[0];
 			}
-			if (((sp1C * sp10) + ((sp14 * sp8) + (sp18 * spC))) < lbl_8_rodata_1BD0) {
+			if (((sp1C * sp10) + ((sp14 * sp8) + (sp18 * spC))) < lbl_8_rodata_1BD0[0]) {
 				return 0;
 			}
 			return 1;
@@ -293,11 +293,13 @@ void fn_8_B0D34(void* arg0)
 			if ((s16*)M2C_FIELD(arg0, s16**, 0x24C) == NULL) {
 				var_r0 = 2;
 			} else {
-				temp_r3 = fn_80103324((u8*)arg0 + 0x140, &lbl_8_rodata_1BE4, lbl_8_rodata_1BE4);
+				temp_r3
+				    = fn_80103324((u8*)arg0 + 0x140, (f32*)lbl_8_rodata_1BE4, lbl_8_rodata_1BE4[0]);
 				if ((temp_r3 != -1)
 				    && (temp_r30 = (void*)*(&lbl_802AD090 + (temp_r3 * 4)),
 				        ((temp_r30 == NULL) == 0))
-				    && (fn_800D71DC((u8*)temp_r30 + 0x18, (u8*)arg0 + 0x140) > lbl_8_rodata_1BE8)) {
+				    && (fn_800D71DC((u8*)temp_r30 + 0x18, (u8*)arg0 + 0x140)
+				        > lbl_8_rodata_1BE8[0])) {
 					sp8     = M2C_FIELD(temp_r30, f32*, 0x18) - M2C_FIELD(arg0, f32*, 0x140);
 					spC     = M2C_FIELD(temp_r30, f32*, 0x1C) - M2C_FIELD(arg0, f32*, 0x144);
 					temp_f1 = M2C_FIELD(temp_r30, f32*, 0x20);
@@ -311,11 +313,12 @@ void fn_8_B0D34(void* arg0)
 						sp18 = sp5C;
 						sp1C = sp60;
 						if ((s32)M2C_FIELD(arg0, s32*, 0x2B4) == 0) {
-							sp14 *= lbl_8_rodata_1BEC;
-							sp18 *= lbl_8_rodata_1BEC;
-							sp1C *= lbl_8_rodata_1BEC;
+							sp14 *= lbl_8_rodata_1BEC[0];
+							sp18 *= lbl_8_rodata_1BEC[0];
+							sp1C *= lbl_8_rodata_1BEC[0];
 						}
-						if (((sp10 * sp1C) + ((sp8 * sp14) + (spC * sp18))) < lbl_8_rodata_1BD0) {
+						if (((sp10 * sp1C) + ((sp8 * sp14) + (spC * sp18)))
+						    < lbl_8_rodata_1BD0[0]) {
 							var_r0 = 0;
 						} else {
 							var_r0 = 1;
@@ -328,7 +331,7 @@ void fn_8_B0D34(void* arg0)
 			switch (var_r0) { /* switch 2; irregular */
 				case 0:       /* switch 2 */
 					M2C_FIELD(arg0, f32*, 0x2FC)
-					    = (f32)(M2C_FIELD(arg0, f32*, 0x2FC) * lbl_8_rodata_1BF0);
+					    = (f32)(M2C_FIELD(arg0, f32*, 0x2FC) * lbl_8_rodata_1BF0[0]);
 					temp_f1_2 = M2C_FIELD(arg0, f32*, 0x2F4);
 					if (M2C_FIELD(arg0, f32*, 0x2FC) < temp_f1_2) {
 						M2C_FIELD(arg0, f32*, 0x2FC) = temp_f1_2;
@@ -336,7 +339,7 @@ void fn_8_B0D34(void* arg0)
 					}
 				case 1: /* switch 2 */
 					M2C_FIELD(arg0, f32*, 0x2FC)
-					    = (f32)(M2C_FIELD(arg0, f32*, 0x2FC) * lbl_8_rodata_1BF4);
+					    = (f32)(M2C_FIELD(arg0, f32*, 0x2FC) * lbl_8_rodata_1BF4[0]);
 					temp_f1_3 = M2C_FIELD(arg0, f32*, 0x2F8);
 					if (M2C_FIELD(arg0, f32*, 0x2FC) > temp_f1_3) {
 						M2C_FIELD(arg0, f32*, 0x2FC) = temp_f1_3;
@@ -347,11 +350,11 @@ void fn_8_B0D34(void* arg0)
 					temp_f1_4 = M2C_FIELD(arg0, f32*, 0x2FC);
 					temp_f0   = M2C_FIELD(arg0, f32*, 0x2F0);
 					if (temp_f1_4 > temp_f0) {
-						M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(temp_f1_4 * lbl_8_rodata_1BF0);
+						M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(temp_f1_4 * lbl_8_rodata_1BF0[0]);
 						return;
 					}
 					if (temp_f1_4 < temp_f0) {
-						M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(temp_f1_4 * lbl_8_rodata_1BF4);
+						M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(temp_f1_4 * lbl_8_rodata_1BF4[0]);
 						return;
 					}
 					M2C_FIELD(arg0, f32*, 0x2FC) = temp_f0;
@@ -359,8 +362,9 @@ void fn_8_B0D34(void* arg0)
 			}
 			break;
 		case 2: /* switch 1 */
-			M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(M2C_FIELD(arg0, f32*, 0x2FC) * lbl_8_rodata_1BF0);
-			temp_f1_5                    = M2C_FIELD(arg0, f32*, 0x2F4);
+			M2C_FIELD(arg0, f32*, 0x2FC)
+			    = (f32)(M2C_FIELD(arg0, f32*, 0x2FC) * lbl_8_rodata_1BF0[0]);
+			temp_f1_5 = M2C_FIELD(arg0, f32*, 0x2F4);
 			if (M2C_FIELD(arg0, f32*, 0x2FC) < temp_f1_5) {
 				M2C_FIELD(arg0, f32*, 0x2FC) = temp_f1_5;
 				return;
@@ -370,18 +374,19 @@ void fn_8_B0D34(void* arg0)
 			temp_f1_6 = M2C_FIELD(arg0, f32*, 0x2FC);
 			temp_f0_2 = M2C_FIELD(arg0, f32*, 0x2F0);
 			if (temp_f1_6 > temp_f0_2) {
-				M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(temp_f1_6 * lbl_8_rodata_1BF0);
+				M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(temp_f1_6 * lbl_8_rodata_1BF0[0]);
 				return;
 			}
 			if (temp_f1_6 < temp_f0_2) {
-				M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(temp_f1_6 * lbl_8_rodata_1BF4);
+				M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(temp_f1_6 * lbl_8_rodata_1BF4[0]);
 				return;
 			}
 			M2C_FIELD(arg0, f32*, 0x2FC) = temp_f0_2;
 			return;
 		case 4: /* switch 1 */
-			M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(M2C_FIELD(arg0, f32*, 0x2FC) * lbl_8_rodata_1BF4);
-			temp_f1_7                    = M2C_FIELD(arg0, f32*, 0x2F8);
+			M2C_FIELD(arg0, f32*, 0x2FC)
+			    = (f32)(M2C_FIELD(arg0, f32*, 0x2FC) * lbl_8_rodata_1BF4[0]);
+			temp_f1_7 = M2C_FIELD(arg0, f32*, 0x2F8);
 			if (M2C_FIELD(arg0, f32*, 0x2FC) > temp_f1_7) {
 				M2C_FIELD(arg0, f32*, 0x2FC) = temp_f1_7;
 			}
@@ -420,13 +425,13 @@ void fn_8_B1078(void* arg0)
 
 	var_f31 = saved_reg_f31;
 	var_r28 = NULL;
-	var_f30 = lbl_8_rodata_1BF8;
+	var_f30 = lbl_8_rodata_1BF8[0];
 	var_r29 = M2C_FIELD(lbl_8042C380, s16***, 0x28);
 loop_5:
 	temp_r3 = *var_r29;
 	if (temp_r3 != NULL) {
 		if ((s16)*temp_r3 == 1) {
-			temp_f1 = fn_800AEF48((u8*)arg0 + 0x254, &sp24, &sp8, lbl_8_rodata_1BD0);
+			temp_f1 = fn_800AEF48((u8*)arg0 + 0x254, &sp24, &sp8, lbl_8_rodata_1BD0[0]);
 			if (temp_f1 < var_f30) {
 				var_f30 = temp_f1;
 				var_r28 = *var_r29;
@@ -444,7 +449,7 @@ loop_5:
 			sp1C = sp48 - M2C_FIELD(arg0, f32*, 0x144);
 			sp20 = sp4C - M2C_FIELD(arg0, f32*, 0x148);
 			fn_801990E0(&sp18, &sp18, sp4C);
-			if (((sp20 * sp70) + ((sp18 * sp68) + (sp1C * sp6C))) < lbl_8_rodata_1BD0) {
+			if (((sp20 * sp70) + ((sp18 * sp68) + (sp1C * sp6C))) < lbl_8_rodata_1BD0[0]) {
 				M2C_FIELD(arg0, s32*, 0x2B4) = 0;
 				M2C_FIELD(arg0, f32*, 0x248) = var_f31;
 			} else {
@@ -512,7 +517,7 @@ void fn_8_B134C(void* arg0)
 	s16* var_r28;
 
 	var_r28 = NULL;
-	var_f31 = lbl_8_rodata_1BF8;
+	var_f31 = lbl_8_rodata_1BF8[0];
 	var_r27 = M2C_FIELD(lbl_8042C380, s16***, 0x28);
 loop_5:
 	temp_r3 = *var_r27;
@@ -531,11 +536,11 @@ loop_5:
 	}
 	M2C_FIELD(arg0, s16**, 0x24C) = var_r28;
 	if ((s16*)M2C_FIELD(arg0, s16**, 0x24C) != NULL) {
-		sp30 = lbl_8_rodata_1BD0;
+		sp30 = lbl_8_rodata_1BD0[0];
 		if (fn_800AF3AC(&sp20) == 1) {
-			sp14 = M2C_FIELD(&lbl_8_rodata_1BC4, s32*, 0);
-			sp18 = M2C_FIELD(&lbl_8_rodata_1BC4, s32*, 4);
-			sp1C = M2C_FIELD(&lbl_8_rodata_1BC4, s32*, 8);
+			sp14 = M2C_FIELD(lbl_8_rodata_1BC4, s32*, 0);
+			sp18 = M2C_FIELD(lbl_8_rodata_1BC4, s32*, 4);
+			sp1C = M2C_FIELD(lbl_8_rodata_1BC4, s32*, 8);
 			fn_800D735C(&sp58, 0, &sp14);
 			M2C_FIELD(arg0, f32*, 0x254) = sp34;
 			M2C_FIELD(arg0, f32*, 0x258) = sp38;
@@ -544,7 +549,7 @@ loop_5:
 			M2C_FIELD(arg0, s32*, 0x270) = sp18;
 			M2C_FIELD(arg0, s32*, 0x274) = sp1C;
 		}
-		M2C_FIELD(arg0, f32*, 0x248) = (f32)lbl_8_rodata_1BD0;
+		M2C_FIELD(arg0, f32*, 0x248) = (f32)lbl_8_rodata_1BD0[0];
 		M2C_FIELD(arg0, s32*, 0x27C) = 0;
 		M2C_FIELD(arg0, f32*, 0x260)
 		    = (f32)(M2C_FIELD(arg0, f32*, 0x254) - M2C_FIELD(arg0, f32*, 0x140));
@@ -576,7 +581,7 @@ s32 fn_8_B154C(void* arg0)
 
 	M2C_FIELD(arg0, s32*, 0x27C) = (s32)(M2C_FIELD(arg0, s32*, 0x27C) + 0x250);
 	M2C_FIELD(arg0, f32*, 0x278)
-	    = (f32)(lbl_8_rodata_1BFC * fn_800D7B00(M2C_FIELD(arg0, s32*, 0x27C)));
+	    = (f32)(lbl_8_rodata_1BFC[0] * fn_800D7B00(M2C_FIELD(arg0, s32*, 0x27C)));
 	M2C_FIELD(arg0, s32*, 0x14C) = (s32)M2C_FIELD(arg0, s32*, 0x26C);
 	M2C_FIELD(arg0, s32*, 0x150)
 	    = fn_800D7A94(M2C_FIELD(arg0, s32*, 0x150), M2C_FIELD(arg0, s32*, 0x270), 0x80);
@@ -591,7 +596,8 @@ s32 fn_8_B154C(void* arg0)
 	    = (f32)(M2C_FIELD(arg0, f32*, 0x264) + M2C_FIELD(arg0, f32*, 0x144));
 	temp_f1                      = M2C_FIELD(arg0, f32*, 0x268);
 	M2C_FIELD(arg0, f32*, 0x148) = (f32)(temp_f1 + M2C_FIELD(arg0, f32*, 0x148));
-	if (fn_800D7BD8((u8*)arg0 + 0x254, &sp8, (u8*)arg0 + 0x140, 0, temp_f1) < lbl_8_rodata_1BDC) {
+	if (fn_800D7BD8((u8*)arg0 + 0x254, &sp8, (u8*)arg0 + 0x140, 0, temp_f1)
+	    < lbl_8_rodata_1BDC[0]) {
 		M2C_FIELD(arg0, f32*, 0x140) = (f32)M2C_FIELD(arg0, f32*, 0x254);
 		M2C_FIELD(arg0, f32*, 0x144) = (f32)M2C_FIELD(arg0, f32*, 0x258);
 		M2C_FIELD(arg0, f32*, 0x148) = (f32)M2C_FIELD(arg0, f32*, 0x25C);
@@ -614,8 +620,8 @@ void* fn_8_B1828(void* arg0, void* arg1, u32 arg2, f32 farg0)
 	void* var_r31;
 
 	var_r31 = NULL;
-	var_f31 = lbl_8_rodata_1BF8;
-	if (lbl_8_rodata_1BEC != farg0) {
+	var_f31 = lbl_8_rodata_1BF8[0];
+	if (lbl_8_rodata_1BEC[0] != farg0) {
 		var_f31 = farg0 * farg0;
 	}
 	var_r27 = M2C_FIELD(lbl_8042C380, void***, 0x28);
@@ -655,8 +661,8 @@ s16* fn_8_B193C(void* arg0, void* arg1, f32 farg0)
 	s16* var_r29;
 
 	var_r29 = NULL;
-	var_f31 = lbl_8_rodata_1BF8;
-	if (lbl_8_rodata_1BEC != farg0) {
+	var_f31 = lbl_8_rodata_1BF8[0];
+	if (lbl_8_rodata_1BEC[0] != farg0) {
 		var_f31 = farg0 * farg0;
 	}
 	var_r30 = M2C_FIELD(lbl_8042C380, s16***, 0x28);
@@ -680,7 +686,7 @@ loop_7:
 
 s32 fn_8_B1A0C(s32 arg0, s32 arg1, f32 farg0)
 {
-	if (fn_800D71DC(lbl_8042C208) > lbl_8_rodata_1C00) {
+	if (fn_800D71DC(lbl_8042C208) > lbl_8_rodata_1C00[0]) {
 		return 0;
 	}
 	return fn_800A6D60(arg0, arg1, farg0);
@@ -705,11 +711,12 @@ void fn_8_B1AE8(void* arg0)
 	void* temp_r5;
 
 	if ((s32)M2C_FIELD(arg0, s32*, 0x2B4) != 0) {
-		M2C_FIELD(arg0, f32*, 0x248) = (f32)lbl_8_rodata_1BD0;
+		M2C_FIELD(arg0, f32*, 0x248) = (f32)lbl_8_rodata_1BD0[0];
 	} else {
 		temp_r4 = M2C_FIELD(arg0, void**, 0x24C);
 		if (temp_r4 != NULL) {
-			M2C_FIELD(arg0, f32*, 0x248) = (f32)(M2C_FIELD(temp_r4, f32*, 4) - lbl_8_rodata_1C04);
+			M2C_FIELD(arg0, f32*, 0x248)
+			    = (f32)(M2C_FIELD(temp_r4, f32*, 4) - lbl_8_rodata_1C04[0]);
 		}
 	}
 	temp_r5                      = M2C_FIELD(M2C_FIELD(arg0, void**, 0xB0), void**, 0x2C);
@@ -780,12 +787,12 @@ void fn_8_B1C1C(void* arg0)
 	fn_800A3D48(arg0);
 	if ((s32)M2C_FIELD(arg0, s32*, 0x2E0) != 0) {
 		temp_f1 = M2C_FIELD(arg0, f32*, 0x2FC);
-		if (temp_f1 < lbl_8_rodata_1BDC) {
+		if (temp_f1 < lbl_8_rodata_1BDC[0]) {
 			M2C_FIELD(arg0, s32*, 0x2B8) = 0x70;
 			M2C_FIELD(arg0, s32*, 0x2BC) = 0x70;
 		} else {
 			M2C_ERROR(/* unknown instruction: cror eq, gt, eq */);
-			if ((temp_f1 == lbl_8_rodata_1BDC) && (temp_f1 < lbl_8_rodata_1BE0)) {
+			if ((temp_f1 == lbl_8_rodata_1BDC[0]) && (temp_f1 < lbl_8_rodata_1BE0[0])) {
 				M2C_FIELD(arg0, s32*, 0x2B8) = 0x100;
 				M2C_FIELD(arg0, s32*, 0x2BC) = 0x100;
 			} else {
@@ -855,7 +862,7 @@ void fn_8_B1E9C(void* arg0, s32 arg1)
 			switch (temp_r0) { /* switch 2; irregular */
 				case 0:        /* switch 2 */
 					var_r28 = NULL;
-					var_f31 = lbl_8_rodata_1BF8;
+					var_f31 = lbl_8_rodata_1BF8[0];
 					var_r27 = M2C_FIELD(lbl_8042C380, s16***, 0x28);
 				loop_16:
 					temp_r3 = *var_r27;
@@ -874,11 +881,11 @@ void fn_8_B1E9C(void* arg0, s32 arg1)
 					}
 					M2C_FIELD(arg0, s16**, 0x24C) = var_r28;
 					if ((s16*)M2C_FIELD(arg0, s16**, 0x24C) != NULL) {
-						sp3C = lbl_8_rodata_1BD0;
+						sp3C = lbl_8_rodata_1BD0[0];
 						if (fn_800AF3AC(&sp2C) == 1) {
-							sp20 = M2C_FIELD(&lbl_8_rodata_1BC4, s32*, 0);
-							sp24 = M2C_FIELD(&lbl_8_rodata_1BC4, s32*, 4);
-							sp28 = M2C_FIELD(&lbl_8_rodata_1BC4, s32*, 8);
+							sp20 = M2C_FIELD(lbl_8_rodata_1BC4, s32*, 0);
+							sp24 = M2C_FIELD(lbl_8_rodata_1BC4, s32*, 4);
+							sp28 = M2C_FIELD(lbl_8_rodata_1BC4, s32*, 8);
 							fn_800D735C(&sp64, 0, &sp20);
 							M2C_FIELD(arg0, f32*, 0x254) = sp40;
 							M2C_FIELD(arg0, f32*, 0x258) = sp44;
@@ -887,7 +894,7 @@ void fn_8_B1E9C(void* arg0, s32 arg1)
 							M2C_FIELD(arg0, s32*, 0x270) = sp24;
 							M2C_FIELD(arg0, s32*, 0x274) = sp28;
 						}
-						M2C_FIELD(arg0, f32*, 0x248) = (f32)lbl_8_rodata_1BD0;
+						M2C_FIELD(arg0, f32*, 0x248) = (f32)lbl_8_rodata_1BD0[0];
 						M2C_FIELD(arg0, s32*, 0x27C) = 0;
 						M2C_FIELD(arg0, f32*, 0x260)
 						    = (f32)(M2C_FIELD(arg0, f32*, 0x254) - M2C_FIELD(arg0, f32*, 0x140));
@@ -922,7 +929,7 @@ void fn_8_B1E9C(void* arg0, s32 arg1)
 		case 1: /* switch 1 */
 			M2C_FIELD(arg0, s32*, 0x27C) = (s32)(M2C_FIELD(arg0, s32*, 0x27C) + 0x250);
 			M2C_FIELD(arg0, f32*, 0x278)
-			    = (f32)(lbl_8_rodata_1BFC * fn_800D7B00(M2C_FIELD(arg0, s32*, 0x27C)));
+			    = (f32)(lbl_8_rodata_1BFC[0] * fn_800D7B00(M2C_FIELD(arg0, s32*, 0x27C)));
 			M2C_FIELD(arg0, s32*, 0x14C) = (s32)M2C_FIELD(arg0, s32*, 0x26C);
 			M2C_FIELD(arg0, s32*, 0x150)
 			    = fn_800D7A94(M2C_FIELD(arg0, s32*, 0x150), M2C_FIELD(arg0, s32*, 0x270), 0x80);
@@ -938,7 +945,7 @@ void fn_8_B1E9C(void* arg0, s32 arg1)
 			temp_f1_3                    = M2C_FIELD(arg0, f32*, 0x268);
 			M2C_FIELD(arg0, f32*, 0x148) = (f32)(temp_f1_3 + M2C_FIELD(arg0, f32*, 0x148));
 			if (fn_800D7BD8((u8*)arg0 + 0x254, &sp14, (u8*)arg0 + 0x140, 0, temp_f1_3)
-			    < lbl_8_rodata_1BDC) {
+			    < lbl_8_rodata_1BDC[0]) {
 				M2C_FIELD(arg0, f32*, 0x140) = (f32)M2C_FIELD(arg0, f32*, 0x254);
 				M2C_FIELD(arg0, f32*, 0x144) = (f32)M2C_FIELD(arg0, f32*, 0x258);
 				M2C_FIELD(arg0, f32*, 0x148) = (f32)M2C_FIELD(arg0, f32*, 0x25C);
@@ -987,12 +994,12 @@ void fn_8_B2224(void* arg0, s32 arg1)
 			fn_8_B2BB4();
 			fn_8_B0D34(arg0);
 			if ((s32)M2C_FIELD(arg0, s32*, 0x2C4) == 0) {
-				sp1C = lbl_8_rodata_1BD0;
-				sp18 = lbl_8_rodata_1BD0;
-				sp14 = lbl_8_rodata_1BD0;
-				sp28 = lbl_8_rodata_1BD0;
-				sp24 = lbl_8_rodata_1BD0;
-				sp20 = lbl_8_rodata_1BD0;
+				sp1C = lbl_8_rodata_1BD0[0];
+				sp18 = lbl_8_rodata_1BD0[0];
+				sp14 = lbl_8_rodata_1BD0[0];
+				sp28 = lbl_8_rodata_1BD0[0];
+				sp24 = lbl_8_rodata_1BD0[0];
+				sp20 = lbl_8_rodata_1BD0[0];
 				sp38 = 0;
 				sp34 = 0;
 				sp30 = 0;
@@ -1014,9 +1021,9 @@ void fn_8_B2224(void* arg0, s32 arg1)
 				sp3C = 0x258;
 				sp44 = ((TRenderer*)arg0)->Slot90();
 				fn_8_B5160(&sp14);
-				sp8  = M2C_FIELD(&lbl_8_rodata_1BB8, s32*, 0);
-				spC  = M2C_FIELD(&lbl_8_rodata_1BB8, s32*, 4);
-				sp10 = M2C_FIELD(&lbl_8_rodata_1BB8, s32*, 8);
+				sp8  = M2C_FIELD(lbl_8_rodata_1BB8, s32*, 0);
+				spC  = M2C_FIELD(lbl_8_rodata_1BB8, s32*, 4);
+				sp10 = M2C_FIELD(lbl_8_rodata_1BB8, s32*, 8);
 				fn_8006298C(5, (u8*)arg0 + 0x294, &sp8);
 				if ((u32)lbl_8042C388 != 0U) {
 					fn_800B4A38(0x403B, (u8*)arg0 + 0x140, 0, 1, 0, 0);
@@ -1050,9 +1057,10 @@ void fn_8_B240C(void* arg0, s32 arg1)
 			return;
 		case 1:
 			fn_8_B2BB4();
-			M2C_FIELD(arg0, f32*, 0x2FC) = (f32)(M2C_FIELD(arg0, f32*, 0x2FC) * lbl_8_rodata_1BF0);
-			if (M2C_FIELD(arg0, f32*, 0x2FC) < lbl_8_rodata_1BD0) {
-				M2C_FIELD(arg0, f32*, 0x2FC) = (f32)lbl_8_rodata_1BD0;
+			M2C_FIELD(arg0, f32*, 0x2FC)
+			    = (f32)(M2C_FIELD(arg0, f32*, 0x2FC) * lbl_8_rodata_1BF0[0]);
+			if (M2C_FIELD(arg0, f32*, 0x2FC) < lbl_8_rodata_1BD0[0]) {
+				M2C_FIELD(arg0, f32*, 0x2FC) = (f32)lbl_8_rodata_1BD0[0];
 			}
 			break;
 	}
@@ -1073,12 +1081,13 @@ void fn_8_B24C0(void* arg0, s32 arg1)
 	if (temp_r4 == NULL) {
 		var_r0 = 0;
 	} else if ((s32)M2C_FIELD(arg0, s32*, 0x2B4) != 0) {
-		if (lbl_8_rodata_1BD0 == M2C_FIELD(arg0, f32*, 0x248)) {
+		if (lbl_8_rodata_1BD0[0] == M2C_FIELD(arg0, f32*, 0x248)) {
 			var_r0 = 1;
 		} else {
 			var_r0 = 0;
 		}
-	} else if (M2C_FIELD(arg0, f32*, 0x248) == (M2C_FIELD(temp_r4, f32*, 4) - lbl_8_rodata_1C04)) {
+	} else if (M2C_FIELD(arg0, f32*, 0x248)
+	    == (M2C_FIELD(temp_r4, f32*, 4) - lbl_8_rodata_1C04[0])) {
 		var_r0 = 1;
 	} else {
 		var_r0 = 0;


### PR DESCRIPTION
Applies #511's transcription to five more units. **1012 more bytes of data
match**; Game Code data 94.01% -> 94.26%. No function regresses anywhere.

| unit | `.rodata` fuzzy | matched data |
| --- | --- | --- |
| `rel/e_rinoliner_collision_stage11` | 15.3% -> 100.0% | 4 -> 448 bytes |
| `rel/e_flyer_path_stage11` | 37.6% -> 100.0% | 0 -> 264 bytes |
| `rel/e_s11_flag_stage11` | 0.0% -> 100.0% | 4 -> 228 bytes |
| `rel/o_colli_communication_stage11` | 0.0% -> 100.0% | 0 -> 80 bytes |
| `rel/e_grass_stage11` | 29.8% -> 99.4% | 4 -> 4 bytes |

Data at 0% is a hard ceiling on these units: `matched_functions` counts a
function only once its relocations resolve to matched symbols, so text work
in a unit whose `.rodata` is unmatched cannot be banked. #511 established
the transcription; this makes it repeatable.

## The declared type comes from the target's load instruction

#511 found that typing a constant by its bit pattern is wrong - two
integer constants that look like floats cost a function nine points, because
our code emitted `lfs` + `fctiwz` + a stack round-trip where retail has
`lwz` + `cmpw`. Rather than discover that per unit, the type is now read out
of the target: walk the target's `.text` with relocations, bind each
register to the symbol its `lis`/`addi` pair materialises (invalidating the
binding when anything else writes that register), and record which load
instruction reads through it.

`lfd` gives `f64`, `lfs` gives `f32`, and `lwz` on a **4-byte** symbol gives
`s32`. `lwz` on a *longer* symbol stays `f32`: those are vectors copied word
by word into a stack struct, which is why the naive "integer load means
integer" rule needs the size guard. Checked against #511's hand-verified
result, the inference reproduces all four of its decisions.

## `o_colli_communication_stage11` needed `-pool off`

With its constants named, the unit crossed CodeWarrior's pooling threshold
and started addressing its statics through a `...rodata.0` anchor - two
functions lost five and ten points. The anchor symbol in our object is the
tell, exactly as recorded for the twenty units in #482, and `-pool off`
restores per-symbol `lis`/`addi`. That is the only compiler-flag change
here.

## What is left out

`e_capture` (280 bytes) does not carve cleanly and `e_strategy_flyer_stage11`
and `e_rinoliner_stage11` do not compile after transcription; all three are
reverted and untouched. `e_strategy_magician_stage11` transcribes and builds,
and takes its `.rodata` to 100%, but costs two functions about a point each
in diffuse re-colouring rather than any identifiable type error - it is left
out rather than merged with a regression, and is worth a second look with
the pooling threshold in mind.

## Verification

- `python3 configure.py && ninja` - `18 files OK`; direct `sha1sum` against
  `config/G9SE8P/build.sha1` clean.
- `report.json` per-function comparison against `main`, every module: 0 up,
  **0 down**.
- `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)